### PR TITLE
Make testing faster

### DIFF
--- a/docker/docker-compose.jenkins.yml
+++ b/docker/docker-compose.jenkins.yml
@@ -1,0 +1,36 @@
+# Docker Compose file for test
+version: "2"
+services:
+
+  db:
+    image: postgres:9.5.4
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+      - "15431:5432"
+    command: postgres -F
+
+  acousticbrainz:
+    build:
+      context: ..
+      dockerfile: ./docker/Dockerfile.dev
+    depends_on:
+      - db
+      - redis
+
+  redis:
+    image: redis:4.0-alpine
+
+  hl_extractor:
+    build:
+      context: ..
+      dockerfile: ./docker/Dockerfile.gaia
+    depends_on:
+      - db
+
+  dataset_evaluator:
+    build:
+      context: ..
+      dockerfile: ./docker/Dockerfile.gaia
+    depends_on:
+      - db

--- a/docker/docker-compose.jenkins.yml
+++ b/docker/docker-compose.jenkins.yml
@@ -24,13 +24,13 @@ services:
   hl_extractor:
     build:
       context: ..
-      dockerfile: ./docker/Dockerfile.gaia
+      dockerfile: ./docker/Dockerfile.dev
     depends_on:
       - db
 
   dataset_evaluator:
     build:
       context: ..
-      dockerfile: ./docker/Dockerfile.gaia
+      dockerfile: ./docker/Dockerfile.dev
     depends_on:
       - db

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,4 +1,4 @@
-# Docker Compose file for development
+# Docker Compose file for test
 version: "2"
 services:
 
@@ -8,13 +8,14 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
     ports:
       - "15431:5432"
+    command: postgres -F
 
   acousticbrainz:
     build:
       context: ..
       dockerfile: ./docker/Dockerfile.dev
-    ports:
-      - "8082:8080"
+    volumes:
+      - ..:/code:z
     depends_on:
       - db
       - redis

--- a/test.sh
+++ b/test.sh
@@ -122,11 +122,11 @@ if [ $DB_EXISTS -eq 1 -a $DB_RUNNING -eq 1 ]; then
     setup
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
-                   run --rm acousticbrainz py.test -s
+                   run --rm acousticbrainz pytest -s "$@"
     dcdown
 else
     # Else, we have containers, just run tests
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
-                   run --rm acousticbrainz py.test -s
+                   run --rm acousticbrainz pytest -s "$@"
 fi


### PR DESCRIPTION
Disable fsync in postgres to make tests run faster
Mount source code into the test volume so that you don't have to build the image each time you test
Add the ability to pass arguments to pytest from test.sh