### PR TITLE
AB-290 Viewing the recording information of a dataset or a snapshot requires being logged in

### DIFF
--- a/dataset_eval/artistfilter.py
+++ b/dataset_eval/artistfilter.py
@@ -16,8 +16,11 @@ import db.cache
 import config
 
 #db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
-
-rtoajson = json.load(open("recordingtoartistmap.json"))
+fname="recordingtoartistmap.json"
+if os.path.isfile(fname):
+    rtoajson = json.load(open(fname))
+else:
+    rtoajson = {}
 
 def chunks(l, n):
     """Yield successive n-sized chunks from l."""

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -322,7 +322,7 @@ def delete(dataset_id):
 
 
 @datasets_bp.route("/recording/<uuid:mbid>")
-@login_required
+#@login_required
 def recording_info(mbid):
     """Endpoint for getting information about recordings (title and artist)."""
     try:

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -322,7 +322,6 @@ def delete(dataset_id):
 
 
 @datasets_bp.route("/recording/<uuid:mbid>")
-#@login_required
 def recording_info(mbid):
     """Endpoint for getting information about recordings (title and artist)."""
     try:


### PR DESCRIPTION
Auth-Login removed to view recording details from datasets
The ticket was - Viewing the recording information of a dataset or a snapshot requires being logged in
https://tickets.metabrainz.org/browse/AB-290