### PR TITLE
Inject pyopenssl for certificate validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ raven[flask] == 5.9.2
 setproctitle == 1.1.9
 six == 1.9.0
 SQLAlchemy == 1.0.9
+urllib3[secure]==1.19
 Werkzeug == 0.10.4
 -r docs/requirements.txt

--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -2,6 +2,14 @@ from flask import Flask
 import sys
 import os
 
+# SNI support for Python 2
+# See http://urllib3.readthedocs.org/en/latest/contrib.html#module-urllib3.contrib.pyopenssl
+try:
+    import urllib3.contrib.pyopenssl
+    urllib3.contrib.pyopenssl.inject_into_urllib3()
+except ImportError:
+    pass
+
 
 def create_app():
     app = Flask(__name__)


### PR DESCRIPTION
Used in oauth login with musicbrainz, broken since
newhost setup. Also reported in AB-130 but not correctly
fixed the first time around