### PR TITLE
AB-139: Enabled sign in option on error pages

### DIFF
--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -1,4 +1,5 @@
-from flask import render_template, jsonify, request
+from flask import render_template, jsonify, request, has_request_context, _request_ctx_stack, current_app
+
 import webserver
 from webserver.views.api import exceptions as api_exceptions
 
@@ -13,7 +14,7 @@ def init_error_handlers(app):
     def bad_request(error):
         if request.path.startswith(webserver.API_PREFIX):
             return jsonify_error(error)
-        return render_template('errors/400.html', error=error, code = error.code), 400
+        return render_template('errors/400.html', error=error), 400
 
     @app.errorhandler(401)
     def unauthorized(error):
@@ -22,13 +23,13 @@ def init_error_handlers(app):
     
     @app.errorhandler(403)
     def forbidden(error):
-        return render_template('errors/403.html', error=error, code = error.code), 403
+        return render_template('errors/403.html', error=error), 403
 
     @app.errorhandler(404)
     def not_found(error):
         if request.path.startswith(webserver.API_PREFIX):
             return jsonify_error(error)
-        return render_template('errors/404.html', error=error, code = error.code), 404
+        return render_template('errors/404.html', error=error), 404
 
     @app.errorhandler(500)
     def internal_server_error(error):
@@ -41,11 +42,19 @@ def init_error_handlers(app):
             error = Exception("An unknown error occurred")
             error.code = 500
             return jsonify_error(error)
-        return render_template('errors/500.html', error=error, code = error.code), 500
+        # On an HTTP500 page we want to make sure we don't do any more database queries
+        # in case the error was caused by an un-rolled-back database exception.
+        # flask-login will do a query to add `current_user` to the template if it's not
+        # already in the request context, so we override it with AnonymousUser to prevent it from doing so
+        # Ideally we wouldn't do this, and we would catch and roll back all database exceptions
+        if has_request_context() and not hasattr(_request_ctx_stack.top, 'user'):
+            _request_ctx_stack.top.user = current_app.login_manager.anonymous_user()
+        hide_navbar_user_menu = True
+        return render_template('errors/500.html', error=error, hide_navbar_user_menu=hide_navbar_user_menu), 500
 
     @app.errorhandler(503)
     def service_unavailable(error):
-        return render_template('errors/503.html', error=error, code = error.code), 503
+        return render_template('errors/503.html', error=error), 503
 
 
 def jsonify_error(error, code=None):

--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -13,7 +13,7 @@ def init_error_handlers(app):
     def bad_request(error):
         if request.path.startswith(webserver.API_PREFIX):
             return jsonify_error(error)
-        return render_template('errors/400.html', error=error), 400
+        return render_template('errors/400.html', error=error, code = error.code), 400
 
     @app.errorhandler(401)
     def unauthorized(error):
@@ -22,13 +22,13 @@ def init_error_handlers(app):
     
     @app.errorhandler(403)
     def forbidden(error):
-        return render_template('errors/403.html', error=error), 403
+        return render_template('errors/403.html', error=error, code = error.code), 403
 
     @app.errorhandler(404)
     def not_found(error):
         if request.path.startswith(webserver.API_PREFIX):
             return jsonify_error(error)
-        return render_template('errors/404.html', error=error), 404
+        return render_template('errors/404.html', error=error, code = error.code), 404
 
     @app.errorhandler(500)
     def internal_server_error(error):
@@ -41,11 +41,11 @@ def init_error_handlers(app):
             error = Exception("An unknown error occurred")
             error.code = 500
             return jsonify_error(error)
-        return render_template('errors/500.html', error=error), 500
+        return render_template('errors/500.html', error=error, code = error.code), 500
 
     @app.errorhandler(503)
     def service_unavailable(error):
-        return render_template('errors/503.html', error=error), 503
+        return render_template('errors/503.html', error=error, code = error.code), 503
 
 
 def jsonify_error(error, code=None):

--- a/webserver/templates/navbar.html
+++ b/webserver/templates/navbar.html
@@ -40,10 +40,11 @@
         </li>
       </ul>
 
-      {% if code != 500 %}
         <ul class="nav navbar-nav navbar-right">
-          {% if not current_user or current_user.is_anonymous %}
-            <li><a href="{{ url_for('login.index', next=request.path) }}">Sign in</a></li>
+          {% if hide_navbar_user_menu or not current_user or current_user.is_anonymous %}
+            <li>
+              <a href="{{ url_for('login.index', next=request.path) }}">Sign in</a>
+            </li>
           {% else %}
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">
@@ -54,15 +55,8 @@
                 <li><a href="{{ url_for('login.logout', next=request.path) }}">Sign out</a></li>
               </ul>
             </li>
-          {% endif %}
+          {%- endif -%}
         </ul>
-      {% else %}
-        {% if not current_user or current_user.is_anonymous %}
-       <ul class="nav navbar-nav navbar-right">
-            <li><a href="{{ url_for('login.index', next=request.path) }}">Sign in</a></li>
-      </ul>
-        {% endif %}
-      {%- endif -%}
     </div>
 
   </div>

--- a/webserver/templates/navbar.html
+++ b/webserver/templates/navbar.html
@@ -40,6 +40,7 @@
         </li>
       </ul>
 
+      {% if not error %}
         <ul class="nav navbar-nav navbar-right">
           {% if not current_user or current_user.is_anonymous %}
             <li><a href="{{ url_for('login.index', next=request.path) }}">Sign in</a></li>
@@ -55,7 +56,13 @@
             </li>
           {% endif %}
         </ul>
-        
+      {% else %}
+        {% if not current_user or current_user.is_anonymous %}
+       <ul class="nav navbar-nav navbar-right">
+            <li><a href="{{ url_for('login.index', next=request.path) }}">Sign in</a></li>
+      </ul>
+        {% endif %}
+      {%- endif -%}
     </div>
 
   </div>

--- a/webserver/templates/navbar.html
+++ b/webserver/templates/navbar.html
@@ -40,7 +40,7 @@
         </li>
       </ul>
 
-      {% if not error %}
+      {% if code != 500 %}
         <ul class="nav navbar-nav navbar-right">
           {% if not current_user or current_user.is_anonymous %}
             <li><a href="{{ url_for('login.index', next=request.path) }}">Sign in</a></li>

--- a/webserver/templates/navbar.html
+++ b/webserver/templates/navbar.html
@@ -40,8 +40,6 @@
         </li>
       </ul>
 
-      {# Not showing user stuff on error pages. If attempt to load user info fails there, page will not render. #}
-      {% if not error %}
         <ul class="nav navbar-nav navbar-right">
           {% if not current_user or current_user.is_anonymous %}
             <li><a href="{{ url_for('login.index', next=request.path) }}">Sign in</a></li>
@@ -57,7 +55,7 @@
             </li>
           {% endif %}
         </ul>
-      {%- endif -%}
+        
     </div>
 
   </div>

--- a/webserver/views/test/test_index.py
+++ b/webserver/views/test/test_index.py
@@ -1,7 +1,14 @@
 from __future__ import absolute_import
 from webserver import create_app
 from webserver.testing import ServerTestCase
+
+import mock
 from flask import url_for
+
+from flask_login import login_required, AnonymousUserMixin
+from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
+import db.user as db_user
+import webserver.login
 
 
 class IndexViewsTestCase(ServerTestCase):
@@ -37,3 +44,106 @@ class IndexViewsTestCase(ServerTestCase):
         resp = client.get(url_for('index.goals'))
         self.assert200(resp)
         self.assertIn('flDebug', str(resp.data))
+
+    @mock.patch('db.user.get')
+    def test_menu_not_logged_in(self, mock_user_get):
+        resp = self.client.get(url_for('index.index'))
+        data = resp.data.decode('utf-8')
+        self.assertIn('Sign in', data)
+        # item in user menu doesn't exist
+        self.assertNotIn('Your Profile', data)
+        mock_user_get.assert_not_called()
+
+    @mock.patch('db.user.get')
+    def test_menu_logged_in(self, mock_user_get):
+        """ If the user is logged in, check that we perform a database query to get user data """
+        user = db_user.get_or_create('little_rsh')
+        mock_user_get.return_value = user
+        self.temporary_login(user['id'])
+        resp = self.client.get(url_for('index.index'))
+        data = resp.data.decode('utf-8')
+
+        # username (menu header)
+        self.assertIn('little_rsh', data)
+        # item in user menu
+        self.assertIn('Your Profile', data)
+        mock_user_get.assert_called_with(user['id'])
+
+    @mock.patch('db.user.get')
+    def test_menu_logged_in_error_show(self, mock_user_get):
+        """ If the user is logged in, if we show a 400 or 404 error, show the user menu"""
+        @self.app.route('/page_that_returns_400')
+        def view400():
+            raise BadRequest('bad request')
+
+        @self.app.route('/page_that_returns_404')
+        def view404():
+            raise NotFound('not found')
+
+        user = db_user.get_or_create('little_rsh')
+        mock_user_get.return_value = user
+        self.temporary_login(user['id'])
+        resp = self.client.get('/page_that_returns_400')
+        data = resp.data.decode('utf-8')
+        self.assert400(resp)
+
+        # username (menu header)
+        self.assertIn('little_rsh', data)
+        # item in user menu
+        self.assertIn('Your Profile', data)
+        mock_user_get.assert_called_with(user['id'])
+
+        resp = self.client.get('/page_that_returns_404')
+        data = resp.data.decode('utf-8')
+        self.assert404(resp)
+        # username (menu header)
+        self.assertIn('little_rsh', data)
+        # item in user menu
+        self.assertIn('Your Profile', data)
+        mock_user_get.assert_called_with(user['id'])
+
+    @mock.patch('db.user.get')
+    def test_menu_logged_in_error_dont_show_no_user(self, mock_user_get):
+        """ If the user is logged in, if we show a 500 error, do not show the user menu
+            Don't query the database to get a current_user for the template context"""
+        @self.app.route('/page_that_returns_500')
+        def view500():
+            raise InternalServerError('error')
+
+        user = db_user.get_or_create('little_rsh')
+        mock_user_get.return_value = user
+        self.temporary_login(user['id'])
+        resp = self.client.get('/page_that_returns_500')
+        data = resp.data.decode('utf-8')
+        # item not in user menu
+        self.assertNotIn('Your Profile', data)
+        self.assertIn('Sign in', data)
+        mock_user_get.assert_not_called()
+        self.assertIsInstance(self.get_context_variable('current_user'), AnonymousUserMixin)
+
+    @mock.patch('db.user.get')
+    def test_menu_logged_in_error_dont_show_user_loaded(self, mock_user_get):
+        """ If the user is logged in, if we show a 500 error, do not show the user menu
+        If the user has previously been loaded in the view, check that it's not
+        loaded while rendering the template"""
+
+        user = db_user.get_or_create('little_rsh')
+        mock_user_get.return_value = user
+
+        @self.app.route('/page_that_returns_500')
+        @login_required
+        def view500():
+            # flask-login user is loaded during @login_required, so check that the db has been queried
+            mock_user_get.assert_called_with(user['id'])
+            raise InternalServerError('error')
+
+        self.temporary_login(user['id'])
+        resp = self.client.get('/page_that_returns_500')
+        data = resp.data.decode('utf-8')
+        # item not in user menu
+        self.assertNotIn('Your Profile', data)
+        self.assertIn('Sign in', data)
+        # Even after rendering the template, the database has only been queried once (before the exception)
+        mock_user_get.assert_called_once()
+        self.assertIsInstance(self.get_context_variable('current_user'), webserver.login.User)
+

--- a/webserver/views/test/test_index.py
+++ b/webserver/views/test/test_index.py
@@ -2,11 +2,12 @@ from __future__ import absolute_import
 from webserver import create_app
 from webserver.testing import ServerTestCase
 
-import mock
-from flask import url_for
+from unittest import mock
 
+from flask import url_for
 from flask_login import login_required, AnonymousUserMixin
 from werkzeug.exceptions import BadRequest, InternalServerError, NotFound
+
 import db.user as db_user
 import webserver.login
 

--- a/webserver/views/test/test_index.py
+++ b/webserver/views/test/test_index.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from webserver import create_app
 from webserver.testing import ServerTestCase
 
-from unittest import mock
+import mock
 
 from flask import url_for
 from flask_login import login_required, AnonymousUserMixin
@@ -52,7 +52,7 @@ class IndexViewsTestCase(ServerTestCase):
         data = resp.data.decode('utf-8')
         self.assertIn('Sign in', data)
         # item in user menu doesn't exist
-        self.assertNotIn('Your Profile', data)
+        self.assertNotIn('Your profile', data)
         mock_user_get.assert_not_called()
 
     @mock.patch('db.user.get')
@@ -67,7 +67,7 @@ class IndexViewsTestCase(ServerTestCase):
         # username (menu header)
         self.assertIn('little_rsh', data)
         # item in user menu
-        self.assertIn('Your Profile', data)
+        self.assertIn('Your profile', data)
         mock_user_get.assert_called_with(user['id'])
 
     @mock.patch('db.user.get')
@@ -91,7 +91,7 @@ class IndexViewsTestCase(ServerTestCase):
         # username (menu header)
         self.assertIn('little_rsh', data)
         # item in user menu
-        self.assertIn('Your Profile', data)
+        self.assertIn('Your profile', data)
         mock_user_get.assert_called_with(user['id'])
 
         resp = self.client.get('/page_that_returns_404')
@@ -100,7 +100,7 @@ class IndexViewsTestCase(ServerTestCase):
         # username (menu header)
         self.assertIn('little_rsh', data)
         # item in user menu
-        self.assertIn('Your Profile', data)
+        self.assertIn('Your profile', data)
         mock_user_get.assert_called_with(user['id'])
 
     @mock.patch('db.user.get')
@@ -117,7 +117,7 @@ class IndexViewsTestCase(ServerTestCase):
         resp = self.client.get('/page_that_returns_500')
         data = resp.data.decode('utf-8')
         # item not in user menu
-        self.assertNotIn('Your Profile', data)
+        self.assertNotIn('Your profile', data)
         self.assertIn('Sign in', data)
         mock_user_get.assert_not_called()
         self.assertIsInstance(self.get_context_variable('current_user'), AnonymousUserMixin)
@@ -142,9 +142,8 @@ class IndexViewsTestCase(ServerTestCase):
         resp = self.client.get('/page_that_returns_500')
         data = resp.data.decode('utf-8')
         # item not in user menu
-        self.assertNotIn('Your Profile', data)
+        self.assertNotIn('Your profile', data)
         self.assertIn('Sign in', data)
         # Even after rendering the template, the database has only been queried once (before the exception)
-        mock_user_get.assert_called_once()
+        mock_user_get.assert_called_once_with(user['id'])
         self.assertIsInstance(self.get_context_variable('current_user'), webserver.login.User)
-


### PR DESCRIPTION
This is a...
- [x]   Bug Fix
- [ ]          Feature addition
- [ ]          Refactoring
- [ ]          Minor / simple change (like a typo)
- [ ]          Other

**Problem:** 
Error pages are missing the Sign in button.

**Solution:**
I've enabled the `Sign in` button on HTTPS500 error pages, and `Sign in` button and corresponding drop-down with `Your profile` and sign out button for all other error pages as well. 