### PR TITLE
Delete temporary files if hl calculation fails

### DIFF
--- a/hl_extractor/hl_calc.py
+++ b/hl_extractor/hl_calc.py
@@ -50,6 +50,8 @@ class HighLevel(Thread):
             f.close()
         except IOError:
             print("IO Error while writing temp file")
+            # If we return early, remove the ll file we created
+            os.unlink(name)
             return "{}"
 
         # Securely generate a temporary filename
@@ -62,21 +64,27 @@ class HighLevel(Thread):
             subprocess.check_call([os.path.join(".", HIGH_LEVEL_EXTRACTOR_BINARY),
                                    name, out_file, PROFILE_CONF],
                                   stdout=fnull, stderr=fnull)
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, OSError):
             print("Cannot call high-level extractor")
+            # If we return early, make sure we remove the temp
+            # output file that we created
+            os.unlink(out_file)
             return "{}"
-
-        fnull.close()
-        os.unlink(name)
+        finally:
+            # At this point we can remove the source file,
+            # regardless of if we failed or if we succeeded
+            fnull.close()
+            os.unlink(name)
 
         try:
             f = open(out_file)
             hl_data = f.read()
             f.close()
-            os.unlink(out_file)
         except IOError:
             print("IO Error while removing temp file")
             return "{}"
+        finally:
+            os.unlink(out_file)
 
         return hl_data
 


### PR DESCRIPTION
Whenever we return early from the hl calculation file we need
to make sure that we remove any temporary files that we created.
This includes:
 - input (lowlevel) file if we fail to write data to it
 - input and output (highlevel) file if we fail to run the extractor

Tests:
Ran manually with a `streaming_extractor_music_svm` file which was not `+x` (failed with `OSError`), and a dummy script which returned `1` (failed with `subprocess.CalledProcessError`). Without these changes, tmp files remained, with the changes they were cleaned up.
I'm not sure of the best way to test the `IOError`s for the input and output file. If these open/reads fail I think we have more serious problems on the server