### PR TITLE
AB-90: Return a json error message for API endpoints

### DIFF
--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -3,8 +3,8 @@ import webserver.exceptions
 
 def init_error_handlers(app):
 
-    @app.errorhandler(webserver.exceptions.InvalidAPIUsage)
-    def handle_invalid_usage(error):
+    @app.errorhandler(webserver.exceptions.APIError)
+    def api_error(error):
         response = jsonify(error.to_dict())
         response.status_code = error.status_code
         return response

--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -1,7 +1,13 @@
-from flask import render_template
-
+from flask import render_template, jsonify
+import webserver.exceptions
 
 def init_error_handlers(app):
+
+    @app.errorhandler(webserver.exceptions.InvalidAPIUsage)
+    def handle_invalid_usage(error):
+        response = jsonify(error.to_dict())
+        response.status_code = error.status_code
+        return response
 
     @app.errorhandler(400)
     def bad_request(error):

--- a/webserver/exceptions.py
+++ b/webserver/exceptions.py
@@ -1,8 +1,7 @@
-class InvalidAPIUsage(Exception):
-    status_code = 400
+class APIError(Exception):
 
     def __init__(self, message, status_code, payload=None):
-        Exception.__init__(self)
+        super(APIError, self).__init__()
         self.message = message
         self.status_code = status_code
         self.payload = payload
@@ -11,3 +10,11 @@ class InvalidAPIUsage(Exception):
         rv = dict(self.payload or ())
         rv['message'] = self.message
         return rv
+
+class APINotFound(APIError):
+    def __init__(self, message, payload=None):
+        super(APINotFound, self).__init__(message, 404, payload)
+
+class APIBadRequest(APIError):
+    def __init__(self, message, payload=None):
+        super(APIBadRequest, self).__init__(message, 400, payload)

--- a/webserver/exceptions.py
+++ b/webserver/exceptions.py
@@ -1,0 +1,13 @@
+class InvalidAPIUsage(Exception):
+    status_code = 400
+
+    def __init__(self, message, status_code, payload=None):
+        Exception.__init__(self)
+        self.message = message
+        self.status_code = status_code
+        self.payload = payload
+
+    def to_dict(self):
+        rv = dict(self.payload or ())
+        rv['message'] = self.message
+        return rv

--- a/webserver/templates/navbar.html
+++ b/webserver/templates/navbar.html
@@ -28,7 +28,7 @@
       {# Not showing user stuff on error pages. If attempt to load user info fails there, page will not render. #}
       {% if not error %}
         <ul class="nav navbar-nav navbar-right">
-          {% if not current_user or current_user.is_anonymous() %}
+          {% if not current_user or current_user.is_anonymous %}
             <li><a href="{{ url_for('login.index') }}">Sign in</a></li>
           {% else %}
             <li class="dropdown">

--- a/webserver/test/test_api.py
+++ b/webserver/test/test_api.py
@@ -1,0 +1,47 @@
+from webserver.testing import ServerTestCase
+import mock
+import uuid
+import db.exceptions
+
+class APITestCase(ServerTestCase):
+
+    def setUp(self):
+        self.uuid = str(uuid.uuid4())
+
+    @mock.patch("db.data.load_low_level")
+    def test_ll_bad_uuid(self, ll):
+        resp = self.client.get('/nothing/low-level')
+        self.assertEqual(404, resp.status_code)
+
+    @mock.patch("db.data.load_low_level")
+    def test_ll_no_offset(self, ll):
+        ll.return_value = {}
+        resp = self.client.get('/%s/low-level' % self.uuid)
+        self.assertEqual(200, resp.status_code)
+        ll.assert_called_with(self.uuid, 0)
+
+    @mock.patch("db.data.load_low_level")
+    def test_ll_numerical_offset(self, ll):
+        ll.return_value = {}
+        resp = self.client.get('/%s/low-level?n=3' % self.uuid)
+        self.assertEqual(200, resp.status_code)
+        ll.assert_called_with(self.uuid, 3)
+
+    @mock.patch("db.data.load_low_level")
+    def test_ll_bad_offset(self, ll):
+        resp = self.client.get('/%s/low-level?n=x' % self.uuid)
+        self.assertEqual(400, resp.status_code)
+
+    @mock.patch("db.data.load_low_level")
+    def test_ll_no_item(self, ll):
+        ll.side_effect = db.exceptions.NoDataFoundException
+        resp = self.client.get('/%s/low-level' % self.uuid)
+        self.assertEqual(404, resp.status_code)
+        self.assertEqual("Not found", resp.json["message"])
+
+    @mock.patch("db.data.load_high_level")
+    def test_hl_numerical_offset(self, hl):
+        hl.return_value = {}
+        resp = self.client.get('/%s/high-level?n=3' % self.uuid)
+        self.assertEqual(200, resp.status_code)
+        hl.assert_called_with(self.uuid, 3)


### PR DESCRIPTION
Fixes AB-90: http://tickets.musicbrainz.org/browse/AB-90
We use a flask pattern from
http://flask.pocoo.org/docs/0.10/patterns/apierrors/
to raise a specific api error and return a json response in the
error handler.
We add two more routes to catch /anything/low-level and .../high-level
so that we can also return json for invalid uuids, not just missing
ones.