### PR TITLE
Fixed collapsed navbar mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -41,9 +41,8 @@
     </div>
 
     {%- block scripts -%}
-      {# commented out for now, since unused:
-         <script src="{{ url_for('static', filename='js/jquery-2.1.0.min.js') }}"></script>
-         <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script> #}
+      <script src="{{ url_for('static', filename='js/jquery-2.1.0.min.js') }}"></script>
+      <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
     {%- endblock -%}
   </body>
 </html>


### PR DESCRIPTION
> If JavaScript is disabled and the viewport is narrow enough that the navbar collapses, it will be impossible to expand the navbar and view the content within the .navbar-collapse.  

See [Bootstrap documentation](http://getbootstrap.com/components/#navbar-default).
