### PR TITLE
AB-334: Setup to directly access MusicBrainz Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,71 @@ In order to load a psql session, use the following command:
 
     ./develop.sh run --rm db psql -U acousticbrainz -h db
 
+### Setup the MusicBrainz Server
+
+MusicBrainz database containing all the MusicBrainz metadata is needed for
+setting up your application. The ``mbdump.tar.bz2`` is the core MusicBrainz
+archive which includes the tables for artist, release_group etc.
+The ``mbdump-derived.tar.bz2`` archive contains annotations, user tags and search indexes.
+These archives include all the data required for setting up an instance of
+AcousticBrainz.
+
+You can import the database dump by downloading and importing the data in
+a single command::
+
+    $ docker-compose -f docker/docker-compose.dev.yml run musicbrainz_db
+
+.. note::
+
+ One can also manually download the dumps and then import it:-
+
+  i. For this, you have to download the dumps ``mbdump.tar.bz2`` and ``mbdump-derived.tar.bz2``
+     from http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/.
+
+     .. warning::
+
+        Make sure to get the latest dumps
+
+  ii. Then the environment variable ``DUMPS_DIR`` must be set to the path of the
+      folders containing the dumps. This can be done by::
+
+        $ export DUMPS_DIR="Path of the folder containing the dumps"
+
+      You can check that the variable ``DUMPS_DIR`` has been succesfully assigned or not by::
+
+        $ echo $DUMPS_DIR
+
+      This must display the path of your folder containing the database dumps. The folder must contain at least the file ``mbdump.tar.bz2``.
+
+  iii. Then import the database dumps by this command::
+
+        $ docker-compose -f docker/docker-compose.dev.yml run -v $DUMPS_DIR:/home/musicbrainz/dumps \
+        -v $PWD/data/mbdata:/var/lib/postgresql/data/pgdata musicbrainz_db
+
+.. note::
+
+  You can also use the smaller sample dumps available at http://ftp.musicbrainz.org/pub/musicbrainz/data/sample/
+  to set up the MusicBrainz database. However, note that these dumps are .tar.xz
+  dumps while AcousticBrainz currently only supports import of .tar.bz2 dumps.
+  So, a decompression of the sample dumps and recompression into .tar.bz2 dumps
+  will be needed. This can be done using the following command
+
+      $ xzcat mbdump-sample.tar.xz | bzip2 > mbdump.tar.bz2
+
+.. warning::
+
+   Keep in mind that this process is very time consuming, so make sure that you don't delete
+   the ``data/mbdata`` directory accidently. Also make sure that you have about 25GB of free
+   space to keep the MusicBrainz data.
+
+Initialization of AcousticBrainz database is also required:
+
+$ ./develop.sh run --rm  webserver python2 manage.py init_db
+
+Then you can start all the services:
+
+$ ./develop.sh up --build
+
 ### Manually
 
 Full installation instructions are available in [INSTALL.md](https://github.com/metabrainz/acousticbrainz-server/blob/master/INSTALL.md) file. After installing, continue the following steps.

--- a/README.md
+++ b/README.md
@@ -47,61 +47,59 @@ The ``mbdump-derived.tar.bz2`` archive contains annotations, user tags and searc
 These archives include all the data required for setting up an instance of
 AcousticBrainz.
 
-You can import the database dump by downloading and importing the data in
-a single command::
+You can import the database dumps by downloading and importing the data in
+a single command:
 
-    $ docker-compose -f docker/docker-compose.dev.yml run musicbrainz_db
+    docker-compose -f docker/docker-compose.dev.yml run musicbrainz_db
 
-.. note::
+**Note**
 
- One can also manually download the dumps and then import it:-
+One can also manually download the dumps and then import it:-
 
-  i. For this, you have to download the dumps ``mbdump.tar.bz2`` and ``mbdump-derived.tar.bz2``
+  1. For this, you have to download the dumps ``mbdump.tar.bz2`` and ``mbdump-derived.tar.bz2``
      from http://ftp.musicbrainz.org/pub/musicbrainz/data/fullexport/.
 
-     .. warning::
+       **Warning**
 
-        Make sure to get the latest dumps
+       Make sure to get the latest dumps
 
-  ii. Then the environment variable ``DUMPS_DIR`` must be set to the path of the
-      folders containing the dumps. This can be done by::
+  2. Then the environment variable ``DUMPS_DIR`` must be set to the path of the
+     folders containing the dumps. This can be done by:
 
-        $ export DUMPS_DIR="Path of the folder containing the dumps"
+         export DUMPS_DIR="Path of the folder containing the dumps"
 
-      You can check that the variable ``DUMPS_DIR`` has been succesfully assigned or not by::
+     You can check that the variable ``DUMPS_DIR`` has been succesfully assigned or not by:
 
-        $ echo $DUMPS_DIR
+         echo $DUMPS_DIR
 
-      This must display the path of your folder containing the database dumps. The folder must contain at least the file ``mbdump.tar.bz2``.
+      This must display the path of your folder containing the database dumps. The folder must contain at least the file    ``mbdump.tar.bz2``.
 
-  iii. Then import the database dumps by this command::
+  3. Then import the database dumps by this command:
 
-        $ docker-compose -f docker/docker-compose.dev.yml run -v $DUMPS_DIR:/home/musicbrainz/dumps \
-        -v $PWD/data/mbdata:/var/lib/postgresql/data/pgdata musicbrainz_db
+         docker-compose -f docker/docker-compose.dev.yml run -v $DUMPS_DIR:/home/musicbrainz/dumps \
+         -v $PWD/data/mbdata:/var/lib/postgresql/data/pgdata musicbrainz_db
 
-.. note::
+**Note**
 
   You can also use the smaller sample dumps available at http://ftp.musicbrainz.org/pub/musicbrainz/data/sample/
   to set up the MusicBrainz database. However, note that these dumps are .tar.xz
   dumps while AcousticBrainz currently only supports import of .tar.bz2 dumps.
   So, a decompression of the sample dumps and recompression into .tar.bz2 dumps
-  will be needed. This can be done using the following command
+  will be needed. This can be done using the following command:
 
-      $ xzcat mbdump-sample.tar.xz | bzip2 > mbdump.tar.bz2
+     xzcat mbdump-sample.tar.xz | bzip2 > mbdump.tar.bz2
 
-.. warning::
+**Warning**
 
-   Keep in mind that this process is very time consuming, so make sure that you don't delete
-   the ``data/mbdata`` directory accidently. Also make sure that you have about 25GB of free
-   space to keep the MusicBrainz data.
+Keep in mind that this process is very time consuming, so make sure that you don't delete the ``data/mbdata`` directory accidently. Also make sure that you have about 25GB of free space to keep the MusicBrainz data.
 
 Initialization of AcousticBrainz database is also required:
 
-$ ./develop.sh run --rm  webserver python2 manage.py init_db
+    ./develop.sh run --rm  webserver python2 manage.py init_db
 
 Then you can start all the services:
 
-$ ./develop.sh up --build
+    ./develop.sh up --build
 
 ### Manually
 

--- a/default_config.py
+++ b/default_config.py
@@ -14,7 +14,7 @@ SECRET_KEY = "CHANGE_ME"
 SQLALCHEMY_DATABASE_URI = "postgresql://acousticbrainz@db/acousticbrainz"
 
 # MusicBrainz Database
-MB_DATABASE_URI = "postgresql://musicbrainz:musicbrainz@musicbrainz_database:5432/musicbrainz_database"
+MB_DATABASE_URI = "postgresql://musicbrainz:musicbrainz@musicbrainz_db:5432/musicbrainz_db"
 
 # URI to connect to an empty database as the superuser
 POSTGRES_ADMIN_URI = "postgresql://postgres@db/template1"

--- a/default_config.py
+++ b/default_config.py
@@ -13,6 +13,9 @@ SECRET_KEY = "CHANGE_ME"
 # Primary database
 SQLALCHEMY_DATABASE_URI = "postgresql://acousticbrainz@db/acousticbrainz"
 
+# MusicBrainz Database
+MB_DATABASE_URI = "postgresql://musicbrainz:musicbrainz@musicbrainz_database:5432/musicbrainz_database"
+
 # URI to connect to an empty database as the superuser
 POSTGRES_ADMIN_URI = "postgresql://postgres@db/template1"
 # URI to connect to the acousticbrainz database as the superuser (to install extensions)

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -23,12 +23,12 @@ services:
     depends_on:
       - db
       - redis
-      - musicbrainz_database
+      - musicbrainz_db
 
   redis:
     image: redis:4.0-alpine
 
-  musicbrainz_database:
+  musicbrainz_db:
     image: metabrainz/musicbrainz-test-database:schema-change-2017-q2
     volumes:
       - ../data/mbdata:/var/lib/postgresql/data/pgdata

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -23,9 +23,20 @@ services:
     depends_on:
       - db
       - redis
+      - musicbrainz_database
 
   redis:
     image: redis:4.0-alpine
+
+  musicbrainz_database:
+    image: metabrainz/musicbrainz-test-database:schema-change-2017-q2
+    volumes:
+      - ../data/mbdata:/var/lib/postgresql/data/pgdata
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      MB_IMPORT_DUMPS: "true"
+    ports:
+      - "5430:5432"
 
   hl_extractor:
     build:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/rsh7/brainzutils-python.git@7c3366d8a432afe4b04438cfb86dc004310b70dd
+git+https://github.com/metabrainz/brainzutils-python.git@v1.5.0
 click == 6.7
 coverage == 4.5.1
 Fabric == 1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/metabrainz/brainzutils-python.git@v1.4.2
+git+https://github.com/rsh7/brainzutils-python.git@82e0ceab9ac19a253273e6185a7bcadc7b0f3248
 click == 6.7
 coverage == 4.5.1
 Fabric == 1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/rsh7/brainzutils-python.git@82e0ceab9ac19a253273e6185a7bcadc7b0f3248
+git+https://github.com/rsh7/brainzutils-python.git@7c3366d8a432afe4b04438cfb86dc004310b70dd
 click == 6.7
 coverage == 4.5.1
 Fabric == 1.14.0

--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -50,6 +50,10 @@ def create_app(debug=None, config_path=None):
     from db import init_db_engine
     init_db_engine(app.config['SQLALCHEMY_DATABASE_URI'])
 
+    # MusicBrainz Database
+    from brainzutils import musicbrainz_db
+    musicbrainz_db.init_db_engine(app.config.get('MB_DATABASE_URI'))
+
     # Cache
     if 'REDIS_HOST' in app.config and\
        'REDIS_PORT' in app.config and\


### PR DESCRIPTION
Setup in AB to access the MB database. The metabrainz/musicbrainz-test-docker image is use to add the container.