### PR TITLE
AB-117: Add functions for creating dataset dumps

### DIFF
--- a/db/dump.py
+++ b/db/dump.py
@@ -310,12 +310,12 @@ def _copy_tables(location, start_time=None, end_time=None):
         connection.close()
 
 
-def import_db_dump(archive_path):
+def import_db_dump(archive_path, tables):
     """Import data from .tar.xz archive into the database."""
     pxz_command = ["pxz", "--decompress", "--stdout", archive_path]
     pxz = subprocess.Popen(pxz_command, stdout=subprocess.PIPE)
 
-    table_names = _TABLES.keys()
+    table_names = tables.keys()
 
     connection = db.engine.raw_connection()
     try:
@@ -339,7 +339,7 @@ def import_db_dump(archive_path):
                     if file_name in table_names:
                         logging.info(" - Importing data into %s table..." % file_name)
                         cursor.copy_from(tar.extractfile(member), '"%s"' % file_name,
-                                         columns=_TABLES[file_name])
+                                         columns=tables[file_name])
         connection.commit()
     finally:
         connection.close()
@@ -703,27 +703,11 @@ def dump_dataset_tables(location, threads=None):
     return archive_path
 
 
+def import_dump(archive_path):
+    """Imports a database dump from .tar.xz archive into the database."""
+    import_db_dump(archive_path, _TABLES)
+
+
 def import_datasets_dump(archive_path):
     """Import datasets from .tar.xz archive into the database."""
-    archive_name = os.path.basename(archive_path).split('.')[0]
-    pxz_command = ["pxz", "--decompress", "--stdout", archive_path]
-    pxz = subprocess.Popen(pxz_command, stdout=subprocess.PIPE)
-
-    table_names = _DATASET_TABLES.keys()
-    connection = db.engine.raw_connection()
-    try:
-        cursor = connection.cursor()
-        with tarfile.open(fileobj=pxz.stdout, mode="r|") as tar:
-            temp_dir = tempfile.mkdtemp()
-            tar.extractall(temp_dir)
-
-            for table in table_names:
-                with open(os.path.join(temp_dir, archive_name, 'abdump', table)) as f:
-                    logging.info(" - Importing data into %s table..." % table)
-                    cursor.copy_from(f, table, columns=_DATASET_TABLES[table])
-        connection.commit()
-    finally:
-        connection.close()
-
-    shutil.rmtree(temp_dir)
-    pxz.stdout.close()
+    import_db_dump(archive_path, _DATASET_TABLES)

--- a/db/dump.py
+++ b/db/dump.py
@@ -106,6 +106,45 @@ _DATASET_TABLES = {
         "class",
         "mbid",
     ),
+    "dataset_snapshot": (
+        "id",
+        "dataset_id",
+        "data",
+        "created",
+    ),
+    "dataset_eval_jobs": (
+        "id",
+        "snapshot_id",
+        "status",
+        "status_msg",
+        "options"
+        "training_snapshot",
+        "testing_snapshot",
+        "created",
+        "updated",
+        "result",
+        "eval_location",
+    ),
+    "dataset_eval_sets": (
+        "id",
+        "data",
+    ),
+    "challenge": (
+        "id",
+        "name",
+        "validation_snapshot",
+        "creator",
+        "created",
+        "start_time",
+        "end_time",
+        "classes",
+        "concluded",
+    ),
+    "dataset_eval_challenge":(
+        "dataset_eval_job",
+        "challenge_id",
+        "result",
+    ),
 }
 
 
@@ -197,6 +236,26 @@ def _copy_tables(location, dataset_dump, start_time=None, end_time=None):
             # dataset_class_member
             _copy_table(cursor, location, "dataset_class_member", "(SELECT %s FROM dataset_class_member)" %
                         (", ".join(_DATASET_TABLES["dataset_class_member"])))
+
+            # dataset_snapshot
+            _copy_table(cursor, location, "dataset_snapshot", "(SELECT %s FROM dataset_snapshot)" %
+                        (", ".join(_DATASET_TABLES["dataset_snapshot"])))
+
+            # dataset_eval_jobs
+            _copy_table(cursor, location, "dataset_eval_jobs", "(SELECT %s FROM dataset_eval_jobs)" %
+                        (", ".join(_DATASET_TABLES["dataset_eval_jobs"])))
+
+            # dataset_eval_sets
+            _copy_table(cursor, location, "dataset_eval_sets", "(SELECT %s FROM dataset_eval_sets)" %
+                        (", ".join(_DATASET_TABLES["dataset_eval_sets"])))
+
+            # challenge
+            _copy_table(cursor, location, "challenge", "(SELECT %s FROM challenge)" %
+                        (", ".join(_DATASET_TABLES["challenge"])))
+
+            # dataset_eval_challenge
+            _copy_table(cursor, location, "dataset_eval_challenge", "(SELECT %s FROM dataset_eval_challenge)" %
+                        (", ".join(_DATASET_TABLES["dataset_eval_challenge"])))
 
         else:
             # version

--- a/db/dump.py
+++ b/db/dump.py
@@ -574,7 +574,6 @@ def _dump_tables(archive_path, threads, dataset_dump, time_now, start_t=None, en
         end_t (datetime): End time of the frame that will be used for data selection.
     """
     archive_name = os.path.basename(archive_path).split('.')[0]
-    print(archive_name)
     with open(archive_path, "w") as archive:
 
         pxz_command = ["pxz", "--compress"]

--- a/db/dump.py
+++ b/db/dump.py
@@ -117,7 +117,7 @@ _DATASET_TABLES = {
         "snapshot_id",
         "status",
         "status_msg",
-        "options"
+        "options",
         "training_snapshot",
         "testing_snapshot",
         "created",
@@ -198,8 +198,51 @@ def _copy_table(cursor, location, table_name, query):
         cursor.copy_to(f, query)
 
 
-def _copy_tables(location, dataset_dump, start_time=None, end_time=None):
-    """Copies all tables into separate files within a specified location (directory).
+def _copy_dataset_tables(location, start_time=None, end_time=None):
+    """ Copies datasets tables into seperate files withing a specified location (directory).
+    """
+    connection = db.engine.raw_connection()
+    try:
+        cursor = connection.cursor()
+        # dataset
+        _copy_table(cursor, location, "dataset", "(SELECT %s FROM dataset)" %
+                    (", ".join(_DATASET_TABLES["dataset"])))
+
+        # dataset_class
+        _copy_table(cursor, location, "dataset_class", "(SELECT %s FROM dataset_class)" %
+                    (", ".join(_DATASET_TABLES["dataset_class"])))
+
+        # dataset_class_member
+        _copy_table(cursor, location, "dataset_class_member", "(SELECT %s FROM dataset_class_member)" %
+                    (", ".join(_DATASET_TABLES["dataset_class_member"])))
+
+        # dataset_snapshot
+        _copy_table(cursor, location, "dataset_snapshot", "(SELECT %s FROM dataset_snapshot)" %
+                    (", ".join(_DATASET_TABLES["dataset_snapshot"])))
+
+        # dataset_eval_jobs
+        _copy_table(cursor, location, "dataset_eval_jobs", "(SELECT %s FROM dataset_eval_jobs)" %
+                    (", ".join(_DATASET_TABLES["dataset_eval_jobs"])))
+
+        # dataset_eval_sets
+        _copy_table(cursor, location, "dataset_eval_sets", "(SELECT %s FROM dataset_eval_sets)" %
+                    (", ".join(_DATASET_TABLES["dataset_eval_sets"])))
+
+        # challenge
+        _copy_table(cursor, location, "challenge", "(SELECT %s FROM challenge)" %
+                    (", ".join(_DATASET_TABLES["challenge"])))
+
+        # dataset_eval_challenge
+        _copy_table(cursor, location, "dataset_eval_challenge", "(SELECT %s FROM dataset_eval_challenge)" %
+                    (", ".join(_DATASET_TABLES["dataset_eval_challenge"])))
+    finally:
+        connection.close()
+
+
+def _copy_tables(location, start_time=None, end_time=None):
+    """Copies all core tables into separate files within a specified location (directory).
+
+    NOTE: only copies tables in the variable _TABLES
 
     You can also define time frame that will be used during data selection.
     Files in a specified directory will only contain rows that have timestamps
@@ -223,81 +266,46 @@ def _copy_tables(location, dataset_dump, start_time=None, end_time=None):
     connection = db.engine.raw_connection()
     try:
         cursor = connection.cursor()
+        # version
+        _copy_table(cursor, location, "version", "(SELECT %s FROM version %s)" %
+                    (", ".join(_TABLES["version"]), generate_where("created")))
 
-        if dataset_dump:
-            # dataset
-            _copy_table(cursor, location, "dataset", "(SELECT %s FROM dataset)" %
-                        (", ".join(_DATASET_TABLES["dataset"])))
+        # lowlevel
+        _copy_table(cursor, location, "lowlevel", "(SELECT %s FROM lowlevel %s)" %
+                    (", ".join(_TABLES["lowlevel"]), generate_where("submitted")))
 
-            # dataset_class
-            _copy_table(cursor, location, "dataset_class", "(SELECT %s FROM dataset_class)" %
-                        (", ".join(_DATASET_TABLES["dataset_class"])))
+        # lowlevel_json
+        query = "SELECT %s FROM lowlevel_json WHERE id IN (SELECT id FROM lowlevel %s)" \
+                % (", ".join(_TABLES["lowlevel_json"]), generate_where("submitted"))
+        _copy_table(cursor, location, "lowlevel_json", "(%s)" % query)
 
-            # dataset_class_member
-            _copy_table(cursor, location, "dataset_class_member", "(SELECT %s FROM dataset_class_member)" %
-                        (", ".join(_DATASET_TABLES["dataset_class_member"])))
-
-            # dataset_snapshot
-            _copy_table(cursor, location, "dataset_snapshot", "(SELECT %s FROM dataset_snapshot)" %
-                        (", ".join(_DATASET_TABLES["dataset_snapshot"])))
-
-            # dataset_eval_jobs
-            _copy_table(cursor, location, "dataset_eval_jobs", "(SELECT %s FROM dataset_eval_jobs)" %
-                        (", ".join(_DATASET_TABLES["dataset_eval_jobs"])))
-
-            # dataset_eval_sets
-            _copy_table(cursor, location, "dataset_eval_sets", "(SELECT %s FROM dataset_eval_sets)" %
-                        (", ".join(_DATASET_TABLES["dataset_eval_sets"])))
-
-            # challenge
-            _copy_table(cursor, location, "challenge", "(SELECT %s FROM challenge)" %
-                        (", ".join(_DATASET_TABLES["challenge"])))
-
-            # dataset_eval_challenge
-            _copy_table(cursor, location, "dataset_eval_challenge", "(SELECT %s FROM dataset_eval_challenge)" %
-                        (", ".join(_DATASET_TABLES["dataset_eval_challenge"])))
-
-        else:
-            # version
-            _copy_table(cursor, location, "version", "(SELECT %s FROM version %s)" %
-                        (", ".join(_TABLES["version"]), generate_where("created")))
-
-            # lowlevel
-            _copy_table(cursor, location, "lowlevel", "(SELECT %s FROM lowlevel %s)" %
-                        (", ".join(_TABLES["lowlevel"]), generate_where("submitted")))
-
-            # lowlevel_json
-            query = "SELECT %s FROM lowlevel_json WHERE id IN (SELECT id FROM lowlevel %s)" \
-                    % (", ".join(_TABLES["lowlevel_json"]), generate_where("submitted"))
-            _copy_table(cursor, location, "lowlevel_json", "(%s)" % query)
-
-            # model
-            query = "SELECT %s FROM model %s" \
-                    % (", ".join(_TABLES["model"]), generate_where("date"))
-            _copy_table(cursor, location, "model", "(%s)" % query)
+        # model
+        query = "SELECT %s FROM model %s" \
+                % (", ".join(_TABLES["model"]), generate_where("date"))
+        _copy_table(cursor, location, "model", "(%s)" % query)
 
 
-            # highlevel
-            _copy_table(cursor, location, "highlevel", "(SELECT %s FROM highlevel %s)" %
-                        (", ".join(_TABLES["highlevel"]), generate_where("submitted")))
+        # highlevel
+        _copy_table(cursor, location, "highlevel", "(SELECT %s FROM highlevel %s)" %
+                    (", ".join(_TABLES["highlevel"]), generate_where("submitted")))
 
-            # highlevel_meta
-            query = "SELECT %s FROM highlevel_meta WHERE id IN (SELECT id FROM highlevel %s)" \
-                    % (", ".join(_TABLES["highlevel_meta"]), generate_where("submitted"))
-            _copy_table(cursor, location, "highlevel_meta", "(%s)" % query)
+        # highlevel_meta
+        query = "SELECT %s FROM highlevel_meta WHERE id IN (SELECT id FROM highlevel %s)" \
+                % (", ".join(_TABLES["highlevel_meta"]), generate_where("submitted"))
+        _copy_table(cursor, location, "highlevel_meta", "(%s)" % query)
 
-            # highlevel_model
-            query = "SELECT %s FROM highlevel_model WHERE id IN (SELECT id FROM highlevel %s)" \
-                    % (", ".join(_TABLES["highlevel_model"]), generate_where("submitted"))
-            _copy_table(cursor, location, "highlevel_model", "(%s)" % query)
+        # highlevel_model
+        query = "SELECT %s FROM highlevel_model WHERE id IN (SELECT id FROM highlevel %s)" \
+                % (", ".join(_TABLES["highlevel_model"]), generate_where("submitted"))
+        _copy_table(cursor, location, "highlevel_model", "(%s)" % query)
 
-            # statistics
-            _copy_table(cursor, location, "statistics", "(SELECT %s FROM statistics %s)" %
-                        (", ".join(_TABLES["statistics"]), generate_where("collected")))
+        # statistics
+        _copy_table(cursor, location, "statistics", "(SELECT %s FROM statistics %s)" %
+                    (", ".join(_TABLES["statistics"]), generate_where("collected")))
 
-            # incremental_dumps
-            _copy_table(cursor, location, "incremental_dumps", "(SELECT %s FROM incremental_dumps %s)" %
-                        (", ".join(_TABLES["incremental_dumps"]), generate_where("created")))
+        # incremental_dumps
+        _copy_table(cursor, location, "incremental_dumps", "(SELECT %s FROM incremental_dumps %s)" %
+                    (", ".join(_TABLES["incremental_dumps"]), generate_where("created")))
     finally:
         connection.close()
 
@@ -661,7 +669,10 @@ def _dump_tables(archive_path, threads, dataset_dump, time_now, start_t=None, en
 
             archive_tables_dir = os.path.join(temp_dir, "abdump", "abdump")
             utils.path.create_path(archive_tables_dir)
-            _copy_tables(archive_tables_dir, dataset_dump, start_t, end_t)
+            if dataset_dump:
+                _copy_dataset_tables(archive_tables_dir, start_t, end_t)
+            else:
+                _copy_tables(archive_tables_dir, start_t, end_t)
             tar.add(archive_tables_dir, arcname=os.path.join(archive_name, "abdump"))
 
             shutil.rmtree(temp_dir)

--- a/db/dump.py
+++ b/db/dump.py
@@ -86,6 +86,28 @@ _TABLES = {
     ),
 }
 
+_DATASET_TABLES = {
+    "dataset": (
+        "id",
+        "name",
+        "description",
+        "author",
+        "public",
+        "created",
+        "last_edited",
+    ),
+    "dataset_class": (
+        "id",
+        "name",
+        "description",
+        "dataset",
+    ),
+    "dataset_class_member": (
+        "class",
+        "mbid",
+    ),
+}
+
 
 def dump_db(location, threads=None, incremental=False, dump_id=None):
     """Create database dump in a specified location.
@@ -555,3 +577,98 @@ def _get_incremental_dump_timestamp(dump_id=None):
 
 class NoNewData(Exception):
     pass
+
+
+def dump_dataset_tables(location, threads=None):
+    """Create full dump of dataset tables in a specified location.
+
+    Args:
+        location: Directory where archive will be created.
+    Returns:
+        Path to created dump.
+    """
+    utils.path.create_path(location)
+    time_now = datetime.today()
+    archive_name = "acousticbrainz-dataset-dump-%s" % time_now.strftime("%Y%m%d-%H%M%S")
+
+    archive_path = os.path.join(location, archive_name + ".tar.xz")
+    with open(archive_path, "w") as archive:
+
+        pxz_command = ["pxz", "--compress"]
+        if threads is not None:
+            pxz_command.append("-T %s" % threads)
+        pxz = subprocess.Popen(pxz_command, stdin=subprocess.PIPE, stdout=archive)
+
+        # Creating the archive
+        with tarfile.open(fileobj=pxz.stdin, mode="w|") as tar:
+            temp_dir = tempfile.mkdtemp()
+
+            # Adding SCHEMA_SEQUENCE and TIMESTAMP
+            schema_seq_path = os.path.join(temp_dir, "SCHEMA_SEQUENCE")
+            with open(schema_seq_path, "w") as f:
+                f.write(str(db.SCHEMA_VERSION))
+            tar.add(schema_seq_path,
+                    arcname=os.path.join(archive_name, "SCHEMA_SEQUENCE"))
+            timestamp_path = os.path.join(temp_dir, "TIMESTAMP")
+            with open(timestamp_path, "w") as f:
+                f.write(time_now.isoformat(" "))
+            tar.add(timestamp_path,
+                    arcname=os.path.join(archive_name, "TIMESTAMP"))
+
+            dataset_tables_dir = os.path.join(temp_dir, "datasets", "datasets")
+            utils.path.create_path(dataset_tables_dir)
+            _copy_dataset_tables(dataset_tables_dir)
+            tar.add(dataset_tables_dir, arcname=os.path.join(archive_name, "abdatasetdump"))
+
+            shutil.rmtree(temp_dir)  # Cleanup
+
+        pxz.stdin.close()
+    return archive_path
+
+
+def _copy_dataset_tables(location):
+    """Copies all dataset tables into separate files within a specified location."""
+    connection = db.engine.raw_connection()
+    try:
+        cursor = connection.cursor()
+
+        with open(os.path.join(location, "dataset"), "w") as f:
+            logging.info(" - Copying table dataset...")
+            cursor.copy_to(f, 'dataset', columns=_DATASET_TABLES['dataset'])
+
+        with open(os.path.join(location, "dataset_class"), "w") as f:
+            logging.info(" - Copying table dataset_class...")
+            cursor.copy_to(f, 'dataset_class', columns=_DATASET_TABLES['dataset_class'])
+
+        with open(os.path.join(location, "dataset_class_member"), "w") as f:
+            logging.info(" - Copying table dataset_class_member...")
+            cursor.copy_to(f, 'dataset_class_member', columns=_DATASET_TABLES['dataset_class_member'])
+
+    finally:
+        connection.close()
+
+
+def import_datasets_dump(archive_path):
+    """Import datasets from .tar.xz archive into the database."""
+    archive_name = os.path.basename(archive_path).split('.')[0]
+    pxz_command = ["pxz", "--decompress", "--stdout", archive_path]
+    pxz = subprocess.Popen(pxz_command, stdout=subprocess.PIPE)
+
+    table_names = ['dataset', 'dataset_class', 'dataset_class_member']
+    connection = db.engine.raw_connection()
+    try:
+        cursor = connection.cursor()
+        with tarfile.open(fileobj=pxz.stdout, mode="r|") as tar:
+            temp_dir = tempfile.mkdtemp()
+            tar.extractall(temp_dir)
+
+            for table in table_names:
+                with open(os.path.join(temp_dir, archive_name, 'abdatasetdump', table)) as f:
+                    logging.info(" - Importing data into %s table..." % table)
+                    cursor.copy_from(f, table, columns=_DATASET_TABLES[table])
+        connection.commit()
+    finally:
+        connection.close()
+
+    shutil.rmtree(temp_dir)
+    pxz.stdout.close()

--- a/db/dump.py
+++ b/db/dump.py
@@ -667,6 +667,7 @@ def _dump_tables(archive_path, threads, dataset_dump, time_now, start_t=None, en
             shutil.rmtree(temp_dir)
 
         pxz.stdin.close()
+        pxz.wait()
 
 
 def dump_dataset_tables(location, threads=None):

--- a/db/dump.py
+++ b/db/dump.py
@@ -697,7 +697,7 @@ def import_datasets_dump(archive_path):
     pxz_command = ["pxz", "--decompress", "--stdout", archive_path]
     pxz = subprocess.Popen(pxz_command, stdout=subprocess.PIPE)
 
-    table_names = ['dataset', 'dataset_class', 'dataset_class_member']
+    table_names = _DATASET_TABLES.keys()
     connection = db.engine.raw_connection()
     try:
         cursor = connection.cursor()

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -182,7 +182,7 @@ def remove_old_archives(location, pattern, is_dir=False, sort_key=None):
               help="Directory where dumps need to be created")
 @click.option("--threads", "-t", type=int)
 def full_dataset_dump(location, threads):
-    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    create_app()
     print("Creating full datasets dump...")
     path = dump.dump_dataset_tables(location, threads)
     print("Done! Created:", path)

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -175,3 +175,14 @@ def remove_old_archives(location, pattern, is_dir=False, sort_key=None):
             shutil.rmtree(entry)
         else:
             os.remove(entry)
+
+
+@cli.command()
+@click.option("--location", "-l", default=os.path.join(os.getcwd(), 'export'), show_default=True,
+              help="Directory where dumps need to be created")
+@click.option("--threads", "-t", type=int)
+def full_dataset_dump(location, threads):
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    print("Creating full datasets dump...")
+    path = dump.dump_dataset_tables(location, threads)
+    print("Done! Created:", path)

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -182,7 +182,6 @@ def remove_old_archives(location, pattern, is_dir=False, sort_key=None):
               help="Directory where dumps need to be created")
 @click.option("--threads", "-t", type=int)
 def full_dataset_dump(location, threads):
-    create_app()
     print("Creating full datasets dump...")
     path = dump.dump_dataset_tables(location, threads)
     print("Done! Created:", path)

--- a/db/test/test_dump.py
+++ b/db/test/test_dump.py
@@ -1,5 +1,6 @@
 from db.testing import DatabaseTestCase
 from db import dump
+from db.dump import _TABLES
 import os.path
 import tempfile
 import shutil
@@ -23,7 +24,7 @@ class DatabaseDumpTestCase(DatabaseTestCase):
     def test_import_db_dump(self):
         path = dump.dump_db(self.temp_dir)
         self.reset_db()
-        dump.import_db_dump(path)
+        dump.import_db_dump(path, _TABLES)
 
     def test_dump_lowlevel_json(self):
         path = dump.dump_lowlevel_json(self.temp_dir)

--- a/manage.py
+++ b/manage.py
@@ -78,7 +78,7 @@ def init_db(archive, force, skip_create_db=False):
 
     if archive:
         print('Importing data...')
-        db.dump.import_db_dump(archive)
+        db.dump.import_dump(archive)
     else:
         print('Skipping data importing.')
         print('Loading fixtures...')

--- a/manage.py
+++ b/manage.py
@@ -97,11 +97,16 @@ def init_db(archive, force, skip_create_db=False):
 
 @cli.command()
 @click.argument("archive", type=click.Path(exists=True))
-def import_data(archive):
+@click.option("--is-dataset-dump", "-d", is_flag=True, help="Import dataset dumps.")
+def import_data(archive, is_dataset_dump=False):
     """Imports data dump into the database."""
 
     print('Importing data...')
-    db.dump.import_db_dump(archive)
+    if is_dataset_dump:
+        db.dump.import_datasets_dump(archive)
+    else:
+        db.dump.import_db_dump(archive)
+    print('Done!')
 
 
 @cli.command()

--- a/manage.py
+++ b/manage.py
@@ -109,7 +109,7 @@ def import_data(archive):
 @click.argument("archive", type=click.Path(exists=True))
 def import_dataset_data(archive):
     """Imports dataset dump into the database."""
-    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+
     print('Importing dataset data...')
     db.dump.import_datasets_dump(archive)
     print('Done!')

--- a/manage.py
+++ b/manage.py
@@ -97,15 +97,21 @@ def init_db(archive, force, skip_create_db=False):
 
 @cli.command()
 @click.argument("archive", type=click.Path(exists=True))
-@click.option("--is-dataset-dump", "-d", is_flag=True, help="Import dataset dumps.")
-def import_data(archive, is_dataset_dump=False):
+def import_data(archive):
     """Imports data dump into the database."""
 
     print('Importing data...')
-    if is_dataset_dump:
-        db.dump.import_datasets_dump(archive)
-    else:
-        db.dump.import_db_dump(archive)
+    db.dump.import_db_dump(archive)
+    print('Done!')
+
+
+@cli.command()
+@click.argument("archive", type=click.Path(exists=True))
+def import_dataset_data(archive):
+    """Imports dataset dump into the database."""
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    print('Importing dataset data...')
+    db.dump.import_datasets_dump(archive)
     print('Done!')
 
 


### PR DESCRIPTION
Added functions `dump_dataset_tables`  and `import_datasets_dumps` for exporting and importing dataset dumps. 

To create dumps, one can use:
`python manage.py dump full_dataset_dump`
To import dataset dump, one can use:
`python manage.py import_data --is-dataset-dump export/<dump.tar.xz>` 