### PR TITLE
Gaia Config and essentia extractor

### DIFF
--- a/admin/install_hl_extractor.sh
+++ b/admin/install_hl_extractor.sh
@@ -17,7 +17,7 @@ apt-get -y install build-essential libyaml-dev libfftw3-dev libavcodec-dev \
 # See https://github.com/MTG/gaia
 git clone https://github.com/MTG/gaia.git /tmp/gaia
 cd /tmp/gaia
-./waf configure --download --with-python-bindings
+./waf configure --with-python-bindings
 ./waf
 ./waf install
 
@@ -27,8 +27,8 @@ git clone https://github.com/MTG/essentia.git /tmp/essentia
 cd /tmp/essentia
 ./waf configure --mode=release --with-gaia --with-example=streaming_extractor_music_svm
 ./waf
-cp /tmp/essentia/build/src/examples/streaming_extractor_music_svm \
-    $APP_DIR/high-level/streaming_extractor_music_svm
+cp /tmp/essentia/build/src/examples/essentia_streaming_extractor_music_svm \
+    $APP_DIR/hl_extractor/streaming_extractor_music_svm
 
 # SVM models
 mkdir /tmp/models


### PR DESCRIPTION
Removed ‘—download’ option from waf configure
Changed the name of the essentia extrator from
streaming_extractor_music_svm to essentia_streaming_extractor_music_svm
and changed the destination dir to hl_etractor