### PR TITLE
Upgrade javascript dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,30 +7,30 @@
     "url": "https://github.com/metabrainz/acousticbrainz-server.git"
   },
   "dependencies": {
-    "babel-core": "6.2.1",
-    "babel-plugin-transform-react-constant-elements": "6.1.20",
-    "babel-plugin-transform-react-inline-elements": "6.1.20",
-    "babel-plugin-transform-react-jsx": "6.2.0",
-    "babel-preset-es2015": "6.1.18",
-    "babel-preset-stage-2": "6.1.18",
-    "babelify": "7.2.0",
-    "bootstrap": "3.3.6",
-    "gulp": "3.9.0",
-    "gulp-less": "3.0.5",
-    "gulp-rev": "6.0.1",
+    "babel-core": "6.26.0",
+    "babel-plugin-transform-react-constant-elements": "6.23.0",
+    "babel-plugin-transform-react-inline-elements": "6.22.0",
+    "babel-plugin-transform-react-jsx": "6.24.1",
+    "babel-preset-es2015": "6.24.1",
+    "babel-preset-stage-2": "6.24.1",
+    "babelify": "7.3.0",
+    "bootstrap": "3.3.7",
+    "gulp": "3.9.1",
+    "gulp-less": "3.3.2",
+    "gulp-rev": "8.0.0",
     "gulp-streamify": "1.0.2",
     "highcharts": "4.2.0",
     "jquery": "2.1.4",
     "less-plugin-clean-css": "1.5.1",
     "lodash": "3.10.1",
-    "q": "1.4.1",
+    "q": "1.5.0",
     "react": "0.14.7",
     "react-dom": "0.14.7",
     "vinyl-source-stream": "1.1.0",
-    "yarb": "0.6.1"
+    "yarb": "0.8.0"
   },
   "devDependencies": {
-    "gulp-watch": "4.3.5"
+    "gulp-watch": "4.3.11"
   },
   "private": true
 }


### PR DESCRIPTION
based on output of `npm outdated`. I left react, jquery, lodash, and highcharts
because they were a major version upgrade. Tested by running gulp
and checking the dataset editor/viewer pages.