### PR TITLE
getMonth() returns the month (from 0-11) for a particular date

### DIFF
--- a/webserver/static/scripts/homepage.js
+++ b/webserver/static/scripts/homepage.js
@@ -4,7 +4,7 @@ $(function() {
     if (lc_time > 0) {
         // lc_time of 0 means never
         var d = new Date(lc_time);
-        var collected_str = d.getFullYear() + "-" + ('0'+d.getMonth()).slice(-2) + "-" +
+        var collected_str = d.getFullYear() + "-" + ('0'+(d.getMonth()+1)).slice(-2) + "-" +
             ('0'+d.getDate()).slice(-2) + " " + ('0'+d.getHours()).slice(-2) + ":" +
             ('0'+d.getMinutes()).slice(-2);
         last_collected.html(collected_str);


### PR DESCRIPTION
For January, d.getMonth() returns value 0. That's why it displayed 00 as the month value on the main page.
Now it will return proper month values for every month.