### PR TITLE
AB-21: Get high-level data for multiple recordings with one request

### DIFF
--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -156,7 +156,13 @@ def _parse_bulk_params(params):
 
 
 def check_bad_request_for_multiple_recordings():
-    """Checking whether the recording ids throw exceptions
+    """Check whether the recording ids are not more than 200 
+    and whether the recording ids are found or not.
+
+    If recording_ids are missing, an APIBadRequest Exception is
+    raised stating the missing MBIDs message.
+    If there are more than 200 recordings, then an APIBadRequest Exception is raised.
+    In both cases, no further processing is done.
     """
     recording_ids = request.args.get("recording_ids")
 

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -155,10 +155,23 @@ def _parse_bulk_params(params):
     return [x for x in ret if not (x in seen or seen.add(x))]
 
 
-@bp_core.route("/low-level", methods=["GET"])
-@crossdomain()
-def get_many_lowlevel():
-    """Get low-level data for many recordings at once.
+def check_bad_request_for_multiple_recordings():
+    """Checking whether the recording ids throw exceptions
+    """
+    recording_ids = request.args.get("recording_ids")
+
+    if not recording_ids:
+        raise webserver.views.api.exceptions.APIBadRequest("Missing `recording_ids` parameter")
+
+    recordings = _parse_bulk_params(recording_ids)
+    if len(recordings) > 200:
+        raise webserver.views.api.exceptions.APIBadRequest("More than 200 recordings not allowed per request")
+
+    return recordings
+
+
+def get_data_for_multiple_recordings(collect_data):
+    """Gets low-level and high-level data using the function collect_data
 
     **Example response**:
 
@@ -176,82 +189,43 @@ def get_many_lowlevel():
     If the list of MBIDs in the query string has a recording which is not
     present in the database, then it is silently ignored and will not appear
     in the returned data.
- 
+
     :query recording_ids: *Required.* A list of recording MBIDs to retrieve
 
       Takes the form `mbid[:offset];mbid[:offset]`. Offsets are optional, and should
       be >= 0
 
     :resheader Content-Type: *application/json*
-   """
-    recording_ids = request.args.get("recording_ids")
-
-    if not recording_ids:
-        raise webserver.views.api.exceptions.APIBadRequest("Missing `recording_ids` parameter")
-
-    recordings = _parse_bulk_params(recording_ids)
-    if len(recordings) > 200:
-        raise webserver.views.api.exceptions.APIBadRequest("More than 200 recordings not allowed per request")
+    """
+    recordings = check_bad_request_for_multiple_recordings()
 
     recording_details = {}
 
-    # TODO: This should use a bulk get method for speed
     for recording_id, offset in recordings:
         try:
-            recording_details.setdefault(recording_id, {})[offset] = db.data.load_low_level(recording_id, offset)
+            recording_details.setdefault(recording_id, {})[offset] = collect_data(recording_id, offset)
         except NoDataFoundException:
             pass
 
     return jsonify(recording_details)
+
+
+@bp_core.route("/low-level", methods=["GET"])
+@crossdomain()
+def get_many_lowlevel():
+    """Get low-level data for many recordings at once.
+    """
+    recording_details = get_data_for_multiple_recordings(db.data.load_low_level)
+    return recording_details
 
 
 @bp_core.route("/high-level", methods=["GET"])
 @crossdomain()
 def get_many_highlevel():
     """Get high-level data for many recordings at once.
-
-    **Example response**:
-
-    .. sourcecode:: json
-
-       {"mbid1": {"offset1": {document},
-                  "offset2": {document}},
-        "mbid2": {"offset1": {document}}
-       }
-
-    Offset keys are returned as strings, as per JSON encoding rules.
-    If an offset was not specified in the request for an mbid, the offset
-    will be 0.
-
-    If the list of MBIDs in the query string has a recording which is not
-    present in the database, then it is silently ignored and will not appear
-    in the returned data.
-
-    :query recording_ids: *Required.* A list of recording MBIDs to retrieve
-
-      Takes the form `mbid[:offset];mbid[:offset]`. Offsets are optional, and should
-      be >= 0
-
-    :resheader Content-Type: *application/json*
-   """
-    recording_ids = request.args.get("recording_ids")
-
-    if not recording_ids:
-        raise webserver.views.api.exceptions.APIBadRequest("Missing `recording_ids` parameter")
-
-    recordings = _parse_bulk_params(recording_ids)
-    if len(recordings) > 200:
-        raise webserver.views.api.exceptions.APIBadRequest("More than 200 recordings not allowed per request")
-
-    recording_details = {}
-
-    for recording_id, offset in recordings:
-        try:
-            recording_details.setdefault(recording_id, {})[offset] = db.data.load_high_level(recording_id, offset)
-        except NoDataFoundException:
-            pass
-
-    return jsonify(recording_details)
+    """
+    recording_details = get_data_for_multiple_recordings(db.data.load_high_level)
+    return recording_details
 
 
 @bp_core.route("/count", methods=["GET"])
@@ -274,16 +248,7 @@ def get_many_count():
 
     :resheader Content-Type: *application/json*
     """
-    recording_ids = request.args.get("recording_ids")
-
-    if not recording_ids:
-        raise webserver.views.api.exceptions.APIBadRequest(
-            "Missing `recording_ids` parameter")
-
-    recordings = _parse_bulk_params(recording_ids)
-    if len(recordings) > 200:
-        raise webserver.views.api.exceptions.APIBadRequest(
-            "More than 200 recordings not allowed per request")
+    recordings = check_bad_request_for_multiple_recordings()
 
     mbids = [mbid for (mbid, offset) in recordings]
     return jsonify(db.data.count_many_lowlevel(mbids))

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -29,12 +29,12 @@ class CoreViewsTestCase(ServerTestCase):
     def test_get_low_level(self):
         mbid = "0dad432b-16cc-4bf0-8961-fd31d124b01b"
         resp = self.client.get("/api/v1/%s/low-level" % mbid)
-        self.assertEqual(resp.status_code, 404)
+        self.assert404(resp)
 
         self.load_low_level_data(mbid)
 
         resp = self.client.get("/api/v1/%s/low-level" % mbid)
-        self.assertEqual(resp.status_code, 200)
+        self.assert200(resp)
 
     def test_submit_low_level(self):
         mbid = "0dad432b-16cc-4bf0-8961-fd31d124b01b"
@@ -44,10 +44,10 @@ class CoreViewsTestCase(ServerTestCase):
                 sub_resp = client.post("/api/v1/%s/low-level" % mbid,
                                        data=json_file.read(),
                                        content_type="application/json")
-                self.assertEqual(sub_resp.status_code, 200)
+                self.assert200(sub_resp)
 
         resp = self.client.get("/api/v1/%s/low-level" % mbid)
-        self.assertEqual(resp.status_code, 200)
+        self.assert200(resp)
 
     def test_cors_headers(self):
         mbid = "0dad432b-16cc-4bf0-8961-fd31d124b01b"
@@ -65,11 +65,11 @@ class CoreViewsTestCase(ServerTestCase):
             This error is raised by Flask, but we special-case to json.
         """
         resp = self.client.get("/api/v1/nothing/low-level")
-        self.assertEqual(404, resp.status_code)
+        self.assert404(resp)
         load_low_level.assert_not_called()
         
         expected_result = {"message": "The requested URL was not found on the server.  If you entered the URL manually please check your spelling and try again."}
-        self.assertEqual(resp.json, expected_result)
+        self.assertDictEqual(resp.json, expected_result)
 
     @mock.patch("db.data.load_low_level")
     def test_ll_internal_server_error(self, load_low_level):
@@ -83,53 +83,53 @@ class CoreViewsTestCase(ServerTestCase):
 
         load_low_level.side_effect = ValueError
         resp = self.client.get("/api/v1/%s/low-level" % self.uuid)
-        self.assertEqual(500, resp.status_code)
+        self.assert500(resp)
 
         expected_result = {"message": "An unknown error occurred"}
-        self.assertEqual(resp.json, expected_result)
+        self.assertDictEqual(resp.json, expected_result)
         self.app.config['PROPAGATE_EXCEPTIONS'] = old_propagate_exceptions
 
     @mock.patch("db.data.load_low_level")
     def test_ll_no_offset(self, ll):
         ll.return_value = {}
         resp = self.client.get("/api/v1/%s/low-level" % self.uuid)
-        self.assertEqual(200, resp.status_code)
+        self.assert200(resp)
         ll.assert_called_with(self.uuid, 0)
 
     @mock.patch("db.data.load_low_level")
     def test_ll_numerical_offset(self, ll):
         ll.return_value = {}
         resp = self.client.get("/api/v1/%s/low-level?n=3" % self.uuid)
-        self.assertEqual(200, resp.status_code)
+        self.assert200(resp)
         ll.assert_called_with(self.uuid, 3)
 
     @mock.patch("db.data.load_low_level")
     def test_ll_bad_offset(self, ll):
         resp = self.client.get("/api/v1/%s/low-level?n=x" % self.uuid)
-        self.assertEqual(400, resp.status_code)
+        self.assert400(resp)
 
     @mock.patch("db.data.load_low_level")
     def test_ll_no_item(self, ll):
         ll.side_effect = db.exceptions.NoDataFoundException
         resp = self.client.get("/api/v1/%s/low-level" % self.uuid)
-        self.assertEqual(404, resp.status_code)
+        self.assert404(resp)
         self.assertEqual("Not found", resp.json["message"])
 
     @mock.patch("db.data.load_high_level")
     def test_hl_numerical_offset(self, hl):
         hl.return_value = {}
         resp = self.client.get("/api/v1/%s/high-level?n=3" % self.uuid)
-        self.assertEqual(200, resp.status_code)
+        self.assert200(resp)
         hl.assert_called_with(self.uuid, 3)
 
     @mock.patch('db.data.load_low_level')
     def test_get_bulk_ll_no_param(self, load_low_level):
         # No parameter in bulk lookup results in an error
         resp = self.client.get('api/v1/low-level')
-        self.assertEqual(resp.status_code, 400)
+        self.assert400(resp)
 
         expected_result = {"message": "Missing `recording_ids` parameter"}
-        self.assertEqual(resp.json, expected_result)
+        self.assertDictEqual(resp.json, expected_result)
 
     @mock.patch('db.data.load_low_level')
     def test_get_bulk_ll(self, load_low_level):
@@ -146,14 +146,14 @@ class CoreViewsTestCase(ServerTestCase):
         load_low_level.side_effect = [rec_c5, rec_7f, rec_40_2, rec_40_3]
 
         resp = self.client.get('api/v1/low-level?recording_ids=' + params)
-        self.assertEqual(resp.status_code, 200)
+        self.assert200(resp)
 
         expected_result = {
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
             "7f27d7a9-27f0-4663-9d20-2c9c40200e6d": {"3": rec_7f},
             "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2, "3": rec_40_3}
         }
-        self.assertEqual(resp.json, expected_result)
+        self.assertDictEqual(resp.json, expected_result)
 
         calls = [mock.call("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
                  mock.call("7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 3),
@@ -174,13 +174,13 @@ class CoreViewsTestCase(ServerTestCase):
         load_low_level.side_effect = [rec_c5, db.exceptions.NoDataFoundException, rec_40_2]
 
         resp = self.client.get('api/v1/low-level?recording_ids=' + params)
-        self.assertEqual(resp.status_code, 200)
+        self.assert200(resp)
 
         expected_result = {
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
             "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2},
         }
-        self.assertEqual(resp.json, expected_result)
+        self.assertDictEqual(resp.json, expected_result)
 
         calls = [mock.call("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
                  mock.call("7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 3),
@@ -192,17 +192,17 @@ class CoreViewsTestCase(ServerTestCase):
         manyids = [str(uuid.uuid4()) for i in range(205)]
         limit_exceed_url = ";".join(manyids)
         resp = self.client.get('api/v1/low-level?recording_ids=' + limit_exceed_url)
-        self.assertEqual(resp.status_code, 400)
+        self.assert400(resp)
         self.assertEqual('More than 200 recordings not allowed per request', resp.json['message'])
 
     @mock.patch('db.data.load_high_level')
     def test_get_bulk_hl_no_param(self, load_high_level):
         # No parameter in bulk lookup results in an error
         resp = self.client.get('api/v1/high-level')
-        self.assertEqual(resp.status_code, 400)
+        self.assert400(resp)
 
         expected_result = {"message": "Missing `recording_ids` parameter"}
-        self.assertEqual(resp.json, expected_result)
+        self.assertDictEqual(resp.json, expected_result)
 
     @mock.patch('db.data.load_high_level')
     def test_get_bulk_ll(self, load_high_level):
@@ -219,14 +219,14 @@ class CoreViewsTestCase(ServerTestCase):
         load_high_level.side_effect = [rec_c5, rec_7f, rec_40_2, rec_40_3]
 
         resp = self.client.get('api/v1/high-level?recording_ids=' + params)
-        self.assertEqual(resp.status_code, 200)
+        self.assert200(resp)
 
         expected_result = {
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
             "7f27d7a9-27f0-4663-9d20-2c9c40200e6d": {"3": rec_7f},
             "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2, "3": rec_40_3}
         }
-        self.assertEqual(resp.json, expected_result)
+        self.assertDictEqual(resp.json, expected_result)
 
         calls = [mock.call("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
                  mock.call("7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 3),
@@ -247,13 +247,13 @@ class CoreViewsTestCase(ServerTestCase):
         load_high_level.side_effect = [rec_c5, db.exceptions.NoDataFoundException, rec_40_2]
 
         resp = self.client.get('api/v1/high-level?recording_ids=' + params)
-        self.assertEqual(resp.status_code, 200)
+        self.assert200(resp)
 
         expected_result = {
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
             "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2},
         }
-        self.assertEqual(resp.json, expected_result)
+        self.assertDictEqual(resp.json, expected_result)
 
         calls = [mock.call("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
                  mock.call("7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 3),
@@ -265,7 +265,7 @@ class CoreViewsTestCase(ServerTestCase):
         manyids = [str(uuid.uuid4()) for i in range(205)]
         limit_exceed_url = ";".join(manyids)
         resp = self.client.get('api/v1/high-level?recording_ids=' + limit_exceed_url)
-        self.assertEqual(resp.status_code, 400)
+        self.assert400(resp)
         self.assertEqual('More than 200 recordings not allowed per request', resp.json['message'])
 
     def submit_fake_data(self):
@@ -286,7 +286,7 @@ class CoreViewsTestCase(ServerTestCase):
 
         for mbid in mbids:
             resp = self.client.get('api/v1/%s/count' % mbid)
-            self.assertEqual(resp.status_code, 200)
+            self.assert200(resp)
             self.assertDictEqual(resp.json,
                                  {"mbid": mbid,
                                   "count": expected_result[mbid]})
@@ -294,12 +294,12 @@ class CoreViewsTestCase(ServerTestCase):
     def test_get_bulk_count_no_param(self):
         # No parameter in bulk lookup results in an error
         resp = self.client.get('api/v1/count')
-        self.assertEqual(resp.status_code, 400)
+        self.assert400(resp)
 
     def test_get_bulk_count(self):
         mbids = self.submit_fake_data()
         resp = self.client.get('api/v1/count?recording_ids=' + ';'.join(mbids))
-        self.assertEqual(resp.status_code, 200)
+        self.assert200(resp)
 
         expected_result = {
             "7f27d7a9-27f0-4663-9d20-2c9c40200e6d": {"count": 1},
@@ -312,7 +312,7 @@ class CoreViewsTestCase(ServerTestCase):
         manyids = [str(uuid.uuid4()) for i in range(205)]
         limit_exceed_url = ";".join(manyids)
         resp = self.client.get('api/v1/count?recording_ids=' + limit_exceed_url)
-        self.assertEqual(resp.status_code, 400)
+        self.assert400(resp)
         self.assertEqual('More than 200 recordings not allowed per request',
                          resp.json['message'])
 

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -195,6 +195,79 @@ class CoreViewsTestCase(ServerTestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertEqual('More than 200 recordings not allowed per request', resp.json['message'])
 
+    @mock.patch('db.data.load_high_level')
+    def test_get_bulk_hl_no_param(self, load_high_level):
+        # No parameter in bulk lookup results in an error
+        resp = self.client.get('api/v1/high-level')
+        self.assertEqual(resp.status_code, 400)
+
+        expected_result = {"message": "Missing `recording_ids` parameter"}
+        self.assertEqual(resp.json, expected_result)
+
+    @mock.patch('db.data.load_high_level')
+    def test_get_bulk_ll(self, load_high_level):
+        # Check that many items are returned, including two offsets of the
+        # same mbid
+
+        params = "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9;7f27d7a9-27f0-4663-9d20-2c9c40200e6d:3;405a5ff4-7ee2-436b-95c1-90ce8a83b359:2;405a5ff4-7ee2-436b-95c1-90ce8a83b359:3"
+
+        rec_c5 = {"recording": "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9"}
+        rec_7f = {"recording": "7f27d7a9-27f0-4663-9d20-2c9c40200e6d"}
+        rec_40_2 = {"recording": "405a5ff4-7ee2-436b-95c1-90ce8a83b359:2"}
+        rec_40_3 = {"recording": "405a5ff4-7ee2-436b-95c1-90ce8a83b359:3"}
+
+        load_high_level.side_effect = [rec_c5, rec_7f, rec_40_2, rec_40_3]
+
+        resp = self.client.get('api/v1/high-level?recording_ids=' + params)
+        self.assertEqual(resp.status_code, 200)
+
+        expected_result = {
+            "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
+            "7f27d7a9-27f0-4663-9d20-2c9c40200e6d": {"3": rec_7f},
+            "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2, "3": rec_40_3}
+        }
+        self.assertEqual(resp.json, expected_result)
+
+        calls = [mock.call("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
+                 mock.call("7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 3),
+                 mock.call("405a5ff4-7ee2-436b-95c1-90ce8a83b359", 2),
+                 mock.call("405a5ff4-7ee2-436b-95c1-90ce8a83b359", 3)]
+        load_high_level.assert_has_calls(calls)
+
+    @mock.patch('db.data.load_high_level')
+    def test_get_bulk_hl_absent_mbid(self, load_high_level):
+        # Check that within a set of mbid parameters, the ones absent
+        # from the database are ignored.
+
+        params = "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9;7f27d7a9-27f0-4663-9d20-2c9c40200e6d:3;405a5ff4-7ee2-436b-95c1-90ce8a83b359:2"
+
+        rec_c5 = {"recording": "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9"}
+        rec_40_2 = {"recording": "405a5ff4-7ee2-436b-95c1-90ce8a83b359:2"}
+
+        load_high_level.side_effect = [rec_c5, db.exceptions.NoDataFoundException, rec_40_2]
+
+        resp = self.client.get('api/v1/high-level?recording_ids=' + params)
+        self.assertEqual(resp.status_code, 200)
+
+        expected_result = {
+            "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
+            "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2},
+        }
+        self.assertEqual(resp.json, expected_result)
+
+        calls = [mock.call("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
+                 mock.call("7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 3),
+                 mock.call("405a5ff4-7ee2-436b-95c1-90ce8a83b359", 2)]
+        load_high_level.assert_has_calls(calls)
+
+    def test_get_bulk_hl_more_than_200(self):
+        # Create many random uuids, because of parameter deduplication
+        manyids = [str(uuid.uuid4()) for i in range(205)]
+        limit_exceed_url = ";".join(manyids)
+        resp = self.client.get('api/v1/high-level?recording_ids=' + limit_exceed_url)
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual('More than 200 recordings not allowed per request', resp.json['message'])
+
     def submit_fake_data(self):
         mbids = ["c5f4909e-1d7b-4f15-a6f6-1af376bc01c9",
                  "7f27d7a9-27f0-4663-9d20-2c9c40200e6d",

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -29,12 +29,12 @@ class CoreViewsTestCase(ServerTestCase):
     def test_get_low_level(self):
         mbid = "0dad432b-16cc-4bf0-8961-fd31d124b01b"
         resp = self.client.get("/api/v1/%s/low-level" % mbid)
-        self.assert404(resp)
+        self.assertEqual(resp.status_code, 404)
 
         self.load_low_level_data(mbid)
 
         resp = self.client.get("/api/v1/%s/low-level" % mbid)
-        self.assert200(resp)
+        self.assertEqual(resp.status_code, 200)
 
     def test_submit_low_level(self):
         mbid = "0dad432b-16cc-4bf0-8961-fd31d124b01b"
@@ -44,10 +44,10 @@ class CoreViewsTestCase(ServerTestCase):
                 sub_resp = client.post("/api/v1/%s/low-level" % mbid,
                                        data=json_file.read(),
                                        content_type="application/json")
-                self.assert200(sub_resp)
+                self.assertEqual(sub_resp.status_code, 200)
 
         resp = self.client.get("/api/v1/%s/low-level" % mbid)
-        self.assert200(resp)
+        self.assertEqual(resp.status_code, 200)
 
     def test_cors_headers(self):
         mbid = "0dad432b-16cc-4bf0-8961-fd31d124b01b"
@@ -65,11 +65,11 @@ class CoreViewsTestCase(ServerTestCase):
             This error is raised by Flask, but we special-case to json.
         """
         resp = self.client.get("/api/v1/nothing/low-level")
-        self.assert404(resp)
+        self.assertEqual(404, resp.status_code)
         load_low_level.assert_not_called()
         
         expected_result = {"message": "The requested URL was not found on the server.  If you entered the URL manually please check your spelling and try again."}
-        self.assertDictEqual(resp.json, expected_result)
+        self.assertEqual(resp.json, expected_result)
 
     @mock.patch("db.data.load_low_level")
     def test_ll_internal_server_error(self, load_low_level):
@@ -83,7 +83,7 @@ class CoreViewsTestCase(ServerTestCase):
 
         load_low_level.side_effect = ValueError
         resp = self.client.get("/api/v1/%s/low-level" % self.uuid)
-        self.assert500(resp)
+        self.assertEqual(500, resp.status_code)
 
         expected_result = {"message": "An unknown error occurred"}
         self.assertDictEqual(resp.json, expected_result)
@@ -93,43 +93,43 @@ class CoreViewsTestCase(ServerTestCase):
     def test_ll_no_offset(self, ll):
         ll.return_value = {}
         resp = self.client.get("/api/v1/%s/low-level" % self.uuid)
-        self.assert200(resp)
+        self.assertEqual(200, resp.status_code)
         ll.assert_called_with(self.uuid, 0)
 
     @mock.patch("db.data.load_low_level")
     def test_ll_numerical_offset(self, ll):
         ll.return_value = {}
         resp = self.client.get("/api/v1/%s/low-level?n=3" % self.uuid)
-        self.assert200(resp)
+        self.assertEqual(200, resp.status_code)
         ll.assert_called_with(self.uuid, 3)
 
     @mock.patch("db.data.load_low_level")
     def test_ll_bad_offset(self, ll):
         resp = self.client.get("/api/v1/%s/low-level?n=x" % self.uuid)
-        self.assert400(resp)
+        self.assertEqual(400, resp.status_code)
 
     @mock.patch("db.data.load_low_level")
     def test_ll_no_item(self, ll):
         ll.side_effect = db.exceptions.NoDataFoundException
         resp = self.client.get("/api/v1/%s/low-level" % self.uuid)
-        self.assert404(resp)
+        self.assertEqual(404, resp.status_code)
         self.assertEqual("Not found", resp.json["message"])
 
     @mock.patch("db.data.load_high_level")
     def test_hl_numerical_offset(self, hl):
         hl.return_value = {}
         resp = self.client.get("/api/v1/%s/high-level?n=3" % self.uuid)
-        self.assert200(resp)
+        self.assertEqual(200, resp.status_code)
         hl.assert_called_with(self.uuid, 3)
 
     @mock.patch('db.data.load_low_level')
     def test_get_bulk_ll_no_param(self, load_low_level):
         # No parameter in bulk lookup results in an error
         resp = self.client.get('api/v1/low-level')
-        self.assert400(resp)
+        self.assertEqual(resp.status_code, 400)
 
         expected_result = {"message": "Missing `recording_ids` parameter"}
-        self.assertDictEqual(resp.json, expected_result)
+        self.assertEqual(resp.json, expected_result)
 
     @mock.patch('db.data.load_low_level')
     def test_get_bulk_ll(self, load_low_level):
@@ -146,14 +146,14 @@ class CoreViewsTestCase(ServerTestCase):
         load_low_level.side_effect = [rec_c5, rec_7f, rec_40_2, rec_40_3]
 
         resp = self.client.get('api/v1/low-level?recording_ids=' + params)
-        self.assert200(resp)
+        self.assertEqual(resp.status_code, 200)
 
         expected_result = {
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
             "7f27d7a9-27f0-4663-9d20-2c9c40200e6d": {"3": rec_7f},
             "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2, "3": rec_40_3}
         }
-        self.assertDictEqual(resp.json, expected_result)
+        self.assertEqual(resp.json, expected_result)
 
         calls = [mock.call("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
                  mock.call("7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 3),
@@ -174,13 +174,13 @@ class CoreViewsTestCase(ServerTestCase):
         load_low_level.side_effect = [rec_c5, db.exceptions.NoDataFoundException, rec_40_2]
 
         resp = self.client.get('api/v1/low-level?recording_ids=' + params)
-        self.assert200(resp)
+        self.assertEqual(resp.status_code, 200)
 
         expected_result = {
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
             "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2},
         }
-        self.assertDictEqual(resp.json, expected_result)
+        self.assertEqual(resp.json, expected_result)
 
         calls = [mock.call("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
                  mock.call("7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 3),
@@ -192,7 +192,7 @@ class CoreViewsTestCase(ServerTestCase):
         manyids = [str(uuid.uuid4()) for i in range(205)]
         limit_exceed_url = ";".join(manyids)
         resp = self.client.get('api/v1/low-level?recording_ids=' + limit_exceed_url)
-        self.assert400(resp)
+        self.assertEqual(resp.status_code, 400)
         self.assertEqual('More than 200 recordings not allowed per request', resp.json['message'])
 
     @mock.patch('db.data.load_high_level')
@@ -286,7 +286,7 @@ class CoreViewsTestCase(ServerTestCase):
 
         for mbid in mbids:
             resp = self.client.get('api/v1/%s/count' % mbid)
-            self.assert200(resp)
+            self.assertEqual(resp.status_code, 200)
             self.assertDictEqual(resp.json,
                                  {"mbid": mbid,
                                   "count": expected_result[mbid]})
@@ -294,12 +294,12 @@ class CoreViewsTestCase(ServerTestCase):
     def test_get_bulk_count_no_param(self):
         # No parameter in bulk lookup results in an error
         resp = self.client.get('api/v1/count')
-        self.assert400(resp)
+        self.assertEqual(resp.status_code, 400)
 
     def test_get_bulk_count(self):
         mbids = self.submit_fake_data()
         resp = self.client.get('api/v1/count?recording_ids=' + ';'.join(mbids))
-        self.assert200(resp)
+        self.assertEqual(resp.status_code, 200)
 
         expected_result = {
             "7f27d7a9-27f0-4663-9d20-2c9c40200e6d": {"count": 1},
@@ -312,7 +312,7 @@ class CoreViewsTestCase(ServerTestCase):
         manyids = [str(uuid.uuid4()) for i in range(205)]
         limit_exceed_url = ";".join(manyids)
         resp = self.client.get('api/v1/count?recording_ids=' + limit_exceed_url)
-        self.assert400(resp)
+        self.assertEqual(resp.status_code, 400)
         self.assertEqual('More than 200 recordings not allowed per request',
                          resp.json['message'])
 


### PR DESCRIPTION
This is a...
- [ ]   Bug Fix
- [x]          Feature addition
- [ ]          Refactoring
- [ ]          Minor / simple change (like a typo)
- [ ]          Other

**Present Case:** 
We don't have any feature which provides high-level data with one request for many `recording ids`.

**Solution:**
I have added a feature through which we can fetch JSON documents for a list of MusicBrainz recording IDs for high-level data.
The user can construct the endpoint (Suppose for a list of 3 MBIDs) for high-level data by:
 GET https://acousticbrainz.org/api/v1/high-level?recording_ids=mbid;mbid;mbid