### PR TITLE
Fix bulk low-level get request with non-existent MBID

### DIFF
--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -193,7 +193,12 @@ def get_many_lowlevel():
 
     # TODO: This should use a bulk get method for speed
     for recording_id, offset in recordings:
-        recording_details.setdefault(recording_id, {})[offset] = db.data.load_low_level(recording_id, offset)
+        try:
+            recording_details.setdefault(recording_id, {})[offset] = db.data.load_low_level(recording_id, offset)
+        except NoDataFoundException:
+            errors = recording_details.setdefault("errors", {})
+            mbid_entry = errors.setdefault(recording_id, {})
+            mbid_entry[offset] = {"message": "recording does not exist"}
 
     return jsonify(recording_details)
 

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -196,9 +196,7 @@ def get_many_lowlevel():
         try:
             recording_details.setdefault(recording_id, {})[offset] = db.data.load_low_level(recording_id, offset)
         except NoDataFoundException:
-            errors = recording_details.setdefault("errors", {})
-            mbid_entry = errors.setdefault(recording_id, {})
-            mbid_entry[offset] = {"message": "recording does not exist"}
+            pass
 
     return jsonify(recording_details)
 

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -173,13 +173,17 @@ def get_many_lowlevel():
     If an offset was not specified in the request for an mbid, the offset
     will be 0.
 
+    If the list of MBIDs in the query string has a recording which is not
+    present in the database, then it is silently ignored and will not appear
+    in the returned data.
+ 
     :query recording_ids: *Required.* A list of recording MBIDs to retrieve
 
       Takes the form `mbid[:offset];mbid[:offset]`. Offsets are optional, and should
       be >= 0
 
     :resheader Content-Type: *application/json*
-    """
+   """
     recording_ids = request.args.get("recording_ids")
 
     if not recording_ids:


### PR DESCRIPTION
GET request for bulk low-level data was failing when any single
one of the MBIDs were not present in the database. These entries
are now put into an error field appended to the fetched data for
existing recordings.

Relevant Jira ticket: https://tickets.metabrainz.org/browse/AB-296