### PR TITLE
Use an https client which checks SSL certificates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ Flask-WTF == 0.12
 Jinja2 == 2.8
 mock == 1.3.0
 musicbrainzngs == 0.5
+ndg-httpsclient==0.4.2
 psycopg2 == 2.6.1
 python-memcached == 1.57
 pytz==2015.7


### PR DESCRIPTION
https://github.com/metabrainz/acousticbrainz-server/pull/216 again

Used in oauth login with musicbrainz, broken since
newhost setup. Also reported in AB-130 but not correctly
fixed the first time around

I actually tested this on a trusty VM this time around (same as spike), and I got the error without the package, and no error with it.