### PR TITLE
AB-55: Reject submissions with invalid-according-to-postgres json

### DIFF
--- a/db/data.py
+++ b/db/data.py
@@ -8,6 +8,7 @@ import db
 import db.exceptions
 
 from sqlalchemy import text
+import sqlalchemy.exc
 
 _whitelist_file = os.path.join(os.path.dirname(__file__), "tagwhitelist.json")
 _whitelist_tags = set(json.load(open(_whitelist_file)))
@@ -124,7 +125,11 @@ def submit_low_level_data(mbid, data):
         )
 
     # The data looks good, lets see about saving it
-    write_low_level(mbid, data)
+    try:
+        write_low_level(mbid, data)
+    except sqlalchemy.exc.DataError as e:
+        raise db.exceptions.BadDataException(
+                "data is badly formed")
 
 def insert_version(connection, data, version_type):
     # TODO: Memoise sha -> id

--- a/db/data.py
+++ b/db/data.py
@@ -125,11 +125,7 @@ def submit_low_level_data(mbid, data):
         )
 
     # The data looks good, lets see about saving it
-    try:
-        write_low_level(mbid, data)
-    except sqlalchemy.exc.DataError as e:
-        raise db.exceptions.BadDataException(
-                "data is badly formed")
+    write_low_level(mbid, data)
 
 def insert_version(connection, data, version_type):
     # TODO: Memoise sha -> id
@@ -156,32 +152,59 @@ def insert_version(connection, data, version_type):
 
 def write_low_level(mbid, data):
 
+    def _get_by_data_sha256(connection, data_sha256):
+        query = text("""
+            SELECT id
+              FROM lowlevel_json
+             WHERE data_sha256 = :data_sha256
+        """)
+        result = connection.execute(query, {"data_sha256": data_sha256})
+        return result.fetchone()
+
+    def _insert_lowlevel(connection, mbid, build_sha1, is_lossless_submit):
+        """ Insert metadata into the lowlevel table and return its id """
+        query = text("""
+            INSERT INTO lowlevel (mbid, build_sha1, lossless)
+                 VALUES (:mbid, :build_sha1, :lossless)
+              RETURNING id
+        """)
+        result = connection.execute(query, {"mbid": mbid,
+                                            "build_sha1": build_sha1,
+                                            "lossless": is_lossless_submit})
+        return result.fetchone()[0]
+
+    def _insert_lowlevel_json(connection, ll_id, data_json, data_sha256, version_id):
+        """ Insert the contents of the data file, with references to
+            the version and metadata"""
+        query = text("""
+          INSERT INTO lowlevel_json (id, data, data_sha256, version)
+               VALUES (:id, :data, :data_sha256, :version)
+        """)
+        connection.execute(query, {"id": ll_id,
+                                   "data": data_json,
+                                   "data_sha256": data_sha256,
+                                   "version": version_id})
+
     is_lossless_submit = data['metadata']['audio_properties']['lossless']
     version = data['metadata']['version']
     build_sha1 = version['essentia_build_sha']
     data_json = json.dumps(data, sort_keys=True, separators=(',', ':'))
     data_sha256 = sha256(data_json.encode("utf-8")).hexdigest()
     with db.engine.begin() as connection:
-        # Checking to see if we already have this data
-        result = connection.execute("SELECT id FROM lowlevel_json WHERE data_sha256  = %s", (data_sha256, ))
-
-        if result.fetchone() is None:
-            logging.info("Saved %s" % mbid)
-            query = text("""
-                INSERT INTO lowlevel (mbid, build_sha1, lossless)
-                     VALUES (:mbid, :build_sha1, :lossless)
-                  RETURNING id
-            """)
-            result = connection.execute(query, {"mbid": mbid, "build_sha1": build_sha1, "lossless": is_lossless_submit})
-            ll_id = result.fetchone()[0]
-            version_id = insert_version(connection, version, VERSION_TYPE_LOWLEVEL)
-            query = text("""
-              INSERT INTO lowlevel_json (id, data, data_sha256, version)
-                   VALUES (:id, :data, :data_sha256, :version)
-            """)
-            connection.execute(query, {"id": ll_id, "data": data_json, "data_sha256": data_sha256, "version": version_id})
-        else:
+        # See if we already have this data
+        existing = _get_by_data_sha256(connection, data_sha256)
+        if existing:
             logging.info("Already have %s" % data_sha256)
+            return
+
+        try:
+            ll_id = _insert_lowlevel(connection, mbid, build_sha1, is_lossless_submit)
+            version_id = insert_version(connection, version, VERSION_TYPE_LOWLEVEL)
+            _insert_lowlevel_json(connection, ll_id, data_json, data_sha256, version_id)
+            logging.info("Saved %s" % mbid)
+        except sqlalchemy.exc.DataError as e:
+            raise db.exceptions.BadDataException(
+                    "data is badly formed")
 
 def add_model(model_name, model_version, model_status=STATUS_HIDDEN):
     if model_status not in MODEL_STATUSES:

--- a/db/test/test_data.py
+++ b/db/test/test_data.py
@@ -75,6 +75,14 @@ class DataDBTestCase(DatabaseTestCase):
         self.assertEqual(one, db.data.load_low_level(self.test_mbid))
 
 
+    def test_write_lowlevel_invalid_data(self):
+        """Trying to submit data with invalid utf8 sequences raises an error"""
+        one = {"data": u"\uc544\uc774\uc720 (IU)\udc93", "metadata": {"audio_properties": {"lossless": True}, "version": {"essentia_build_sha": "x"}}}
+
+        with self.assertRaises(db.exceptions.BadDataException):
+            db.data.write_low_level(self.test_mbid, one)
+
+
     def test_load_low_level_offset(self):
         """If two items with the same mbid are added, you can select between them with offset"""
         one = {"data": "one", "metadata": {"audio_properties": {"lossless": True}, "version": {"essentia_build_sha": "x"}}}


### PR DESCRIPTION
http://tickets.musicbrainz.org/browse/AB-55

Postgres has very strict utf-8 handling, and we get funny errors like 
```
DataError: (psycopg2.DataError) invalid input syntax for type json
LINE 3:                    VALUES (1, '{"lowlevel":{"average_loudnes...
                                      ^
DETAIL:  Unicode low surrogate must follow a high surrogate.
CONTEXT:  JSON data, line 1: ...te":44100},"tags":{"album":["IU...IM"],"artist":[...
```

Catch `DataError` and return http 400.