### PR TITLE
AB-322: Renamed mbid to gid from sql query

### DIFF
--- a/dataset_eval/artistfilter.py
+++ b/dataset_eval/artistfilter.py
@@ -143,7 +143,7 @@ def recordings_to_artists_sub(mbids):
             notincache.append(m)
 
     q = text(
-       """SELECT mbid::text, data->'metadata'->'tags'->'musicbrainz_artistid'->>0
+       """SELECT gid::text, data->'metadata'->'tags'->'musicbrainz_artistid'->>0
             FROM lowlevel ll
             JOIN lowlevel_json llj
               ON ll.id = llj.id


### PR DESCRIPTION
This is a:
- [x]   Bug Fix
- [ ]          Feature addition
- [ ]          Refactoring
- [ ]          Minor / simple change (like a typo)
- [ ]          Other

**Problem:**
While dataset_evaluation on preference: ArtistFilter, we get an error: 
```
dataset_evaluator_1  | sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) column "mbid" does not exist
dataset_evaluator_1  | LINE 1: SELECT mbid::text, data->'metadata'->'tags'->'musicbrainz_ar...
dataset_evaluator_1  |
```
In https://github.com/metabrainz/acousticbrainz-server/blob/master/dataset_eval/artistfilter.py#L146, an sql query is trying to get the 'mbid' column which wasn't present in the lowlevel table, instead gid column is present there which should be fetched.

**Solution** 
I have renamed `mbid `to `gid` in `dataset_eval/artistfilter.py`, so that whenever any user tries to evaluate a dataset with the preference `"Artist filter"`, the query won't direct to the wrong column and continues the proper evaluation.