### PR TITLE
Ensure that gaia is available in the virtualenv pythonpath

### DIFF
--- a/admin/install_web_server.sh
+++ b/admin/install_web_server.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-apt-get -y install memcached python-virtualenv python-dev ipython pxz nodejs libffi-dev
 curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+apt-get -y install memcached python-virtualenv python-dev ipython pxz nodejs libffi-dev libssl-dev

--- a/admin/install_web_server.sh
+++ b/admin/install_web_server.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
 apt-get -y install memcached python-virtualenv python-dev ipython pxz nodejs libffi-dev
+curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -

--- a/admin/setup_app.sh
+++ b/admin/setup_app.sh
@@ -8,9 +8,13 @@ else
     echo "Application directory is not specified. Using current directory!"
 fi
 
-echo "source venv-acousticbrainz/bin/activate" > ~/.bashrc
+echo "source venv-acousticbrainz/bin/activate" >> ~/.bashrc
 virtualenv ../venv-acousticbrainz
 source ../venv-acousticbrainz/bin/activate
+# We install gaia in the system, but it should also be available in the venv
+# Generally putting this dir in a venv could be dangerous but in our case
+# there is nothing else here.
+echo "/usr/local/lib/python2.7/dist-packages/" > ../venv-acousticbrainz/lib/python2.7/site-packages/gaia.pth
 
 pip install -U pip
 pip install -r requirements.txt


### PR DESCRIPTION
We install gaia and its python bindings into /usr/local but use a venv for the webapp. Add gaia to the venv path so that we can run the dataset classifier inside vagrant.

Also add libssl-dev which was causing requirements to fail to install, and upgrade from node 5 to 6 because of out-of-supportness