### PR TITLE
Schema change to support non-MBID submissions

### DIFF
--- a/admin/clean-tags.py
+++ b/admin/clean-tags.py
@@ -20,7 +20,7 @@ def rewrite_lowlevel():
     cur2 = conn2.cursor()
     cur3 = conn3.cursor()
 
-    cur.execute("""SELECT id FROM lowlevel ll ORDER BY mbid""")
+    cur.execute("""SELECT id FROM lowlevel ll ORDER BY gid""")
     total = 0
     while True:
         id_list = cur.fetchmany(size = DUMP_CHUNK_SIZE)
@@ -29,7 +29,7 @@ def rewrite_lowlevel():
 
         id_list = tuple([ i[0] for i in id_list ])
 
-        cur2.execute("SELECT id, mbid, data FROM lowlevel WHERE id IN %s ORDER BY mbid", (id_list,))
+        cur2.execute("SELECT id, gid, data FROM lowlevel WHERE id IN %s ORDER BY gid", (id_list,))
         count = 0
         while True:
             row = cur2.fetchone()

--- a/admin/split-highlevel.py
+++ b/admin/split-highlevel.py
@@ -44,7 +44,7 @@ def migrate_rows(oldengine, newconn, id_list):
 
     q = text(
         """SELECT ll.id AS id
-                , ll.mbid AS mbid
+                , ll.gid AS gid
                 , ll.submitted AS ll_submitted
                 , ll.build_sha1 AS ll_build_sha1
                 , ll.lossless AS ll_lossless

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE INDEX mbid_ndx_lowlevel ON lowlevel (mbid);
+CREATE INDEX gid_ndx_lowlevel ON lowlevel (gid);
 CREATE INDEX build_sha1_ndx_lowlevel ON lowlevel (build_sha1);
 CREATE INDEX submitted_ndx_lowlevel ON lowlevel (submitted);
 CREATE INDEX lossless_ndx_lowlevel ON lowlevel (lossless);

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 CREATE INDEX gid_ndx_lowlevel ON lowlevel (gid);
-CREATE INDEX is_mbid_ndx_lowlevel ON lowlevel (is_mbid);
+CREATE INDEX gid_type_ndx_lowlevel ON lowlevel (gid_type);
 CREATE INDEX build_sha1_ndx_lowlevel ON lowlevel (build_sha1);
 CREATE INDEX submitted_ndx_lowlevel ON lowlevel (submitted);
 CREATE INDEX lossless_ndx_lowlevel ON lowlevel (lossless);

--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -1,6 +1,7 @@
 BEGIN;
 
 CREATE INDEX gid_ndx_lowlevel ON lowlevel (gid);
+CREATE INDEX is_mbid_ndx_lowlevel ON lowlevel (is_mbid);
 CREATE INDEX build_sha1_ndx_lowlevel ON lowlevel (build_sha1);
 CREATE INDEX submitted_ndx_lowlevel ON lowlevel (submitted);
 CREATE INDEX lossless_ndx_lowlevel ON lowlevel (lossless);

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -2,11 +2,11 @@ BEGIN;
 
 CREATE TABLE lowlevel (
   id              SERIAL,
-  gid             UUID NOT NULL,
-  build_sha1      TEXT NOT NULL,
+  gid             UUID    NOT NULL,
+  build_sha1      TEXT    NOT NULL,
   lossless        BOOLEAN                  DEFAULT 'n',
   submitted       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  is_mbid         BOOLEAN NOT NULL
+  is_mbid         id_type NOT NULL
 );
 
 CREATE TABLE lowlevel_json (

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -2,11 +2,11 @@ BEGIN;
 
 CREATE TABLE lowlevel (
   id              SERIAL,
-  mbid            UUID NOT NULL,
+  gid             UUID NOT NULL,
   build_sha1      TEXT NOT NULL,
   lossless        BOOLEAN                  DEFAULT 'n',
   submitted       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  submission_type BOOLEAN NOT NULL         DEFAULT FALSE
+  is_mbid         BOOLEAN NOT NULL
 );
 
 CREATE TABLE lowlevel_json (

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -1,12 +1,12 @@
 BEGIN;
 
 CREATE TABLE lowlevel (
-  id              SERIAL,
-  gid             UUID    NOT NULL,
-  build_sha1      TEXT    NOT NULL,
-  lossless        BOOLEAN                  DEFAULT 'n',
-  submitted       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  is_mbid         id_type NOT NULL
+  id         SERIAL,
+  gid        UUID      NOT NULL,
+  build_sha1 TEXT      NOT NULL,
+  lossless   BOOLEAN                  DEFAULT 'n',
+  submitted  TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  gid_type   gid_type  NOT NULL
 );
 
 CREATE TABLE lowlevel_json (

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -1,11 +1,12 @@
 BEGIN;
 
 CREATE TABLE lowlevel (
-  id          SERIAL,
-  mbid        UUID NOT NULL,
-  build_sha1  TEXT NOT NULL,
-  lossless    BOOLEAN                  DEFAULT 'n',
-  submitted   TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+  id              SERIAL,
+  mbid            UUID NOT NULL,
+  build_sha1      TEXT NOT NULL,
+  lossless        BOOLEAN                  DEFAULT 'n',
+  submitted       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  submission_type BOOLEAN NOT NULL         DEFAULT FALSE
 );
 
 CREATE TABLE lowlevel_json (

--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -1,4 +1,4 @@
 CREATE TYPE eval_job_status AS ENUM ('pending', 'running', 'done', 'failed');
 CREATE TYPE model_status AS ENUM ('hidden', 'evaluation', 'show');
 CREATE TYPE version_type AS ENUM ('lowlevel', 'highlevel');
-CREATE TYPE id_type AS ENUM ('mbid', 'mesbid');
+CREATE TYPE gid_type AS ENUM ('mbid', 'msid');

--- a/admin/sql/create_types.sql
+++ b/admin/sql/create_types.sql
@@ -1,3 +1,4 @@
 CREATE TYPE eval_job_status AS ENUM ('pending', 'running', 'done', 'failed');
 CREATE TYPE model_status AS ENUM ('hidden', 'evaluation', 'show');
 CREATE TYPE version_type AS ENUM ('lowlevel', 'highlevel');
+CREATE TYPE id_type AS ENUM ('mbid', 'mesbid');

--- a/admin/updates/20160621-non-mbid-submission.sql
+++ b/admin/updates/20160621-non-mbid-submission.sql
@@ -1,10 +1,10 @@
 BEGIN;
 
-CREATE TYPE id_type AS ENUM ('mbid', 'msid');
+CREATE TYPE gid_type AS ENUM ('mbid', 'msid');
 ALTER TABLE "lowlevel" RENAME COLUMN mbid TO gid;
-ALTER TABLE "lowlevel" ADD COLUMN is_mbid id_type;
-UPDATE "lowlevel" SET is_mbid = 'mbid';
-ALTER TABLE "lowlevel" ALTER COLUMN is_mbid SET NOT NULL;
-CREATE INDEX is_mbid_ndx_lowlevel ON lowlevel (is_mbid);
+ALTER TABLE "lowlevel" ADD COLUMN gid_type gid_type;
+UPDATE "lowlevel" SET gid_type = 'mbid';
+ALTER TABLE "lowlevel" ALTER COLUMN gid_type SET NOT NULL;
+CREATE INDEX gid_type_ndx_lowlevel ON lowlevel (gid_type);
 
 COMMIT;

--- a/admin/updates/20160621-non-mbid-submission.sql
+++ b/admin/updates/20160621-non-mbid-submission.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE TYPE id_type AS ENUM ('mbid', 'mesbid');
+CREATE TYPE id_type AS ENUM ('mbid', 'msid');
 ALTER TABLE "lowlevel" RENAME COLUMN mbid TO gid;
 ALTER TABLE "lowlevel" ADD COLUMN is_mbid id_type;
 UPDATE "lowlevel" SET is_mbid = 'mbid';

--- a/admin/updates/20160621-non-mbid-submission.sql
+++ b/admin/updates/20160621-non-mbid-submission.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE "lowlevel" RENAME COLUMN mbid TO gid;
+ALTER TABLE "lowlevel" ADD COLUMN is_mbid BOOLEAN;
+UPDATE "lowlevel" SET is_mbid = TRUE;
+ALTER TABLE "lowlevel" ALTER COLUMN is_mbid SET NOT NULL;
+
+COMMIT;

--- a/admin/updates/20160621-non-mbid-submission.sql
+++ b/admin/updates/20160621-non-mbid-submission.sql
@@ -4,5 +4,6 @@ ALTER TABLE "lowlevel" RENAME COLUMN mbid TO gid;
 ALTER TABLE "lowlevel" ADD COLUMN is_mbid BOOLEAN;
 UPDATE "lowlevel" SET is_mbid = TRUE;
 ALTER TABLE "lowlevel" ALTER COLUMN is_mbid SET NOT NULL;
+CREATE INDEX is_mbid_ndx_lowlevel ON lowlevel (is_mbid);
 
 COMMIT;

--- a/admin/updates/20160621-non-mbid-submission.sql
+++ b/admin/updates/20160621-non-mbid-submission.sql
@@ -1,8 +1,9 @@
 BEGIN;
 
+CREATE TYPE id_type AS ENUM ('mbid', 'mesbid');
 ALTER TABLE "lowlevel" RENAME COLUMN mbid TO gid;
-ALTER TABLE "lowlevel" ADD COLUMN is_mbid BOOLEAN;
-UPDATE "lowlevel" SET is_mbid = TRUE;
+ALTER TABLE "lowlevel" ADD COLUMN is_mbid id_type;
+UPDATE "lowlevel" SET is_mbid = 'mbid';
 ALTER TABLE "lowlevel" ALTER COLUMN is_mbid SET NOT NULL;
 CREATE INDEX is_mbid_ndx_lowlevel ON lowlevel (is_mbid);
 

--- a/admin/updates/update-alter_lowlevel_add_column_submission_type.sql
+++ b/admin/updates/update-alter_lowlevel_add_column_submission_type.sql
@@ -1,7 +1,0 @@
-BEGIN;
-
-ALTER TABLE "lowlevel" ADD COLUMN sumbission_type BOOLEAN DEFAULT FALSE;
-UPDATE "lowlevel" SET sumbission_type = FALSE;
-ALTER TABLE "lowlevel" ALTER COLUMN sumbission_type SET NOT NULL;
-
-COMMIT;

--- a/admin/updates/update-alter_lowlevel_add_column_submission_type.sql
+++ b/admin/updates/update-alter_lowlevel_add_column_submission_type.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE "lowlevel" ADD COLUMN sumbission_type BOOLEAN DEFAULT FALSE;
+UPDATE "lowlevel" SET sumbission_type = FALSE;
+ALTER TABLE "lowlevel" ALTER COLUMN sumbission_type SET NOT NULL;
+
+COMMIT;

--- a/dataset_eval/artistfilter.py
+++ b/dataset_eval/artistfilter.py
@@ -124,7 +124,7 @@ def recording_to_artist(mbid):
             FROM lowlevel ll
             JOIN lowlevel_json llj
            ON ll.id = llj.id
-           WHERE ll.mbid = :mbid""")
+           WHERE ll.gid = :mbid""")
     result = db.engine.execute(q, {"mbid": mbid})
     row = result.fetchone()
     if row and row[0]:
@@ -148,7 +148,7 @@ def recordings_to_artists_sub(mbids):
             FROM lowlevel ll
             JOIN lowlevel_json llj
               ON ll.id = llj.id
-           WHERE ll.mbid in :mbids""")
+           WHERE ll.gid in :mbids""")
     if notincache:
         result = db.engine.execute(q, {"mbids": tuple(notincache)})
         for row in result.fetchall():

--- a/db/data.py
+++ b/db/data.py
@@ -83,13 +83,14 @@ def clean_metadata(data):
     return data
 
 
-def submit_low_level_data(mbid, data):
+def submit_low_level_data(mbid, data, is_mbid):
     """Function for submitting low-level data.
 
     Args:
         mbid: MusicBrainz ID of the recording that corresponds to the data
             that is being submitted.
         data: Low-level data about the recording.
+        is_mbid: the ID type [musicbrainzid or messibrainzid]
     """
     mbid = str(mbid)
     data = clean_metadata(data)
@@ -105,15 +106,6 @@ def submit_low_level_data(mbid, data):
             data['metadata']['audio_properties']['lossless'] = True
         else:
             data['metadata']['audio_properties']['lossless'] = False
-
-        if 'is_mbid' in data['metadata']['tags']:
-            if str(data['metadata']['tags']['is_mbid']).lower() == 'mbid':
-                is_mbid = 'mbid'
-            else:
-                is_mbid = 'mesbid'
-            del data['metadata']['tags']['is_mbid']
-        else:
-            is_mbid = 'mbid'
 
     except KeyError:
         pass
@@ -159,7 +151,7 @@ def insert_version(connection, data, version_type):
     row = result.fetchone()
     return row[0]
 
-def write_low_level(mbid, data, is_mbid='mbid'):
+def write_low_level(mbid, data, is_mbid):
 
     def _get_by_data_sha256(connection, data_sha256):
         query = text("""

--- a/db/data.py
+++ b/db/data.py
@@ -107,13 +107,13 @@ def submit_low_level_data(mbid, data):
             data['metadata']['audio_properties']['lossless'] = False
 
         if 'is_mbid' in data['metadata']['tags']:
-            if str(data['metadata']['tags']['is_mbid']).lower() == 'true':
-                is_mbid = True
+            if str(data['metadata']['tags']['is_mbid']).lower() == 'mbid':
+                is_mbid = 'mbid'
             else:
-                is_mbid = False
+                is_mbid = 'mesbid'
             del data['metadata']['tags']['is_mbid']
         else:
-            is_mbid = True
+            is_mbid = 'mbid'
 
     except KeyError:
         pass
@@ -159,7 +159,7 @@ def insert_version(connection, data, version_type):
     row = result.fetchone()
     return row[0]
 
-def write_low_level(mbid, data, is_mbid=True):
+def write_low_level(mbid, data, is_mbid='mbid'):
 
     def _get_by_data_sha256(connection, data_sha256):
         query = text("""

--- a/db/data.py
+++ b/db/data.py
@@ -162,17 +162,17 @@ def write_low_level(mbid, data, is_mbid):
         result = connection.execute(query, {"data_sha256": data_sha256})
         return result.fetchone()
 
-    def _insert_lowlevel(connection, mbid, build_sha1, is_lossless_submit, is_mbid):
+    def _insert_lowlevel(connection, mbid, build_sha1, is_lossless_submit, gid_type):
         """ Insert metadata into the lowlevel table and return its id """
         query = text("""
-            INSERT INTO lowlevel (gid, build_sha1, lossless, is_mbid)
-                 VALUES (:mbid, :build_sha1, :lossless, :is_mbid)
+            INSERT INTO lowlevel (gid, build_sha1, lossless, gid_type)
+                 VALUES (:mbid, :build_sha1, :lossless, :gid_type)
               RETURNING id
         """)
         result = connection.execute(query, {"mbid": mbid,
                                             "build_sha1": build_sha1,
                                             "lossless": is_lossless_submit,
-                                            "is_mbid": is_mbid})
+                                            "gid_type": gid_type})
         return result.fetchone()[0]
 
     def _insert_lowlevel_json(connection, ll_id, data_json, data_sha256, version_id):

--- a/db/data.py
+++ b/db/data.py
@@ -83,14 +83,14 @@ def clean_metadata(data):
     return data
 
 
-def submit_low_level_data(mbid, data, is_mbid):
+def submit_low_level_data(mbid, data, gid_type):
     """Function for submitting low-level data.
 
     Args:
         mbid: MusicBrainz ID of the recording that corresponds to the data
             that is being submitted.
         data: Low-level data about the recording.
-        is_mbid: the ID type [musicbrainzid or messibrainzid]
+        gid_type: the ID type [musicbrainzid(mbid) or messybrainzid(msid)]
     """
     mbid = str(mbid)
     data = clean_metadata(data)
@@ -126,7 +126,7 @@ def submit_low_level_data(mbid, data, is_mbid):
         )
 
     # The data looks good, lets see about saving it
-    write_low_level(mbid, data, is_mbid)
+    write_low_level(mbid, data, gid_type)
 
 def insert_version(connection, data, version_type):
     # TODO: Memoise sha -> id

--- a/db/data_jsonb.py
+++ b/db/data_jsonb.py
@@ -21,7 +21,7 @@ def migrate_low_level(old_ll_row):
     with db.engine94.begin() as connection:
 
         connection.execute(
-            "INSERT INTO lowlevel (id, mbid, build_sha1, lossless)"
+            "INSERT INTO lowlevel (id, gid, build_sha1, lossless)"
             "VALUES (%s, %s, %s, %s)",
             (id, mbid, build_sha1, lossless)
         )

--- a/db/data_migrate.py
+++ b/db/data_migrate.py
@@ -60,7 +60,7 @@ def migrate_low_level(connection, old_ll_row):
     version_id = insert_version(connection, ll_version, VERSION_TYPE_LOWLEVEL)
 
     connection.execute(
-        "INSERT INTO lowlevel (id, mbid, build_sha1, lossless, submitted)"
+        "INSERT INTO lowlevel (id, gid, build_sha1, lossless, submitted)"
         "VALUES (%s, %s, %s, %s, %s)",
         (id, mbid, build_sha1, lossless, submitted)
     )
@@ -102,7 +102,7 @@ def migrate_high_level(connection, hl_row):
     hl_json = hl_row["hlj_data"]
 
     hl_query = text(
-        """INSERT INTO highlevel (id, mbid, build_sha1, submitted)
+        """INSERT INTO highlevel (id, gid, build_sha1, submitted)
                 VALUES (:id, :mbid, :build_sha1, :submitted)""")
     connection.execute(hl_query, {"id": highlevel_id, "mbid": mbid,
         "build_sha1": build_sha1, "submitted": submitted})

--- a/db/dump.py
+++ b/db/dump.py
@@ -40,7 +40,7 @@ _TABLES = {
         "build_sha1",
         "lossless",
         "submitted",
-        "gid_type"
+        "gid_type",
     ),
     "lowlevel_json": (
         "id",

--- a/db/dump.py
+++ b/db/dump.py
@@ -40,6 +40,7 @@ _TABLES = {
         "build_sha1",
         "lossless",
         "submitted",
+        "gid_type"
     ),
     "lowlevel_json": (
         "id",

--- a/db/dump.py
+++ b/db/dump.py
@@ -36,7 +36,7 @@ _TABLES = {
     ),
     "lowlevel": (
         "id",
-        "mbid",
+        "gid",
         "build_sha1",
         "lossless",
         "submitted",
@@ -309,10 +309,10 @@ def dump_lowlevel_json(location, incremental=False, dump_id=None):
             # Need to count how many duplicate MBIDs are there before start_time
             if start_time:
                 cursor.execute("""
-                    SELECT mbid, count(id)
+                    SELECT gid, count(id)
                     FROM lowlevel
                     WHERE submitted <= %s
-                    GROUP BY mbid
+                    GROUP BY gid
                     """, (start_time,))
                 counts = cursor.fetchall()
                 for mbid, count in counts:
@@ -327,7 +327,7 @@ def dump_lowlevel_json(location, incremental=False, dump_id=None):
                     where = "WHERE %s%s" % (start_cond, end_cond)
             else:
                 where = ""
-            cursor.execute("SELECT id FROM lowlevel ll %s ORDER BY mbid" % where)
+            cursor.execute("SELECT id FROM lowlevel ll %s ORDER BY gid" % where)
 
             cursor_inner = connection.cursor()
 
@@ -342,7 +342,7 @@ def dump_lowlevel_json(location, incremental=False, dump_id=None):
                 id_list = tuple([i[0] for i in id_list])
 
                 query = text("""
-                   SELECT mbid::text
+                   SELECT gid::text
                         , llj.data::text
                      FROM lowlevel ll
                      JOIN lowlevel_json llj

--- a/db/gid_types.py
+++ b/db/gid_types.py
@@ -1,0 +1,2 @@
+GID_TYPE_MBID = 'mbid'
+GID_TYPE_MSID = 'msid'

--- a/db/stats.py
+++ b/db/stats.py
@@ -51,7 +51,7 @@ def get_last_submitted_recordings():
             # We are getting results with of offset of 10 rows because we'd
             # prefer to show recordings for which we already calculated
             # high-level data. This might not be the best way to do that.
-            result = connection.execute("""SELECT ll.mbid,
+            result = connection.execute("""SELECT ll.gid,
                                      llj.data->'metadata'->'tags'->'artist'->>0,
                                      llj.data->'metadata'->'tags'->'title'->>0
                                 FROM lowlevel ll
@@ -242,7 +242,7 @@ def _count_submissions_to_date(connection, to_date):
     # Unique submissions, split by lossless, lossy
     query = text("""
         SELECT lossless
-             , count(distinct(mbid))
+             , count(distinct(gid))
           FROM lowlevel
          WHERE submitted < :submitted
       GROUP BY lossless
@@ -256,7 +256,7 @@ def _count_submissions_to_date(connection, to_date):
 
     # total number of unique submissions
     query = text("""
-        SELECT count(distinct(mbid))
+        SELECT count(distinct(gid))
           FROM lowlevel
          WHERE submitted < :submitted
     """)

--- a/db/test/test_data.py
+++ b/db/test/test_data.py
@@ -24,7 +24,7 @@ class DataDBTestCase(DatabaseTestCase):
         clean.side_effect = lambda x: x
         sanity.return_value = None
 
-        db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data)
+        db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data, 'mbid')
         write.assert_called_with(self.test_mbid, self.test_lowlevel_data, 'mbid')
 
     @mock.patch("db.data.sanity_check_data")
@@ -38,11 +38,11 @@ class DataDBTestCase(DatabaseTestCase):
         input = {"metadata": {"tags": {"musicbrainz_trackid": [self.test_mbid]}, "audio_properties": {"lossless": 1}}}
         output = {"metadata": {"tags": {"musicbrainz_recordingid": [self.test_mbid]}, "audio_properties": {"lossless": True}}}
 
-        db.data.submit_low_level_data(self.test_mbid, input)
+        db.data.submit_low_level_data(self.test_mbid, input, 'mbid')
         write.assert_called_with(self.test_mbid, output, 'mbid')
         
-        input = {"metadata": {"tags": {"musicbrainz_trackid": [self.test_mbid], "is_mbid": 'mesbid'}, "audio_properties": {"lossless": 1}}}
-        db.data.submit_low_level_data(self.test_mbid, input)
+        input = {"metadata": {"tags": {"musicbrainz_trackid": [self.test_mbid]}, "audio_properties": {"lossless": 1}}}
+        db.data.submit_low_level_data(self.test_mbid, input, 'mesbid')
         write.assert_called_with(self.test_mbid, output, 'mesbid')
 
 
@@ -57,7 +57,7 @@ class DataDBTestCase(DatabaseTestCase):
         input = {"metadata": {"tags": {"musicbrainz_recordingid": ["not-the-recording-mbid"]}, "audio_properties": {"lossless": False}}}
 
         with self.assertRaises(db.exceptions.BadDataException):
-            db.data.submit_low_level_data(self.test_mbid, input)
+            db.data.submit_low_level_data(self.test_mbid, input, 'mbid')
 
 
     @mock.patch("db.data.sanity_check_data")
@@ -69,13 +69,13 @@ class DataDBTestCase(DatabaseTestCase):
         sanity.return_value = ["missing", "key"]
 
         with self.assertRaises(db.exceptions.BadDataException):
-            db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data)
+            db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data, 'mbid')
 
 
     def test_write_load_low_level(self):
         """Writing and loading a dict returns the same data"""
         one = {"data": "one", "metadata": {"audio_properties": {"lossless": True}, "version": {"essentia_build_sha": "x"}}}
-        db.data.write_low_level(self.test_mbid, one)
+        db.data.write_low_level(self.test_mbid, one, 'mbid')
         self.assertEqual(one, db.data.load_low_level(self.test_mbid))
 
 
@@ -84,15 +84,15 @@ class DataDBTestCase(DatabaseTestCase):
         one = {"data": u"\uc544\uc774\uc720 (IU)\udc93", "metadata": {"audio_properties": {"lossless": True}, "version": {"essentia_build_sha": "x"}}}
 
         with self.assertRaises(db.exceptions.BadDataException):
-            db.data.write_low_level(self.test_mbid, one)
+            db.data.write_low_level(self.test_mbid, one, 'mbid')
 
 
     def test_load_low_level_offset(self):
         """If two items with the same mbid are added, you can select between them with offset"""
         one = {"data": "one", "metadata": {"audio_properties": {"lossless": True}, "version": {"essentia_build_sha": "x"}}}
         two = {"data": "two", "metadata": {"audio_properties": {"lossless": True}, "version": {"essentia_build_sha": "x"}}}
-        db.data.write_low_level(self.test_mbid, one)
-        db.data.write_low_level(self.test_mbid, two)
+        db.data.write_low_level(self.test_mbid, one, 'mbid')
+        db.data.write_low_level(self.test_mbid, two, 'mbid')
 
         self.assertEqual(one, db.data.load_low_level(self.test_mbid))
         self.assertEqual(one, db.data.load_low_level(self.test_mbid, 0))
@@ -105,7 +105,7 @@ class DataDBTestCase(DatabaseTestCase):
             db.data.load_low_level(self.test_mbid)
 
         one = {"data": "one", "metadata": {"audio_properties": {"lossless": True}, "version": {"essentia_build_sha": "x"}}}
-        db.data.write_low_level(self.test_mbid, one)
+        db.data.write_low_level(self.test_mbid, one, 'mbid')
         with self.assertRaises(db.exceptions.NoDataFoundException):
             db.data.load_low_level(self.test_mbid, 1)
 
@@ -133,7 +133,7 @@ class DataDBTestCase(DatabaseTestCase):
         db.data.add_model("model2", "v1", "show")
 
         build_sha = "test"
-        db.data.write_low_level(self.test_mbid, ll)
+        db.data.write_low_level(self.test_mbid, ll, 'mbid')
         ll_id = self._get_ll_id_from_mbid(self.test_mbid)[0]
         db.data.write_high_level(self.test_mbid, ll_id, hl, build_sha)
 
@@ -149,8 +149,8 @@ class DataDBTestCase(DatabaseTestCase):
         second_data = copy.deepcopy(self.test_lowlevel_data)
         second_data["metadata"]["tags"]["album"] = ["Another album"]
 
-        db.data.write_low_level(self.test_mbid, self.test_lowlevel_data)
-        db.data.write_low_level(self.test_mbid, second_data)
+        db.data.write_low_level(self.test_mbid, self.test_lowlevel_data, 'mbid')
+        db.data.write_low_level(self.test_mbid, second_data, 'mbid')
         ll_id1, ll_id2 = self._get_ll_id_from_mbid(self.test_mbid)
 
         db.data.add_model("model1", "v1", "show")
@@ -194,8 +194,8 @@ class DataDBTestCase(DatabaseTestCase):
         second_data = copy.deepcopy(self.test_lowlevel_data)
         second_data["metadata"]["tags"]["album"] = ["Another album"]
 
-        db.data.write_low_level(self.test_mbid, self.test_lowlevel_data)
-        db.data.write_low_level(self.test_mbid, second_data)
+        db.data.write_low_level(self.test_mbid, self.test_lowlevel_data, 'mbid')
+        db.data.write_low_level(self.test_mbid, second_data, 'mbid')
         ll_id1, ll_id2 = self._get_ll_id_from_mbid(self.test_mbid)
 
         db.data.add_model("model1", "v1", "show")
@@ -233,7 +233,7 @@ class DataDBTestCase(DatabaseTestCase):
         with self.assertRaises(db.exceptions.NoDataFoundException):
             db.data.load_high_level(self.test_mbid, offset=0)
 
-        db.data.write_low_level(self.test_mbid, self.test_lowlevel_data)
+        db.data.write_low_level(self.test_mbid, self.test_lowlevel_data, 'mbid')
         ll_id1 = self._get_ll_id_from_mbid(self.test_mbid)[0]
 
         db.data.add_model("model1", "1.0", "show")
@@ -253,16 +253,16 @@ class DataDBTestCase(DatabaseTestCase):
 
 
     def test_count_lowlevel(self):
-        db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data)
+        db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data, 'mbid')
         self.assertEqual(1, db.data.count_lowlevel(self.test_mbid))
         # Exact same data is deduplicated
-        db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data)
+        db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data, 'mbid')
         self.assertEqual(1, db.data.count_lowlevel(self.test_mbid))
 
         # make a copy of the data and change it
         second_data = copy.deepcopy(self.test_lowlevel_data)
         second_data["metadata"]["tags"]["album"] = ["Another album"]
-        db.data.submit_low_level_data(self.test_mbid, second_data)
+        db.data.submit_low_level_data(self.test_mbid, second_data, 'mbid')
         self.assertEqual(2, db.data.count_lowlevel(self.test_mbid))
 
     def test_add_get_model(self):

--- a/db/test/test_data.py
+++ b/db/test/test_data.py
@@ -25,7 +25,7 @@ class DataDBTestCase(DatabaseTestCase):
         sanity.return_value = None
 
         db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data)
-        write.assert_called_with(self.test_mbid, self.test_lowlevel_data)
+        write.assert_called_with(self.test_mbid, self.test_lowlevel_data, True)
 
     @mock.patch("db.data.sanity_check_data")
     @mock.patch("db.data.write_low_level")
@@ -39,7 +39,11 @@ class DataDBTestCase(DatabaseTestCase):
         output = {"metadata": {"tags": {"musicbrainz_recordingid": [self.test_mbid]}, "audio_properties": {"lossless": True}}}
 
         db.data.submit_low_level_data(self.test_mbid, input)
-        write.assert_called_with(self.test_mbid, output)
+        write.assert_called_with(self.test_mbid, output, True)
+        
+        input = {"metadata": {"tags": {"musicbrainz_trackid": [self.test_mbid], "is_mbid": 'false'}, "audio_properties": {"lossless": 1}}}
+        db.data.submit_low_level_data(self.test_mbid, input)
+        write.assert_called_with(self.test_mbid, output, False)
 
 
     @mock.patch("db.data.sanity_check_data")

--- a/db/test/test_data.py
+++ b/db/test/test_data.py
@@ -109,7 +109,7 @@ class DataDBTestCase(DatabaseTestCase):
     def _get_ll_id_from_mbid(self, mbid):
         with db.engine.connect() as connection:
             ret = []
-            result = connection.execute("select id from lowlevel where mbid = %s", (mbid, ))
+            result = connection.execute("select id from lowlevel where gid = %s", (mbid, ))
             for row in result:
                 ret.append(row[0])
             return ret

--- a/db/test/test_data.py
+++ b/db/test/test_data.py
@@ -25,7 +25,7 @@ class DataDBTestCase(DatabaseTestCase):
         sanity.return_value = None
 
         db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data)
-        write.assert_called_with(self.test_mbid, self.test_lowlevel_data, True)
+        write.assert_called_with(self.test_mbid, self.test_lowlevel_data, 'mbid')
 
     @mock.patch("db.data.sanity_check_data")
     @mock.patch("db.data.write_low_level")
@@ -39,11 +39,11 @@ class DataDBTestCase(DatabaseTestCase):
         output = {"metadata": {"tags": {"musicbrainz_recordingid": [self.test_mbid]}, "audio_properties": {"lossless": True}}}
 
         db.data.submit_low_level_data(self.test_mbid, input)
-        write.assert_called_with(self.test_mbid, output, True)
+        write.assert_called_with(self.test_mbid, output, 'mbid')
         
-        input = {"metadata": {"tags": {"musicbrainz_trackid": [self.test_mbid], "is_mbid": 'false'}, "audio_properties": {"lossless": 1}}}
+        input = {"metadata": {"tags": {"musicbrainz_trackid": [self.test_mbid], "is_mbid": 'mesbid'}, "audio_properties": {"lossless": 1}}}
         db.data.submit_low_level_data(self.test_mbid, input)
-        write.assert_called_with(self.test_mbid, output, False)
+        write.assert_called_with(self.test_mbid, output, 'mesbid')
 
 
     @mock.patch("db.data.sanity_check_data")

--- a/db/test/test_data.py
+++ b/db/test/test_data.py
@@ -42,8 +42,8 @@ class DataDBTestCase(DatabaseTestCase):
         write.assert_called_with(self.test_mbid, output, 'mbid')
         
         input = {"metadata": {"tags": {"musicbrainz_trackid": [self.test_mbid]}, "audio_properties": {"lossless": 1}}}
-        db.data.submit_low_level_data(self.test_mbid, input, 'mesbid')
-        write.assert_called_with(self.test_mbid, output, 'mesbid')
+        db.data.submit_low_level_data(self.test_mbid, input, 'msid')
+        write.assert_called_with(self.test_mbid, output, 'msid')
 
 
     @mock.patch("db.data.sanity_check_data")

--- a/db/test/test_stats.py
+++ b/db/test/test_stats.py
@@ -272,7 +272,7 @@ def add_empty_lowlevel(mbid, lossless, date):
     data_sha256 = str(lossless) + str(mbid) + str(date)
     data_sha256 = data_sha256[:64]
     data_json = "{}"
-    is_mbid = False
+    is_mbid = 'mesbid' # messy brainz id
     with db.engine.connect() as connection:
         query = text("""
             INSERT INTO lowlevel (gid, build_sha1, lossless, submitted, is_mbid)

--- a/db/test/test_stats.py
+++ b/db/test/test_stats.py
@@ -10,6 +10,8 @@ import pytz
 from sqlalchemy import text
 
 
+GID_TYPE_MBID = 'mbid'
+
 class StatsTestCase(unittest.TestCase):
     """Statistics methods which use mocked database methods for testing"""
 
@@ -42,7 +44,7 @@ class StatsTestCase(unittest.TestCase):
                     "version": {"essentia_build_sha": "sha"},
                 },
             }
-            db.data.write_low_level(rand_mbid, data, 'mbid')
+            db.data.write_low_level(rand_mbid, data, GID_TYPE_MBID)
         last = db.stats.get_last_submitted_recordings()
         dbget.assert_called_with("last-submitted-recordings")
 

--- a/db/test/test_stats.py
+++ b/db/test/test_stats.py
@@ -272,17 +272,17 @@ def add_empty_lowlevel(mbid, lossless, date):
     data_sha256 = str(lossless) + str(mbid) + str(date)
     data_sha256 = data_sha256[:64]
     data_json = "{}"
-    is_mbid = 'mesbid' # messy brainz id
+    gid_type = 'msid'
     with db.engine.connect() as connection:
         query = text("""
-            INSERT INTO lowlevel (gid, build_sha1, lossless, submitted, is_mbid)
-                 VALUES (:mbid, :build_sha1, :lossless, :submitted, :is_mbid)
+            INSERT INTO lowlevel (gid, build_sha1, lossless, submitted, gid_type)
+                 VALUES (:mbid, :build_sha1, :lossless, :submitted, :gid_type)
               RETURNING id
         """)
         result = connection.execute(query,
                 {"mbid": mbid, "build_sha1": build_sha1,
                  "lossless": lossless, "submitted": date,
-                 "is_mbid": is_mbid})
+                 "gid_type": gid_type})
         id = result.fetchone()[0]
 
         version_id = db.data.insert_version(connection, {}, db.data.VERSION_TYPE_LOWLEVEL)

--- a/db/test/test_stats.py
+++ b/db/test/test_stats.py
@@ -8,9 +8,8 @@ import mock
 import datetime
 import pytz
 from sqlalchemy import text
+from db import gid_types
 
-
-GID_TYPE_MBID = 'mbid'
 
 class StatsTestCase(unittest.TestCase):
     """Statistics methods which use mocked database methods for testing"""
@@ -44,7 +43,7 @@ class StatsTestCase(unittest.TestCase):
                     "version": {"essentia_build_sha": "sha"},
                 },
             }
-            db.data.write_low_level(rand_mbid, data, GID_TYPE_MBID)
+            db.data.write_low_level(rand_mbid, data, gid_types.GID_TYPE_MBID)
         last = db.stats.get_last_submitted_recordings()
         dbget.assert_called_with("last-submitted-recordings")
 
@@ -274,7 +273,7 @@ def add_empty_lowlevel(mbid, lossless, date):
     data_sha256 = str(lossless) + str(mbid) + str(date)
     data_sha256 = data_sha256[:64]
     data_json = "{}"
-    gid_type = 'msid'
+    gid_type = gid_types.GID_TYPE_MSID
     with db.engine.connect() as connection:
         query = text("""
             INSERT INTO lowlevel (gid, build_sha1, lossless, submitted, gid_type)
@@ -284,7 +283,7 @@ def add_empty_lowlevel(mbid, lossless, date):
         result = connection.execute(query,
                 {"mbid": mbid, "build_sha1": build_sha1,
                  "lossless": lossless, "submitted": date,
-                 "gid_type": gid_type})
+                 "gid_type": gid_types.GID_TYPE_MSID})
         id = result.fetchone()[0]
 
         version_id = db.data.insert_version(connection, {}, db.data.VERSION_TYPE_LOWLEVEL)

--- a/db/test/test_stats.py
+++ b/db/test/test_stats.py
@@ -272,15 +272,17 @@ def add_empty_lowlevel(mbid, lossless, date):
     data_sha256 = str(lossless) + str(mbid) + str(date)
     data_sha256 = data_sha256[:64]
     data_json = "{}"
+    is_mbid = False
     with db.engine.connect() as connection:
         query = text("""
-            INSERT INTO lowlevel (mbid, build_sha1, lossless, submitted)
-                 VALUES (:mbid, :build_sha1, :lossless, :submitted)
+            INSERT INTO lowlevel (gid, build_sha1, lossless, submitted, is_mbid)
+                 VALUES (:mbid, :build_sha1, :lossless, :submitted, :is_mbid)
               RETURNING id
         """)
         result = connection.execute(query,
                 {"mbid": mbid, "build_sha1": build_sha1,
-                 "lossless": lossless, "submitted": date})
+                 "lossless": lossless, "submitted": date,
+                 "is_mbid": is_mbid})
         id = result.fetchone()[0]
 
         version_id = db.data.insert_version(connection, {}, db.data.VERSION_TYPE_LOWLEVEL)

--- a/db/test/test_stats.py
+++ b/db/test/test_stats.py
@@ -42,7 +42,7 @@ class StatsTestCase(unittest.TestCase):
                     "version": {"essentia_build_sha": "sha"},
                 },
             }
-            db.data.write_low_level(rand_mbid, data)
+            db.data.write_low_level(rand_mbid, data, 'mbid')
         last = db.stats.get_last_submitted_recordings()
         dbget.assert_called_with("last-submitted-recordings")
 

--- a/db/testing.py
+++ b/db/testing.py
@@ -58,6 +58,7 @@ class DatabaseTestCase(unittest.TestCase):
             connection.execute('DROP TYPE IF EXISTS eval_job_status CASCADE;')
             connection.execute('DROP TYPE IF EXISTS model_status CASCADE;')
             connection.execute('DROP TYPE IF EXISTS version_type CASCADE;')
+            connection.execute('DROP TYPE IF EXISTS id_type CASCADE;')
 
     def data_filename(self, mbid):
         """ Get the expected filename of a test datafile given its mbid """

--- a/db/testing.py
+++ b/db/testing.py
@@ -3,6 +3,8 @@ import db.data
 import unittest
 import json
 import os
+from db import gid_types
+
 
 # Configuration
 import sys
@@ -11,7 +13,6 @@ import config
 
 ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'admin', 'sql')
 TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_data')
-GID_TYPE_MBID = 'mbid'
 
 class DatabaseTestCase(unittest.TestCase):
 
@@ -69,5 +70,4 @@ class DatabaseTestCase(unittest.TestCase):
         the database.
         """
         with open(self.data_filename(mbid)) as json_file:
-            db.data.submit_low_level_data(mbid, json.loads(json_file.read()), GID_TYPE_MBID)
-
+            db.data.submit_low_level_data(mbid, json.loads(json_file.read()), gid_types.GID_TYPE_MBID)

--- a/db/testing.py
+++ b/db/testing.py
@@ -11,7 +11,7 @@ import config
 
 ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'admin', 'sql')
 TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_data')
-
+GID_TYPE_MBID = 'mbid'
 
 class DatabaseTestCase(unittest.TestCase):
 
@@ -69,5 +69,5 @@ class DatabaseTestCase(unittest.TestCase):
         the database.
         """
         with open(self.data_filename(mbid)) as json_file:
-            db.data.submit_low_level_data(mbid, json.loads(json_file.read()), 'mbid')
+            db.data.submit_low_level_data(mbid, json.loads(json_file.read()), GID_TYPE_MBID)
 

--- a/db/testing.py
+++ b/db/testing.py
@@ -58,7 +58,7 @@ class DatabaseTestCase(unittest.TestCase):
             connection.execute('DROP TYPE IF EXISTS eval_job_status CASCADE;')
             connection.execute('DROP TYPE IF EXISTS model_status CASCADE;')
             connection.execute('DROP TYPE IF EXISTS version_type CASCADE;')
-            connection.execute('DROP TYPE IF EXISTS id_type CASCADE;')
+            connection.execute('DROP TYPE IF EXISTS gid_type CASCADE;')
 
     def data_filename(self, mbid):
         """ Get the expected filename of a test datafile given its mbid """

--- a/db/testing.py
+++ b/db/testing.py
@@ -69,5 +69,5 @@ class DatabaseTestCase(unittest.TestCase):
         the database.
         """
         with open(self.data_filename(mbid)) as json_file:
-            db.data.submit_low_level_data(mbid, json.loads(json_file.read()))
+            db.data.submit_low_level_data(mbid, json.loads(json_file.read()), 'mbid')
 

--- a/webserver/views/api/legacy.py
+++ b/webserver/views/api/legacy.py
@@ -60,7 +60,7 @@ def submit_low_level(mbid):
         raise webserver.exceptions.APIBadRequest("Cannot parse JSON document: %s" % e)
 
     try:
-        submit_low_level_data(mbid, data)
+        submit_low_level_data(mbid, data, 'mbid')
     except BadDataException as e:
         raise webserver.exceptions.APIBadRequest("%s" % e)
     return jsonify({"message": "ok"})

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -86,7 +86,7 @@ def submit_low_level(mbid):
         raise webserver.exceptions.APIBadRequest("Cannot parse JSON document: %s" % e)
 
     try:
-        submit_low_level_data(str(mbid), data)
+        submit_low_level_data(str(mbid), data, 'mbid')
     except BadDataException as e:
         raise webserver.exceptions.APIBadRequest("%s" % e)
     return jsonify({"message": "ok"})


### PR DESCRIPTION
Add the submission_type column to identify if a record is a recording with an MBID
or a recording with a UUIDv4 generated by the AB server

Add an update sql script to modify existing table
Modify default table creation with the new column