### PR TITLE
AB-327: Validate dataset structure before submitting for evaluation and dataset contents after.

### DIFF
--- a/db/dataset_eval.py
+++ b/db/dataset_eval.py
@@ -76,10 +76,10 @@ def _job_exists(connection, dataset_id):
         SELECT count(*)
           FROM dataset_eval_jobs
           JOIN dataset_snapshot ON dataset_snapshot.id = dataset_eval_jobs.snapshot_id
-         WHERE dataset_snapshot.dataset_id = :dataset_id AND dataset_eval_jobs.status IN :statses
+         WHERE dataset_snapshot.dataset_id = :dataset_id AND dataset_eval_jobs.status IN :statuses
     """), {
         "dataset_id": dataset_id,
-        "statses": (STATUS_PENDING, STATUS_RUNNING),
+        "statuses": (STATUS_PENDING, STATUS_RUNNING),
     })
     return result.fetchone()[0] > 0
 

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -161,6 +161,13 @@ def evaluate(dataset_id):
         flash.warn("Evaluation job for this dataset has been already created.")
         return redirect(url_for(".eval_info", dataset_id=dataset_id))
 
+    # Validate dataset structure before choosing evaluation preferences
+    try:
+        db.dataset_eval.validate_dataset_structure(ds)
+    except db.dataset_eval.IncompleteDatasetException as e:
+        flash.error("Cannot add this dataset because of a validation error: %s" % e)
+        return redirect(url_for("datasets.view", id=dataset_id))
+
     form = forms.DatasetEvaluationForm()
 
     if form.validate_on_submit():


### PR DESCRIPTION
This is a...
- [x]   Bug Fix
- [ ]          Feature addition
- [ ]          Refactoring
- [ ]          Minor / simple change (like a typo)
- [ ]          Other

**Present case:** 
We are not able to validate the structure of the dataset before submitting it for evaluation.

**Solution:**
Validating the dataset previously and show the user the warning before the user has the option to submit the dataset for evaluation and validating dataset contents after submitting the dataset.