### PR TITLE
 Replace use of deprecated Exception.message with str(exception)

### DIFF
--- a/db/dataset_eval.py
+++ b/db/dataset_eval.py
@@ -340,11 +340,14 @@ def get_remote_pending_jobs_for_user(user_id):
 class IncompleteDatasetException(db.exceptions.DatabaseException):
     pass
 
+
 class IncorrectJobStatusException(db.exceptions.DatabaseException):
     pass
 
+
 class JobNotFoundException(db.exceptions.DatabaseException):
     pass
+
 
 class JobExistsException(db.exceptions.DatabaseException):
     """Should be raised when trying to add a job for dataset that already has one."""

--- a/db/exceptions.py
+++ b/db/exceptions.py
@@ -2,9 +2,11 @@ class DatabaseException(Exception):
     """Base exception for this package."""
     pass
 
+
 class NoDataFoundException(DatabaseException):
     """Should be used when no data has been found."""
     pass
+
 
 class BadDataException(DatabaseException):
     """Should be used when incorrect data is being submitted."""

--- a/db/test/test_dataset.py
+++ b/db/test/test_dataset.py
@@ -121,7 +121,7 @@ class DatasetTestCase(DatabaseTestCase):
             dataset.update_dataset_meta(dsid, {"name": "new name", "badkey": "badvalue"})
             self.fail("Shouldn't get here")
         except ValueError as e:
-            self.assertEqual(e.message, "Unexpected meta value(s): badkey")
+            self.assertEqual(str(e), "Unexpected meta value(s): badkey")
 
     def test_get_by_user_id(self):
         dataset.create_from_dict(self.test_data, author_id=self.test_user_id)

--- a/utils/test/test_dataset_validator.py
+++ b/utils/test/test_dataset_validator.py
@@ -8,33 +8,28 @@ class DatasetValidatorTestCase(unittest.TestCase):
         """ Validator for requests to add or delete recordings from a class """
 
         # not a dictionary
-        with self.assertRaises(dataset_validator.ValidationException) as e:
-            out = e
+        with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_recordings_add_delete("not_dictionary")
-        self.assertEqual(out.exception.message, "Request must be a dictionary.")
+        self.assertEqual(str(out.exception), "Request must be a dictionary.")
 
         # missing a required element
-        with self.assertRaises(dataset_validator.ValidationException) as e:
-            out = e
+        with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_recordings_add_delete({"class_name": "Test"})
-        self.assertEqual(out.exception.message, "Field `recordings` is missing from recordings dictionary.")
+        self.assertEqual(str(out.exception), "Field `recordings` is missing from recordings dictionary.")
 
-        with self.assertRaises(dataset_validator.ValidationException) as e:
-            out = e
+        with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_recordings_add_delete({"class_name": "Test", "recordings": [], "other": None})
-        self.assertEqual(out.exception.message, "Unexpected field `other` in recordings dictionary.")
+        self.assertEqual(str(out.exception), "Unexpected field `other` in recordings dictionary.")
 
         # recordings not a list
-        with self.assertRaises(dataset_validator.ValidationException) as e:
-            out = e
+        with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_recordings_add_delete({"class_name": "Test", "recordings": "notlist"})
-        self.assertEqual(out.exception.message, 'Field `recordings` in class "Test" is not a list.')
+        self.assertEqual(str(out.exception), 'Field `recordings` in class "Test" is not a list.')
 
         # recording item not a uuid
-        with self.assertRaises(dataset_validator.ValidationException) as e:
-            out = e
+        with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_recordings_add_delete({"class_name": "Test", "recordings": [1]})
-        self.assertEqual(out.exception.message, '"1" is not a valid recording MBID in class "Test".')
+        self.assertEqual(str(out.exception), '"1" is not a valid recording MBID in class "Test".')
 
         # all ok
         dataset_validator.validate_recordings_add_delete({"class_name": "Test", "recordings": ["cc355a8a-1cf0-4eda-a693-fd38dc1dd4e2"]})
@@ -44,10 +39,9 @@ class DatasetValidatorTestCase(unittest.TestCase):
         # Class validation is also tested in other tests below
 
         # recordings required depending on flag
-        with self.assertRaises(dataset_validator.ValidationException) as e:
-            out = e
+        with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_class({"name": "Test", "description": "Desc"}, recordings_required=True)
-        self.assertEqual(out.exception.message, "Field `recordings` is missing from class.")
+        self.assertEqual(str(out.exception), "Field `recordings` is missing from class.")
 
         # Required=False, no error
         dataset_validator.validate_class({"name": "Test", "description": "Desc"}, recordings_required=False)

--- a/webserver/views/api/exceptions.py
+++ b/webserver/views/api/exceptions.py
@@ -11,6 +11,9 @@ class APIError(Exception):
         rv['message'] = self.message
         return rv
 
+    def __str__(self):
+        return self.message
+
 
 class APINotFound(APIError):
     def __init__(self, message, payload=None):

--- a/webserver/views/api/v1/datasets.py
+++ b/webserver/views/api/v1/datasets.py
@@ -75,7 +75,7 @@ def create_dataset():
     try:
         dataset_id = db.dataset.create_from_dict(dataset_dict, current_user.id)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(e.message)
+        raise api_exceptions.APIBadRequest(str(e))
 
     return jsonify(
         success=True,
@@ -127,7 +127,7 @@ def update_dataset_details(dataset_id):
     try:
         dataset_validator.validate_dataset_update(dataset_data)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(e.message)
+        raise api_exceptions.APIBadRequest(str(e))
 
     db.dataset.update_dataset_meta(ds["id"], dataset_data)
     return jsonify(
@@ -172,7 +172,7 @@ def add_class(dataset_id):
     try:
         dataset_validator.validate_class(class_dict, recordings_required=False)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(e.message)
+        raise api_exceptions.APIBadRequest(str(e))
 
     if "recordings" in class_dict:
         unique_mbids = list(set(class_dict["recordings"]))
@@ -214,7 +214,7 @@ def update_class(dataset_id):
     try:
         dataset_validator.validate_class_update(class_data)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(e.message)
+        raise api_exceptions.APIBadRequest(str(e))
 
     try:
         db.dataset.update_class(ds["id"], class_data["name"], class_data)
@@ -222,7 +222,7 @@ def update_class(dataset_id):
         # NoDataFoundException is raised if the class name doesn't exist in this dataset.
         # We treat this as a bad request, because it's based on data in the request body,
         # and not the url
-        raise api_exceptions.APIBadRequest(e.message)
+        raise api_exceptions.APIBadRequest(str(e))
 
     return jsonify(
         success=True,
@@ -254,7 +254,7 @@ def delete_class(dataset_id):
     try:
         dataset_validator.validate_class(class_dict, recordings_required=False)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(e.message)
+        raise api_exceptions.APIBadRequest(str(e))
 
     db.dataset.delete_class(ds["id"], class_dict)
     return jsonify(
@@ -288,7 +288,7 @@ def add_recordings(dataset_id):
     try:
         dataset_validator.validate_recordings_add_delete(class_dict)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(e.message)
+        raise api_exceptions.APIBadRequest(str(e))
 
     unique_mbids = list(set(class_dict["recordings"]))
     class_dict["recordings"] = unique_mbids
@@ -299,7 +299,7 @@ def add_recordings(dataset_id):
         # NoDataFoundException is raised if the class name doesn't exist in this dataset.
         # We treat this as a bad request, because it's based on data in the request body,
         # and not the url
-        raise api_exceptions.APIBadRequest(e.message)
+        raise api_exceptions.APIBadRequest(str(e))
 
     return jsonify(
         success=True,
@@ -332,7 +332,7 @@ def delete_recordings(dataset_id):
     try:
         dataset_validator.validate_recordings_add_delete(class_dict)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(e.message)
+        raise api_exceptions.APIBadRequest(str(e))
 
     unique_mbids = list(set(class_dict["recordings"]))
     class_dict["recordings"] = unique_mbids
@@ -343,7 +343,7 @@ def delete_recordings(dataset_id):
         # NoDataFoundException is raised if the class name doesn't exist in this dataset.
         # We treat this as a bad request, because it's based on data in the request body,
         # and not the url
-        raise api_exceptions.APIBadRequest(e.message)
+        raise api_exceptions.APIBadRequest(str(e))
 
     return jsonify(
         success=True,

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -265,15 +265,15 @@ class GetBulkValidationTest(unittest.TestCase):
 
         params = "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9:-1:another"
         with self.assertRaises(webserver.views.api.exceptions.APIBadRequest) as ex:
-            validated = core._parse_bulk_params(params)
-        self.assertEquals(ex.exception.message, "More than 1 : in 'c5f4909e-1d7b-4f15-a6f6-1af376bc01c9:-1:another'")
+            core._parse_bulk_params(params)
+        self.assertEquals(str(ex.exception), "More than 1 : in 'c5f4909e-1d7b-4f15-a6f6-1af376bc01c9:-1:another'")
 
     def test_validate_bulk_params_bad_mbid(self):
         # Return an error if an MBID is invalid
         params = "c5f4909e-1d7b-4f15-a6f6-1af376xxxx:1"
         with self.assertRaises(webserver.views.api.exceptions.APIBadRequest) as ex:
-            validated = core._parse_bulk_params(params)
-        self.assertEquals(ex.exception.message, "'c5f4909e-1d7b-4f15-a6f6-1af376xxxx' is not a valid UUID")
+            core._parse_bulk_params(params)
+        self.assertEquals(str(ex.exception), "'c5f4909e-1d7b-4f15-a6f6-1af376xxxx' is not a valid UUID")
 
     def test_validate_bulk_params_deduplicate(self):
         # If the same mbid:offset is provided more than once, only return one

--- a/webserver/views/api/v1/test/test_datasets.py
+++ b/webserver/views/api/v1/test/test_datasets.py
@@ -242,7 +242,7 @@ class APIDatasetViewsTestCase(ServerTestCase):
         self.assertEqual(resp.json, expected_result)
 
     @mock.patch("db.dataset.get")
-    def test_update_dataset_details_bad_uuid(self, dataset_get):
+    def test_update_dataset_details_unknown_error(self, dataset_get):
         self.temporary_login(self.test_user_id)
         dsid = "e01f7638-3902-4bd4-afda-ac73d240a4b3"
 
@@ -577,7 +577,7 @@ class APIDatasetViewsTestCase(ServerTestCase):
         self.assertEqual(resp.json, expected)
 
     @mock.patch("db.dataset.get")
-    def test_add_recordings_invalid_data(self, dataset_get):
+    def test_delete_recordings_invalid_data(self, dataset_get):
         """ Invalid data results in a 400 and query is not made """
 
         self.temporary_login(self.test_user_id)

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -175,7 +175,7 @@ def evaluate(dataset_id):
             )
             flash.info("Dataset %s has been added into evaluation queue." % ds["id"])
         except db.dataset_eval.IncompleteDatasetException as e:
-            flash.error("Cannot add this dataset because of a validation error: %s" % e.message)
+            flash.error("Cannot add this dataset because of a validation error: %s" % e)
         except db.dataset_eval.JobExistsException:
             flash.warn("An evaluation job for this dataset has been already created.")
         return redirect(url_for(".eval_info", dataset_id=dataset_id))


### PR DESCRIPTION
pytest was reporting warnings of the form:

```
db/test/test_dataset.py::DatasetTestCase::test_update_dataset_meta_badmeta
  /code/db/test/test_dataset.py:124: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
    self.assertEqual(e.message, "Unexpected meta value(s): badkey")
```
due to `exception.message` being deprecated. Move all the cases where we use this to `str(exception)`, which is the new accepted way. This gets the contents of the first argument passed to the exception handler.

