### PR TITLE
Cover Art Archive support for summary.html

### DIFF
--- a/templates/summary.html
+++ b/templates/summary.html
@@ -16,7 +16,7 @@
       <div>We do not have data for this track. <a href="/contribute">Please upload it!</a></div>
   {% else %}
       <div>
-        <div class="col-md-8">
+        <div class="col-md-9">
          <table class="table table-striped table-bordered">
             <thead><th style="width: 30%;">Track information</th><th>value</th></thead>
             <tr>
@@ -64,14 +64,14 @@
             <tr><td>track length</td><td>{{ lowlevel.metadata.audio_properties.length_formatted }}</td></tr>
          </table>
         </div>
-        <div class="col-md-4">
-            {% if tomahawk_url %}
-            <iframe src="{{ tomahawk_url }}" width="200" scrolling="no" height="200" frameborder="0" allowtransparency="true" ></iframe>
-            {% endif %}
-        </div>
+        {% if 'front' in caa -%}
+          <div class="col-md-3 well" style="text-align: center;">
+            <img src="{{ caa['front']['thumbnails']['small'] }}" style="max-height: 250px; max-width: 200px;">
+          </div>
+        {% endif -%}
      </div>
 
-        <div class="col-md-12">
+        <div class="col-md-9">
          <table class="table table-striped table-bordered">
             <thead><th style="width: 30%;">Tonal & Rhythm</th><th>value</th></thead>
             <tr>
@@ -91,6 +91,11 @@
                <td>{{ lowlevel.rhythm.bpm }}</td></tr>
             <tr><td>beat count</td><td>{{ lowlevel.rhythm.beats_count }}</td></tr>
          </table>
+        </div>
+        <div class="col-md-3 well" style="text-align: center;">
+            {% if tomahawk_url %}
+            <iframe src="{{ tomahawk_url }}" width="200" scrolling="no" height="200" frameborder="0" allowtransparency="true" ></iframe>
+            {% endif %}
         </div>
 
          {% if other %}


### PR DESCRIPTION
Some talk on IRC for more background: http://chatlogs.musicbrainz.org/musicbrainz-devel/2014/2014-11/2014-11-26.html#T10-15-07-807376

Note that the complicated CAA querying will be useful for making a thickbox (or whatever) CAA gallery, per my comment on IRC.

Also, it would be good if nginx or something could be set up to cache CAA responses, so we won't have to send off a query whenever someone reloads a page or loads another recording MBID from the same release they were just at. :)

![Screenshot!](https://i.imgur.com/1r8GAJE.png)