### PR TITLE
Upgrade JS dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,24 +13,24 @@
     "babel-plugin-transform-react-jsx": "6.24.1",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-stage-2": "6.24.1",
-    "babelify": "7.3.0",
+    "babelify": "8.0.0",
     "bootstrap": "3.3.7",
     "gulp": "3.9.1",
-    "gulp-less": "3.3.2",
-    "gulp-rev": "8.0.0",
+    "gulp-less": "4.0.0",
+    "gulp-rev": "8.1.1",
     "gulp-streamify": "1.0.2",
     "highcharts": "4.2.0",
-    "jquery": "2.1.4",
+    "jquery": "3.3.1",
     "less-plugin-clean-css": "1.5.1",
-    "lodash": "3.10.1",
-    "q": "1.5.0",
+    "lodash": "4.17.5",
+    "q": "1.5.1",
     "react": "0.14.7",
     "react-dom": "0.14.7",
     "vinyl-source-stream": "1.1.0",
     "yarb": "0.8.0"
   },
   "devDependencies": {
-    "gulp-watch": "4.3.11"
+    "gulp-watch": "5.0.0"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "gulp-less": "4.0.0",
     "gulp-rev": "8.1.1",
     "gulp-streamify": "1.0.2",
-    "highcharts": "4.2.0",
+    "highcharts": "6.0.7",
     "jquery": "3.3.1",
     "less-plugin-clean-css": "1.5.1",
     "lodash": "4.17.5",
     "q": "1.5.1",
     "react": "0.14.7",
     "react-dom": "0.14.7",
-    "vinyl-source-stream": "1.1.0",
+    "vinyl-source-stream": "2.0.0",
     "yarb": "0.8.0"
   },
   "devDependencies": {

--- a/webserver/static/scripts/stats.js
+++ b/webserver/static/scripts/stats.js
@@ -1,1 +1,1 @@
-require("highcharts/lib/highstock");
+require("highcharts/highstock");


### PR DESCRIPTION
Upgrade JS dependences as listed by `npm outdated`
Tested that gulp still generates the bundle as expected, and js parts of the site work.

Leaving React for now, as it will require code changes to do the upgrade.