### PR TITLE
Add crossdomain header for /api/v1/low-level endpoint (AB-295)

### DIFF
--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -156,6 +156,7 @@ def _parse_bulk_params(params):
 
 
 @bp_core.route("/low-level", methods=["GET"])
+@crossdomain()
 def get_many_lowlevel():
     """Get low-level data for many recordings at once.
 

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -52,8 +52,9 @@ class CoreViewsTestCase(ServerTestCase):
         mbid = "0dad432b-16cc-4bf0-8961-fd31d124b01b"
         self.load_low_level_data(mbid)
 
-        resp = self.client.get("/api/v1/%s/low-level" % mbid)
-        self.assertEqual(resp.headers["Access-Control-Allow-Origin"], "*")
+        for req in ["%s/low-level", "low-level?recording_ids=%s"]:
+            resp = self.client.get("/api/v1/" + req % mbid)
+            self.assertEqual(resp.headers["Access-Control-Allow-Origin"], "*")
 
         # TODO: Test in get_high_level.
 


### PR DESCRIPTION
Theoretically it should work... I haven't tested it yet though

Edit: tested, the modified test passes only with the change in core.py