### PR TITLE
Solved AB-79

### DIFF
--- a/webserver/templates/datasets/edit.html
+++ b/webserver/templates/datasets/edit.html
@@ -11,6 +11,10 @@
 
 {% block content %}
   <h2 class="page-title">Datasets</h2>
+  <h6>{% if pending == "1" %} 
+        This dataset is in the evalutation queue 
+      {% endif %}
+  </h6>
   <hr />
   <div id="dataset-editor" data-mode="{{ mode }}"
       {{ 'data-edit-id='+dataset_id if dataset_id }}></div>

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -15,6 +15,9 @@ import db.user
 import jsonschema
 import csv
 import six
+import config
+import db
+import db.dataset_eval
 
 datasets_bp = Blueprint("datasets", __name__)
 
@@ -144,7 +147,11 @@ def edit(dataset_id):
     ds = get_dataset(dataset_id)
     if ds["author"] != current_user.id:
         raise Unauthorized("You can't edit this dataset.")
-
+    jobs = db.dataset_eval.get_jobs_for_dataset(str(dataset_id))
+    for job in jobs:
+        if(job["status"]=="running" or job["status"]=="pending"):
+            flash.warn("There is a pending job for this dataset")
+            break
     if request.method == "POST":
         dataset_dict = request.get_json()
         if not dataset_dict:

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -145,12 +145,13 @@ def _parse_dataset_csv(file):
 @login_required
 def edit(dataset_id):
     ds = get_dataset(dataset_id)
+    pending = "0"
     if ds["author"] != current_user.id:
         raise Unauthorized("You can't edit this dataset.")
     jobs = db.dataset_eval.get_jobs_for_dataset(str(dataset_id))
     for job in jobs:
-        if(job["status"]=="running" or job["status"]=="pending"):
-            flash.warn("There is a pending job for this dataset")
+        if(job["status"] in ("running","pending")):
+            pending = "1"            
             break
     if request.method == "POST":
         dataset_dict = request.get_json()
@@ -179,6 +180,7 @@ def edit(dataset_id):
             mode="edit",
             dataset_id=str(dataset_id),
             dataset_name=ds["name"],
+            pending=pending
         )
 
 


### PR DESCRIPTION
This request solves the bug AB-79. It displays a warning whenever a user tries to edit a dataset which has a pending or a running job.