### PR TITLE
explain static builds in DIY section

### DIFF
--- a/templates/download.html
+++ b/templates/download.html
@@ -34,7 +34,7 @@
       <ul><li><a href="https://github.com/MTG/acousticbrainz-client">acousticbrainz-client</a></li>
           <li><a href="https://github.com/MTG/acousticbrainz-gui">acousticbrainz-gui</a></li></ul>
     <p>
-    Part of the source installation requires a static extractor binary. We have these versions for Linux, Mac & Windows available:
+    Part of the source installation requires an extractor binary. You should use one of these static builds for Linux, Mac & Windows (see our <a href="/faq">FAQ</a> why):
     </p>
     <ul>
        <li><a href="/static/download/essentia-extractor-v2.1_beta2-linux-i686.tar.gz">linux i386 extractor static binary</a></li>


### PR DESCRIPTION
We technically don't need the extractor to be a static build,
but we _want_ people/packagers to use one of our static builds.
We should make that clear in this section too, instead of giving vague pointers.

Yes, there is a note about static builds and a link to the FAQ in a section above.
No reason to be that vague for people scrolling directly to the details for DIY/packaging.

When I (as a packager) read "requires a static .. binary" I think  "no I can make a dynamic build myself just fine" (which works)
and reading "We have these versions available" I understand that as "For people that are not at all able to build these from source".
