### PR TITLE
quote artist/title for Tomahawk embedding

### DIFF
--- a/acousticbrainz/server.py
+++ b/acousticbrainz/server.py
@@ -12,6 +12,7 @@ from flask import Flask, request, Response, jsonify, render_template
 from werkzeug.exceptions import BadRequest, ServiceUnavailable, NotFound, InternalServerError
 import memcache
 from hashlib import sha256
+from urllib import quote_plus
 import argparse
 
 SANITY_CHECK_KEYS = [
@@ -387,6 +388,12 @@ def get_summary(mbid):
             lowlevel['metadata']['tags']['title'] = "[unknown]"
         if not lowlevel['metadata']['tags'].has_key('tracknumber'):
             lowlevel['metadata']['tags']['tracknumber'] = "[unknown]"
+
+        # quote special characters "url-encoding"
+        lowlevel['metadata']['tags']['artist_quoted'] = quote_plus(
+                lowlevel['metadata']['tags']['artist'][0].encode("UTF-8"))
+        lowlevel['metadata']['tags']['title_quoted'] = quote_plus(
+                lowlevel['metadata']['tags']['title'][0].encode("UTF-8"))
 
         cur.execute("""SELECT hlj.data 
                          FROM highlevel hl, highlevel_json hlj

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -17,7 +17,7 @@
         </div>
         <div class="col-md-4">
             {% if lowlevel.metadata.tags.artist and lowlevel.metadata.tags.title %}
-            <iframe src="http://toma.hk/embed.php?artist={{lowlevel.metadata.tags.artist[0]}}&title={{lowlevel.metadata.tags.title[0]}}" width="200" scrolling="no" height="200" frameborder="0" allowtransparency="true" ></iframe>
+            <iframe src="http://toma.hk/embed.php?artist={{lowlevel.metadata.tags.artist_quoted}}&title={{lowlevel.metadata.tags.title_quoted}}" width="200" scrolling="no" height="200" frameborder="0" allowtransparency="true" ></iframe>
             {% endif %}
         </div>
      </div>


### PR DESCRIPTION
Firefox does a lot of guessing already to quote/encode urls automatically, but it does fail at some places.

For "Nick Cave & The Bad Seeds - The Weeping Song" the artist gets cut off as just "Nick cave" because of that:
http://acousticbrainz.org/b598c73a-6bd3-4e0c-93b1-9bc988d01e64

This should fix this.

For this to work we also actively (rather than automatically as before) encode to UTF-8.
This is probably correct, but not yet fully working because of:
https://bugs.tomahawk-player.org/browse/THK-92
The tomahawk seems to be sending UTF-8 pages, but doesn't seem to specify an encoding in HTML or HTTP headers. (This might work on some setups when UTF-8 is chosen by default in the client)

This is an example that fails to display correctly with and without quoting on our end:
http://acousticbrainz.org/cc8ddf86-d389-4e1f-a045-3ee85be1b81b
