### PR TITLE
Add track length to summary.html.

### DIFF
--- a/acousticbrainz/server.py
+++ b/acousticbrainz/server.py
@@ -437,6 +437,10 @@ def get_summary(mbid):
         if 'title' not in lowlevel['metadata']['tags']:
             lowlevel['metadata']['tags']['title'] = ["[unknown]"]
 
+        # Format track length readably (mm:ss)
+        lowlevel['metadata']['audio_properties']['length_formatted'] = \
+            time.strftime("%M:%S", time.gmtime(lowlevel['metadata']['audio_properties']['length']))
+
         # Tomahawk player stuff
         if not ('artist' in lowlevel['metadata']['tags'] and 'title' in lowlevel['metadata']['tags']):
             tomahawk_url = None

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -61,6 +61,7 @@
                 </td>
               </tr>
             {% endif %}
+            <tr><td>track length</td><td>{{ lowlevel.metadata.audio_properties.length_formatted }}</td></tr>
          </table>
         </div>
         <div class="col-md-4">


### PR DESCRIPTION
Track length is extracted straight from the audio data, so it is not dependent on any specific metadata tags and should thus always be available, hence no checking for availability.

![Screenshot!](https://i.imgur.com/K01nJIz.png)
