### PR TITLE
Fix AB-321: Added directory to the Python's module search path

### DIFF
--- a/dataset_eval/evaluate.py
+++ b/dataset_eval/evaluate.py
@@ -8,7 +8,8 @@ import tempfile
 import time
 
 import gaia2.fastyaml as yaml
-
+import sys
+sys.path.insert(0,os.path.abspath('..'))
 import db
 import db.data
 import db.dataset
@@ -17,6 +18,7 @@ import db.exceptions
 import utils.path
 from dataset_eval import artistfilter
 from dataset_eval import gaia_wrapper
+
 from webserver import create_app
 
 SLEEP_DURATION = 30  # number of seconds to wait between runs

--- a/default_config.py
+++ b/default_config.py
@@ -60,3 +60,5 @@ FILE_STORAGE_DIR = "./files"
 
 #Feature Flags
 FEATURE_EVAL_LOCATION = False
+
+DATASET_DIR = "./datasets"

--- a/hl_extractor/hl_calc.py
+++ b/hl_extractor/hl_calc.py
@@ -11,12 +11,13 @@ from hashlib import sha1
 from setproctitle import setproctitle
 from threading import Thread
 from time import sleep
-
-import yaml
-
-import db
-import db.data
+import sys
+sys.path.insert(0,os.path.abspath('..'))
 from webserver import create_app
+import yaml
+import db.data
+import db
+
 
 DEFAULT_NUM_THREADS = 1
 


### PR DESCRIPTION
For Issue:
https://tickets.metabrainz.org/browse/AB-321

Initially, The errors were- "ImportError: No module named db" and "can not import webserver"  while running hl_calc.py in /hl_extractor and evaluate.py in /dataset_eval. 
Have added the path for the directory to be inside python's package search and added a variable in default_config.py