### PR TITLE
Provide custom error handlers for API blueprints

### DIFF
--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask
 import sys
 import os
 
+API_PREFIX = '/api/'
 
 def create_app():
     app = Flask(__name__)
@@ -100,7 +101,7 @@ def _register_blueprints(app):
         app.register_blueprint(datasets_bp, url_prefix='/datasets')
 
     def register_api(app):
-        v1_prefix = '/api/v1'
+        v1_prefix = os.path.join(API_PREFIX, 'v1')
         from webserver.views.api.v1.core import bp_core
         from webserver.views.api.v1.datasets import bp_datasets
         from webserver.views.api.v1.dataset_eval import bp_dataset_eval

--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -1,4 +1,4 @@
-from flask import render_template, jsonify
+from flask import render_template, jsonify, request
 from webserver.views.api import exceptions as api_exceptions
 
 
@@ -12,18 +12,31 @@ def init_error_handlers(app):
     def bad_request(error):
         return render_template('errors/400.html', error=error), 400
 
+    @app.errorhandler(401)
+    def unauthorized(error):
+        #always returning JSON, until we need a template for 401 error
+        return jsonify_error(error)
+    
     @app.errorhandler(403)
     def forbidden(error):
         return render_template('errors/403.html', error=error), 403
 
     @app.errorhandler(404)
     def not_found(error):
+        if request.path.startswith('/api/v1/'):
+            return jsonify_error(error)
         return render_template('errors/404.html', error=error), 404
 
     @app.errorhandler(500)
     def internal_server_error(error):
+        if request.path.startswith('/api/v1/'):
+            return jsonify_error(error)
         return render_template('errors/500.html', error=error), 500
 
     @app.errorhandler(503)
     def service_unavailable(error):
         return render_template('errors/503.html', error=error), 503
+
+def jsonify_error(error):
+    api_error = api_exceptions.APIError(error.description, error.code)
+    return jsonify(api_error.to_dict()), api_error.status_code

--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -1,4 +1,5 @@
 from flask import render_template, jsonify, request
+import webserver
 from webserver.views.api import exceptions as api_exceptions
 
 
@@ -10,11 +11,13 @@ def init_error_handlers(app):
 
     @app.errorhandler(400)
     def bad_request(error):
+        if request.path.startswith(webserver.API_PREFIX):
+            return jsonify_error(error)
         return render_template('errors/400.html', error=error), 400
 
     @app.errorhandler(401)
     def unauthorized(error):
-        #always returning JSON, until we need a template for 401 error
+        # always returning JSON because this is only raised from API endpoints
         return jsonify_error(error)
     
     @app.errorhandler(403)
@@ -23,13 +26,20 @@ def init_error_handlers(app):
 
     @app.errorhandler(404)
     def not_found(error):
-        if request.path.startswith('/api/v1/'):
+        if request.path.startswith(webserver.API_PREFIX):
             return jsonify_error(error)
         return render_template('errors/404.html', error=error), 404
 
     @app.errorhandler(500)
     def internal_server_error(error):
-        if request.path.startswith('/api/v1/'):
+        if request.path.startswith(webserver.API_PREFIX):
+            # The error parameter here could be any Exception, not a nice
+            # werkzeug exception like in other error handlers.
+            # In the case of an exception in the API, we want a basic message
+            # and no additional stuff (like a stack trace).
+            # We assume that developers get reports through sentry/reporting emails
+            error = Exception("An unknown error occurred")
+            error.code = 500
             return jsonify_error(error)
         return render_template('errors/500.html', error=error), 500
 
@@ -37,6 +47,11 @@ def init_error_handlers(app):
     def service_unavailable(error):
         return render_template('errors/503.html', error=error), 503
 
-def jsonify_error(error):
-    api_error = api_exceptions.APIError(error.description, error.code)
+
+def jsonify_error(error, code=None):
+    if hasattr(error, 'description'):
+        message = error.description
+    else:
+        message = str(error)
+    api_error = api_exceptions.APIError(message, getattr(error, 'code', code))
     return jsonify(api_error.to_dict()), api_error.status_code

--- a/webserver/views/api/exceptions.py
+++ b/webserver/views/api/exceptions.py
@@ -11,13 +11,16 @@ class APIError(Exception):
         rv['message'] = self.message
         return rv
 
+
 class APINotFound(APIError):
     def __init__(self, message, payload=None):
         super(APINotFound, self).__init__(message, 404, payload)
 
+
 class APIUnauthorized(APIError):
     def __init__(self, message, payload=None):
         super(APIUnauthorized, self).__init__(message, 401, payload)
+
 
 class APIBadRequest(APIError):
     def __init__(self, message, payload=None):

--- a/webserver/views/api/v1/test/test_dataset_eval.py
+++ b/webserver/views/api/v1/test/test_dataset_eval.py
@@ -71,8 +71,6 @@ class APIDatasetEvaluationViewsTestCase(ServerTestCase):
             'updated': 'Tue, 07 Jun 2016 22:12:32 GMT'
         }
 
-
-
     @mock.patch('db.dataset_eval.get_remote_pending_jobs_for_user')
     def test_get_pending_jobs_for_user(self, get_remote_pending_jobs_for_user):
         self.temporary_login(self.test_user_id)
@@ -171,5 +169,5 @@ class APIDatasetEvaluationViewsTestCase(ServerTestCase):
         resp = self.client.get('/api/v1/datasets/evaluation/jobs/7804abe5-58be-4c9c-a787-22b91d031489', content_type='application/json')
         self.assertEqual(resp.status_code, 500)
 
-        expected_result = {"message": "The server encountered an internal error and was unable to complete your request.  Either the server is overloaded or there is an error in the application."}
+        expected_result = {"message": "An unknown error occurred"}
         self.assertEqual(resp.json, expected_result)

--- a/webserver/views/api/v1/test/test_datasets.py
+++ b/webserver/views/api/v1/test/test_datasets.py
@@ -252,7 +252,7 @@ class APIDatasetViewsTestCase(ServerTestCase):
         resp = self.client.put(url, data=json.dumps(submit), content_type="application/json")
 
         self.assertEqual(resp.status_code, 500)
-        expected_result = {"message": "The server encountered an internal error and was unable to complete your request.  Either the server is overloaded or there is an error in the application."}
+        expected_result = {"message": "An unknown error occurred"}
         self.assertEqual(resp.json, expected_result)
 
     @mock.patch("db.dataset.add_class")


### PR DESCRIPTION
Some errors, such as 404 and 500, were still leading to an HTML page
(eg. when an invalid UUID was used in the url). These cases will now
be handled by the provided app_errorhandlers since flask does not
support blueprint level error-handling for 404 and 500 code errors.