### PR TITLE
Add links to the JSON data on summary.html

### DIFF
--- a/templates/summary.html
+++ b/templates/summary.html
@@ -96,6 +96,18 @@
              </div>
             </div>
          {% endif %}
+
+        <div class="col-md-12">
+          <p>Inspect the raw data the above is taken from:
+            <ul>
+              <li><a href="{{ url_for('get_low_level', mbid=mbid) }}">Low level data</a></li>
+              {% if other -%}
+                <li><a href="{{ url_for('get_high_level', mbid=mbid) }}">High level data</a></li>
+              {%- endif %}
+            </ul>
+          </p>
+        </div>
+
   {% endif %}
 </div>
 {%- endblock -%}


### PR DESCRIPTION
Add some links at the bottom of the summary page to navigate to the raw JSON data used for the page.

![Screenshot!](https://i.imgur.com/BdtIlFX.png)
