### PR TITLE
Add dataset information for default classifier models

### DIFF
--- a/webserver/templates/datasets/accuracy.html
+++ b/webserver/templates/datasets/accuracy.html
@@ -33,6 +33,9 @@
 	  </div>
 	  
       <h2 id="danceability">danceability</h2>
+        <p>In-house MTG collection</p>
+        <p>Use: classification of music by danceability</p>
+        <p>Size: 306 full tracks, 124/182 per class</p>
       <h5>Accuracy: 92.410714%</h5>
      <table>
        <tr><th><h3>Predicted (%)</h3></th>
@@ -67,6 +70,9 @@
 
      <br/>
      <h2 id="gender">gender</h2>
+      <p>In-house MTG collection</p>
+      <p>Use: classification of vocal music by gender (male/female)</p>
+      <p>Size: 3311 full tracks, 1508/1803 per class</p>
 	 <h5>Accuracy: 87.213915%</h5>
      <table>
        <tr>
@@ -105,6 +111,11 @@
      
      <br/>
      <h2 id="genre_dortmund">genre_dortmund</h2>
+      <p><a href="http://www-ai.cs.uni-dortmund.de/audio.html">Music Audio Benchmark Data Set</a> by TU Dortmund University (Homburg et al., 2005)</p>
+      <p>Use: classification of music by genre</p>
+      <p>Size: 1820 track excerpts, 46-490 per genre</p>
+      <p>Homburg, H., Mierswa, I., M&ouml;ller, B., Morik, K., &amp; Wurst, M. (2005). A Benchmark Dataset for Audio Classification and Clustering. In 6th International Conference on Music Information Retrieval (ISMIR'05), pp. 528-31.</a></p>
+
 	 <h5>Accuracy: 60.254372%</h5>
      <table>
        <tr>
@@ -262,6 +273,9 @@
      
      <br/>
      <h2 id="genre_electronic">genre_electronic</h2>
+      <p>In-house MTG collection</p>
+      <p>Use: classification of electronic music by subgenres</p>
+      <p>Size: 250 track excerpts, 50 per genre</p>
      <h5>Accuracy: 91.699605%</h5>
      <table>
        <tr>
@@ -339,6 +353,10 @@
   
     <br/>
     <h2 id="genre_rosamerica">genre_rosamerica</h2>
+      <p>In-house MTG collection</p>
+      <p>Use: classification of music by genre</p>
+      <p>Size: 400 tracks, 50 per genre</p>
+      <p>Classes: classical, dance, hip-hop, jazz, pop, rhythm'n'blues, rock, speech</p>
     <h5>Accuracy: 87.557604%</h5>
     <table>
       <tr>
@@ -472,6 +490,11 @@
     
     <br/>
     <h2 id="genre_tzanetakis">genre_tzanetakis</h2>
+      <p><a href="http://marsyas.info/download/data_sets/">GTZAN Genre Collection</a> (Tzanetakis and Cook, 2002)</p>
+      <p>Use: classification of music by genre</p>
+      <p>Size: 1000 track excerpts, 100 per genre</p>
+      <p>Tzanetakis, G., &amp; Cook, P. (2002). Musical genre classification of audio signals. IEEE transactions on Speech and Audio Processing, 10(5), 293-302.</p>
+      <p>Sturm, B. L. (2012). An analysis of the GTZAN music genre dataset. In 2nd International ACM Workshop on Music Information Retrieval with User-centered and Multimodal Strategies (pp. 7-12).</p>
     <h5>Accuracy: 75.528701%</h5>
     <table>
       <tr>
@@ -654,6 +677,10 @@
    
     <br/>
     <h2 id="ismir04_rhythm">ismir04_rhythm</h2>
+      <p><a href="http://mtg.upf.edu/ismir2004/contest/tempoContest/node5.html">ISMIR2004 Rhythm Classification Dataset</a> ("Ballroom dataset") (Cano et al., 2006)</p>
+      <p>Use: classification of ballroom music by dance styles</p>
+      <p>Size: 683 track excerpts, 60-110 per class</p>
+      <p>Cano, P., G&oacute;mez, E., Gouyon, F., Herrera, P., Koppenberger, M., Ong, B., ... &amp; Wack, N. (2006). ISMIR 2004 audio description contest. Music Technology Group, Universitat Pompeu Fabra, Tech. Rep.</p>
     <h5>Accuracy: 73.209169%</h5>
     <table>
       <tr>
@@ -832,6 +859,9 @@
    
     <br/>
     <h2 id="mood_acoustic">mood_acoustic</h2>
+      <p>In-house MTG collection (Laurier et al., 2009)</p>
+      <p>Use: classification of music by type of sound (acoustic/non-acoustic)</p>
+      <p>Size: 321 full tracks + excerpts, 193/128 per class</p>
     <h5>Accuracy: 92.982456%</h5>
     <table>
       <tr>
@@ -869,6 +899,9 @@
     
     <br/>
     <h2 id="mood_aggressive">mood_aggressive</h2>
+      <p>In-house MTG collection (Laurier et al., 2009)</p>
+      <p>Use: classification of music by mood (aggressive/non-aggressive)</p>
+      <p>Size: 280 full tracks + excerpts, 133/147 per class</p>
     <h5>Accuracy: 97.500000%</h5>
     <table>
       <tr>
@@ -906,6 +939,9 @@
     
     <br/>
     <h2 id="mood_electronic">mood_electronic</h2>
+  <p>In-house MTG collection (Laurier et al., 2009)</p>
+  <p>Use: classification of music by type of sound (electronic/non-electronic)</p>
+  <p>Size: 332 full tracks + excerpts, 164/168 per class</p>    
     <h5>Accuracy: 86.379928%</h5>
     <table>
       <tr>
@@ -944,6 +980,9 @@
     
     <br/>
     <h2 id="mood_happy">mood_happy</h2>
+      <p>In-house MTG collection (Laurier et al., 2009)</p>
+      <p>Use: classification of music by mood (happy/non-happy)</p>
+      <p>Size: 302 full tracks + excerpts, 139/163 per class</p>
     <h5>Accuracy: 83.265306%</h5>
     <table>
     	<tr><th><h3>Predicted (%)</h3></th><td></td>
@@ -979,6 +1018,9 @@
     
     <br/>
     <h2 id="mood_party">mood_party</h2>
+      <p>In-house MTG collection (Laurier et al., 2009)</p>
+      <p>Use: classification of music by mood (party/non-party)</p>
+      <p>Size: 349 full tracks + excerpts, 198/151 per class</p>
     <h5>Accuracy: 88.381743%</h5>
     <table>
       <tr>
@@ -1016,6 +1058,9 @@
     
     <br/>
     <h2 id="mood_relaxed">mood_relaxed</h2>
+      <p>In-house MTG collection (Laurier et al., 2009)</p>
+      <p>Use: classification of music by mood (relaxed/non-relaxed)</p>
+      <p>Size: 446 full tracks + excerpts, 145/301 per class</p>
     <h5>Accuracy: 93.201133%</h5>
     <table>
       <tr>
@@ -1054,6 +1099,9 @@
     
     <br/>
     <h2 id="mood_sad">mood_sad</h2>
+      <p>In-house MTG collection (Laurier et al., 2009)</p>
+      <p>Use: classification of music by mood (sad/non-sad)</p>
+      <p>Size: 230 full tracks + excerpts, 96/134 per class</p>
     <h5>Accuracy: 87.826087%</h5>
     <table>
       <tr>
@@ -1092,6 +1140,17 @@
     
     <br/>
     <h2 id="moods_mirex">moods_mirex</h2>
+      <p><a href="http://www.music-ir.org/mirex/wiki/2007:Audio_Music_Mood_Classification">MIREX Audio Mood Classification Dataset</a> (Hu and Downie, 2007)</p>
+      <p>Use: classification of music into 5 mood clusters</p>
+      <ul>
+        <li>Cluster1: passionate, rousing, confident,boisterous, rowdy</li>
+        <li>Cluster2: rollicking, cheerful, fun, sweet, amiable/good natured</li>
+        <li>Cluster3: literate, poignant, wistful, bittersweet, autumnal, brooding</li>
+        <li>Cluster4: humorous, silly, campy, quirky, whimsical, witty, wry</li>
+        <li>Cluster5: aggressive, fiery,tense/anxious, intense, volatile,visceral</li>
+      </ul>
+      <p>Size: 269 track excerpts, 60-110 per class</p>
+      <p>Hu, X., &amp; Downie, J. S. (2007). Exploring Mood Metadata: Relationships with Genre, Artist and Usage Metadata. In 8th International Conference on Music Information Retrieval (ISMIR'07), pp. 67-72.</p>
     <h5>Accuracy: 57.089552%</h5>
     <table>
     	<tr>
@@ -1168,6 +1227,9 @@
     
     <br/>
     <h2 id="timbre">timbre</h2>
+      <p>In-house MTG collection</p>  
+      <p>Use: classification of music by timbre colour (dark/bright timbre)</p>
+      <p>Size: 3000 track excerpts, 1500 per class</p>
     <h5>Accuracy: 94.317418%</h5>
     <table>
       <tr>
@@ -1205,6 +1267,9 @@
     
     <br/>
     <h2 id="tonal_atonal">tonal_atonal</h2>
+      <p>In-house MTG collection</p>  
+      <p>Use: classification of music by tonality (tonal/atonal)</p>
+      <p>Size: 345 track excerpts, 200/145</p>
     <h5>Accuracy: 97.667638%</h5>
     <table>
     	<tr>
@@ -1243,6 +1308,9 @@
     
     <br/>
     <h2 id="voice_instrumental">voice_instrumental</h2>
+      <p>In-house MTG collection</p>
+      <p>Use: classification into music with voice/instrumental</p>
+      <p>Size: 100 track excerpts, 500 per class</p>
     <h5>Accuracy: 93.800000%</h5>
     <table>
       <tr>

--- a/webserver/templates/datasets/accuracy.html
+++ b/webserver/templates/datasets/accuracy.html
@@ -863,6 +863,7 @@
       <p>In-house MTG collection (Laurier et al., 2009)</p>
       <p>Use: classification of music by type of sound (acoustic/non-acoustic)</p>
       <p>Size: 321 full tracks + excerpts, 193/128 per class</p>
+      <p>Laurier, C., Meyers, O., Serra, J., Blech, M., &amp; Herrera, P. (2009). Music mood annotator design and integration. In 7th International Workshop on Content-Based Multimedia Indexing (CBMI'09), pp. 156-161.</p>
     <h5>Accuracy: 92.982456%</h5>
     <table>
       <tr>
@@ -903,6 +904,8 @@
       <p>In-house MTG collection (Laurier et al., 2009)</p>
       <p>Use: classification of music by mood (aggressive/non-aggressive)</p>
       <p>Size: 280 full tracks + excerpts, 133/147 per class</p>
+      <p>Laurier, C., Meyers, O., Serra, J., Blech, M., &amp; Herrera, P. (2009). Music mood annotator design and integration. In 7th International Workshop on Content-Based Multimedia Indexing (CBMI'09), pp. 156-161.</p>
+
     <h5>Accuracy: 97.500000%</h5>
     <table>
       <tr>
@@ -942,7 +945,9 @@
     <h2 id="mood_electronic">mood_electronic</h2>
   <p>In-house MTG collection (Laurier et al., 2009)</p>
   <p>Use: classification of music by type of sound (electronic/non-electronic)</p>
-  <p>Size: 332 full tracks + excerpts, 164/168 per class</p>    
+  <p>Size: 332 full tracks + excerpts, 164/168 per class</p>
+  <p>Laurier, C., Meyers, O., Serra, J., Blech, M., &amp; Herrera, P. (2009). Music mood annotator design and integration. In 7th International Workshop on Content-Based Multimedia Indexing (CBMI'09), pp. 156-161.</p>
+
     <h5>Accuracy: 86.379928%</h5>
     <table>
       <tr>
@@ -984,6 +989,8 @@
       <p>In-house MTG collection (Laurier et al., 2009)</p>
       <p>Use: classification of music by mood (happy/non-happy)</p>
       <p>Size: 302 full tracks + excerpts, 139/163 per class</p>
+      <p>Laurier, C., Meyers, O., Serra, J., Blech, M., &amp; Herrera, P. (2009). Music mood annotator design and integration. In 7th International Workshop on Content-Based Multimedia Indexing (CBMI'09), pp. 156-161.</p>
+
     <h5>Accuracy: 83.265306%</h5>
     <table>
     	<tr><th><h3>Predicted (%)</h3></th><td></td>
@@ -1022,6 +1029,8 @@
       <p>In-house MTG collection (Laurier et al., 2009)</p>
       <p>Use: classification of music by mood (party/non-party)</p>
       <p>Size: 349 full tracks + excerpts, 198/151 per class</p>
+      <p>Laurier, C., Meyers, O., Serra, J., Blech, M., &amp; Herrera, P. (2009). Music mood annotator design and integration. In 7th International Workshop on Content-Based Multimedia Indexing (CBMI'09), pp. 156-161.</p>
+
     <h5>Accuracy: 88.381743%</h5>
     <table>
       <tr>
@@ -1062,6 +1071,8 @@
       <p>In-house MTG collection (Laurier et al., 2009)</p>
       <p>Use: classification of music by mood (relaxed/non-relaxed)</p>
       <p>Size: 446 full tracks + excerpts, 145/301 per class</p>
+      <p>Laurier, C., Meyers, O., Serra, J., Blech, M., &amp; Herrera, P. (2009). Music mood annotator design and integration. In 7th International Workshop on Content-Based Multimedia Indexing (CBMI'09), pp. 156-161.</p>
+
     <h5>Accuracy: 93.201133%</h5>
     <table>
       <tr>
@@ -1103,6 +1114,8 @@
       <p>In-house MTG collection (Laurier et al., 2009)</p>
       <p>Use: classification of music by mood (sad/non-sad)</p>
       <p>Size: 230 full tracks + excerpts, 96/134 per class</p>
+      <p>Laurier, C., Meyers, O., Serra, J., Blech, M., &amp; Herrera, P. (2009). Music mood annotator design and integration. In 7th International Workshop on Content-Based Multimedia Indexing (CBMI'09), pp. 156-161.</p>
+
     <h5>Accuracy: 87.826087%</h5>
     <table>
       <tr>

--- a/webserver/templates/datasets/accuracy.html
+++ b/webserver/templates/datasets/accuracy.html
@@ -1324,7 +1324,7 @@
     <h2 id="voice_instrumental">voice_instrumental</h2>
       <p>In-house MTG collection</p>
       <p>Use: classification into music with voice/instrumental</p>
-      <p>Size: 100 track excerpts, 500 per class</p>
+      <p>Size: 1000 track excerpts, 500 per class</p>
     <h5>Accuracy: 93.800000%</h5>
     <table>
       <tr>

--- a/webserver/templates/datasets/accuracy.html
+++ b/webserver/templates/datasets/accuracy.html
@@ -353,10 +353,11 @@
   
     <br/>
     <h2 id="genre_rosamerica">genre_rosamerica</h2>
-      <p>In-house MTG collection</p>
+      <p>In-house MTG collection created by a musicologist (Guaus, 2009)</p>
       <p>Use: classification of music by genre</p>
       <p>Size: 400 tracks, 50 per genre</p>
       <p>Classes: classical, dance, hip-hop, jazz, pop, rhythm'n'blues, rock, speech</p>
+      <p>Guaus, E. (2009). Audio content processing for automatic music genre classification: descriptors, databases, and classifiers (Doctoral dissertation, Universitat Pompeu Fabra, Barcelona).
     <h5>Accuracy: 87.557604%</h5>
     <table>
       <tr>


### PR DESCRIPTION
I have not tested a rendered HTML yet. 

We should also host ```rosamerica_mp3_filelist.yaml``` file somewhere, and link to in in the description. The same can be done for the rest of music collections to provide at least partial information about the tracks.
 