### PR TITLE
AB-340: Import MusicBrainz data in a separate musicbrainz schema in AB database

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Then you can start all the services:
 
     ./develop.sh run --rm  webserver python2 manage.py init_mb_db
 
+## Import the MusicBrainz database in AcousticBrainz database:
+
+    ./develop.sh run --rm  webserver python2 manage.py import_musicbrainz_db
+
 ### Manually
 
 Full installation instructions are available in [INSTALL.md](https://github.com/metabrainz/acousticbrainz-server/blob/master/INSTALL.md) file. After installing, continue the following steps.

--- a/db/import_mb_data.py
+++ b/db/import_mb_data.py
@@ -3,1128 +3,1510 @@ from brainzutils import musicbrainz_db
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
+
+def load_artist_credit(connection, gids_in_AB):
+    artist_credit_query = text("""
+        SELECT DISTINCT artist_credit.id, artist_credit.name, artist_credit.artist_count,
+                artist_credit.ref_count, artist_credit.created
+                FROM artist_credit
+                INNER JOIN recording
+                ON artist_credit.id = recording.artist_credit
+                WHERE recording.gid in :gids OR artist_credit.id in :data
+    """)
+    MB_release_fk_artist_credit = []
+    for value in MB_release_data:
+        MB_release_fk_artist_credit.append(value[3])
+    MB_release_fk_artist_credit = list(set(MB_release_fk_artist_credit))
+
+    result = connection.execute(artist_credit_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_release_fk_artist_credit)})
+    global MB_artist_credit_data
+    MB_artist_credit_data = result.fetchall()
+
+
+def load_artist_type(connection, gids_in_AB):
+    artist_type_query = text("""
+        SELECT DISTINCT artist_type.id,
+                artist_type.name,
+                artist_type.parent,
+                artist_type.child_order,
+                artist_type.description,
+                artist_type.gid
+          FROM artist_type
+    INNER JOIN artist
+            ON artist.type = artist_type.id
+    INNER JOIN artist_credit
+            ON artist.id = artist_credit.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(artist_type_query, {'gids': tuple(gids_in_AB)})
+    global MB_artist_type_data
+    MB_artist_type_data = result.fetchall()
+
+
+def load_area_type(connection, gids_in_AB):
+    area_type_query =   text("""
+        SELECT DISTINCT area_type.id,
+               area_type.name,
+               area_type.parent,
+               area_type.child_order,
+               area_type.description,
+               area_type.gid
+          FROM area_type
+    INNER JOIN area
+            ON area.type = area_type.id
+    INNER JOIN artist
+            ON area.id = artist.area
+    INNER JOIN artist_credit
+            ON artist.id = artist_credit.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(area_type_query, {'gids': tuple(gids_in_AB)})
+    global MB_area_type_data
+    MB_area_type_data = result.fetchall()
+
+
+def load_begin_area_type(connection, gids_in_AB):
+    begin_area_type_query =   text("""
+        SELECT DISTINCT area_type.id,
+               area_type.name,
+               area_type.parent,
+               area_type.child_order,
+               area_type.description,
+               area_type.gid
+          FROM area_type
+    INNER JOIN area
+            ON area.type = area_type.id
+    INNER JOIN artist
+            ON area.id = artist.begin_area
+    INNER JOIN artist_credit
+            ON artist.id = artist_credit.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(begin_area_type_query, {'gids': tuple(gids_in_AB)})
+    global MB_begin_area_type_data
+    MB_begin_area_type_data = result.fetchall()
+
+
+def load_end_area_type(connection, gids_in_AB):
+    end_area_type_query =   text("""
+        SELECT DISTINCT area_type.id,
+               area_type.name,
+               area_type.parent,
+               area_type.child_order,
+               area_type.description,
+               area_type.gid
+          FROM area_type
+    INNER JOIN area
+            ON area.type = area_type.id
+    INNER JOIN artist
+            ON area.id = artist.end_area
+    INNER JOIN artist_credit
+            ON artist.id = artist_credit.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(end_area_type_query, {'gids': tuple(gids_in_AB)})
+    global MB_end_area_type_data
+    MB_end_area_type_data = result.fetchall()
+
+
+def load_release_status(connection, gids_in_AB):
+    release_status_query = text("""
+        SELECT DISTINCT release_status.id,
+               release_status.name,
+               release_status.parent,
+               release_status.child_order,
+               release_status.description,
+               release_status.gid
+          FROM release_status
+    INNER JOIN release
+            ON release.status = release_status.id
+    INNER JOIN recording
+            ON recording.artist_credit = release.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(release_status_query, {'gids': tuple(gids_in_AB)})
+    global MB_release_status_data
+    MB_release_status_data = result.fetchall()
+
+
+def load_release_group_primary_type(connection, gids_in_AB):
+    release_group_primary_type_query = text("""
+        SELECT DISTINCT release_group_primary_type.id, release_group_primary_type.name,
+               release_group_primary_type.parent, release_group_primary_type.child_order,
+               release_group_primary_type.description, release_group_primary_type.gid
+        FROM release_group_primary_type INNER JOIN release_group
+        ON release_group_primary_type.id = release_group.type
+        INNER JOIN recording
+                ON recording.artist_credit = release_group.artist_credit
+             WHERE recording.gid in :gids OR release_group_primary_type.id in :data
+    """)
+    MB_release_group_fk_type = []
+    for value in MB_release_group_data:
+        MB_release_group_fk_type.append(value[4])
+    MB_release_group_fk_type = list(set(MB_release_group_fk_type))
+
+    result = connection.execute(release_group_primary_type_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_release_group_fk_type)})
+    global MB_release_group_primary_type_data
+    MB_release_group_primary_type_data = result.fetchall()
+
+
+def load_medium_format(connection, gids_in_AB):
+    medium_format_query = text("""
+        SELECT * FROM medium_format
+        ORDER BY id
+    """)
+    result = connection.execute(medium_format_query)
+    global MB_medium_format_data
+    MB_medium_format_data = result.fetchall()
+
+
+def load_release_packaging(connection, gids_in_AB):
+    release_packaging_query = text("""
+        SELECT DISTINCT release_packaging.id,
+               release_packaging.name,
+               release_packaging.parent,
+               release_packaging.child_order,
+               release_packaging.description,
+               release_packaging.gid
+          FROM release_packaging
+    INNER JOIN release
+            ON release.packaging = release_packaging.id
+    INNER JOIN recording
+            ON recording.artist_credit = release.artist_credit
+         WHERE recording.gid in :gids OR release_packaging.id in :data
+    """)
+    MB_release_fk_packaging = []
+    for value in MB_release_data:
+        MB_release_fk_packaging.append(value[6])
+    MB_release_fk_packaging = list(set(MB_release_fk_packaging))
+
+    result = connection.execute(release_packaging_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_release_fk_packaging)})
+    global MB_release_packaging_data
+    MB_release_packaging_data = result.fetchall()
+
+
+def load_language(connection, gids_in_AB):
+    language_query = text("""
+        SELECT DISTINCT language.id,
+               language.iso_code_2t,
+               language.iso_code_2b,
+               language.iso_code_1,
+               language.name,
+               language.frequency,
+               language.iso_code_3
+          FROM language
+    INNER JOIN release
+            ON release.language = language.id
+    INNER JOIN recording
+            ON recording.artist_credit=release.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(language_query, {'gids': tuple(gids_in_AB)})
+    global MB_language_data
+    MB_language_data = result.fetchall()
+
+
+def load_script(connection, gids_in_AB):
+    script_query = text("""
+        SELECT DISTINCT script.id,
+               script.iso_code,
+               script.iso_number,
+               script.name,
+               script.frequency
+          FROM script
+    INNER JOIN release
+            ON release.script = script.id
+    INNER JOIN recording
+            ON recording.artist_credit = release.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(script_query, {'gids': tuple(gids_in_AB)})
+    global MB_script_data
+    MB_script_data = result.fetchall()
+
+
+def load_gender(connection, gids_in_AB):
+    gender_query = text("""
+        SELECT DISTINCT gender.id,
+               gender.name,
+               gender.parent,
+               gender.child_order,
+               gender.description,
+               gender.gid
+          FROM gender
+    INNER JOIN artist
+            ON artist.gender = gender.id
+    INNER JOIN artist_credit
+            ON artist.id = artist_credit.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(gender_query, {'gids': tuple(gids_in_AB)})
+    global MB_gender_data
+    MB_gender_data = result.fetchall()
+
+
+def load_area(connection, gids_in_AB):
+    area_query = text("""
+        SELECT DISTINCT area.id,
+               area.gid,
+               area.name,
+               area.type,
+               area.edits_pending,
+               area.last_updated,
+               area.begin_date_year,
+               area.begin_date_month,
+               area.begin_date_day,
+               area.end_date_year,
+               area.end_date_month,
+               area.end_date_day,
+               area.ended,
+               area.comment
+          FROM area
+    INNER JOIN artist
+            ON area.id = artist.area
+    INNER JOIN artist_credit
+            ON artist.id = artist_credit.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(area_query, {'gids': tuple(gids_in_AB)})
+    global MB_area_data
+    MB_area_data = result.fetchall()
+
+
+def load_begin_area(connection, gids_in_AB):
+    begin_area_query = text("""
+        SELECT DISTINCT area.id,
+               area.gid,
+               area.name,
+               area.type,
+               area.edits_pending,
+               area.last_updated,
+               area.begin_date_year,
+               area.begin_date_month,
+               area.begin_date_day,
+               area.end_date_year,
+               area.end_date_month,
+               area.end_date_day,
+               area.ended,
+               area.comment
+          FROM area
+    INNER JOIN artist
+            ON area.id = artist.begin_area
+    INNER JOIN artist_credit
+            ON artist.id = artist_credit.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids OR area.id in :data
+    """)
+    MB_artist_fk_begin_area = []
+    for value in MB_artist_data:
+        MB_artist_fk_begin_area.append(value[17])
+
+    result = connection.execute(begin_area_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_artist_fk_begin_area)})
+    global MB_begin_area_data
+    MB_begin_area_data = result.fetchall()
+
+
+def load_end_area(connection, gids_in_AB):
+    end_area_query = text("""
+        SELECT DISTINCT area.id,
+               area.gid,
+               area.name,
+               area.type,
+               area.edits_pending,
+               area.last_updated,
+               area.begin_date_year,
+               area.begin_date_month,
+               area.begin_date_day,
+               area.end_date_year,
+               area.end_date_month,
+               area.end_date_day,
+               area.ended,
+               area.comment
+          FROM area
+    INNER JOIN artist
+            ON area.id = artist.end_area
+    INNER JOIN artist_credit
+            ON artist.id = artist_credit.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(end_area_query, {'gids': tuple(gids_in_AB)})
+    global MB_end_area_data
+    MB_end_area_data = result.fetchall()
+
+
+def load_artist_credit_name(connection, gids_in_AB):
+    artist_credit_name_query = text("""
+        SELECT DISTINCT artist_credit_name.artist_credit,
+               artist_credit_name.position,
+               artist_credit_name.artist,
+               artist_credit_name.name,
+               artist_credit_name.join_phrase
+          FROM artist_credit_name
+    INNER JOIN artist_credit
+            ON artist_credit_name.artist_credit = artist_credit.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(artist_credit_name_query, {'gids': tuple(gids_in_AB)})
+    global MB_artist_credit_name_data
+    MB_artist_credit_name_data = result.fetchall()
+
+
+def load_artist(connection, gids_in_AB):
+    artist_query = text("""
+        SELECT DISTINCT artist.id, artist.gid, artist.name, artist.sort_name, artist.begin_date_year,
+               artist.begin_date_month, artist.begin_date_day, artist.end_date_year, artist.end_date_month,
+               artist.end_date_day, artist.type, artist.area, artist.gender, artist.comment, artist.edits_pending,
+               artist.last_updated, artist.ended, artist.begin_area, artist.end_area
+          FROM artist
+    INNER JOIN artist_credit
+            ON artist_credit.id = artist.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids OR artist.id in :data
+    """)
+    MB_artist_credit_name_fk_artist = []
+    for value in MB_artist_credit_name_data:
+        MB_artist_credit_name_fk_artist.append(value[2])
+
+    result = connection.execute(artist_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_artist_credit_name_fk_artist)})
+    global MB_artist_data
+    MB_artist_data = result.fetchall()
+
+
+def load_artist_gid_redirect(connection, gids_in_AB):
+    artist_gid_redirect_query = text("""
+        SELECT DISTINCT artist_gid_redirect.gid,
+               artist_gid_redirect.new_id,
+               artist_gid_redirect.created
+          FROM artist_gid_redirect
+    INNER JOIN artist
+            ON artist.id = artist_gid_redirect.new_id
+    INNER JOIN artist_credit
+            ON artist.id = artist_credit.id
+    INNER JOIN recording
+            ON artist_credit.id = recording.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(artist_gid_redirect_query, {'gids': tuple(gids_in_AB)})
+    global MB_artist_gid_redirect_data
+    MB_artist_gid_redirect_data = result.fetchall()
+
+
+def load_recording(connection, gids_in_AB):
+    recording_query = text("""
+        SELECT DISTINCT recording.id, recording.gid, recording.name, recording.artist_credit,
+               recording.length, recording.comment, recording.edits_pending, recording.last_updated,
+               recording.video
+         FROM  recording
+        WHERE  recording.gid in :gids
+    """)
+    result = connection.execute(recording_query, {'gids': tuple(gids_in_AB)})
+    global MB_recording_data
+    MB_recording_data = result.fetchall()
+
+
+def load_recording_gid_redirect(connection, gids_in_AB):
+    recording_gid_redirect_query = text("""
+        SELECT DISTINCT recording_gid_redirect.gid,
+               recording_gid_redirect.new_id,
+               recording_gid_redirect.created
+          FROM recording_gid_redirect
+    INNER JOIN recording
+            ON recording.id = recording_gid_redirect.new_id
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(recording_gid_redirect_query, {'gids': tuple(gids_in_AB)})
+    global MB_recording_gid_redirect_data
+    MB_recording_gid_redirect_data = result.fetchall()
+
+
+def load_release_group(connection, gids_in_AB):
+    release_group_query = text("""
+        SELECT DISTINCT release_group.id,
+               release_group.gid,
+               release_group.name,
+               release_group.artist_credit,
+               release_group.type,
+               release_group.comment,
+               release_group.edits_pending,
+               release_group.last_updated
+          FROM release_group
+    INNER JOIN recording
+            ON recording.artist_credit = release_group.artist_credit
+         WHERE recording.gid in :gids OR release_group.id in :redirect_data OR release_group.id in :release_data
+    """)
+    MB_release_group_gid_redirect_fk_release_group = []
+    for value in MB_release_group_gid_redirect_data:
+        MB_release_group_gid_redirect_fk_release_group.append(value[1])
+    MB_release_group_gid_redirect_fk_release_group = list(set(MB_release_group_gid_redirect_fk_release_group))
+
+    MB_release_fk_release_group = []
+    for value in MB_release_data:
+        MB_release_fk_release_group.append(value[4])
+    MB_release_fk_release_group = list(set(MB_release_fk_release_group))
+
+    result = connection.execute(release_group_query, {'gids': tuple(gids_in_AB),
+                                                      'redirect_data': tuple(MB_release_group_gid_redirect_fk_release_group),
+                                                      'release_data': tuple(MB_release_fk_release_group)})
+    global MB_release_group_data
+    MB_release_group_data = result.fetchall()
+
+
+def load_release_group_gid_redirect(connection, gids_in_AB):
+    release_group_gid_redirect_query = text("""
+        SELECT DISTINCT release_group_gid_redirect.gid,
+               release_group_gid_redirect.new_id,
+               release_group_gid_redirect.created
+          FROM release_group_gid_redirect
+    INNER JOIN release_group
+            ON release_group.id = release_group_gid_redirect.new_id
+    INNER JOIN recording
+            ON recording.artist_credit = release_group.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(release_group_gid_redirect_query, {'gids': tuple(gids_in_AB)})
+    global MB_release_group_gid_redirect_data
+    MB_release_group_gid_redirect_data = result.fetchall()
+
+
+def load_release(connection, gids_in_AB):
+    release_query = text("""
+        SELECT DISTINCT release.id,
+               release.gid,
+               release.name,
+               release.artist_credit,
+               release.release_group,
+               release.status,
+               release.packaging,
+               release.language,
+               release.script,
+               release.barcode,
+               release.comment,
+               release.edits_pending,
+               release.quality,
+               release.last_updated
+          FROM release
+    INNER JOIN recording
+            ON recording.artist_credit = release.artist_credit
+         WHERE recording.gid in :gids OR release.id in :medium_data OR release.id in :redirect_data
+    """)
+    MB_medium_fk_release = []
+    for value in MB_medium_data:
+        MB_medium_fk_release.append(value[1])
+    MB_medium_fk_release = list(set(MB_medium_fk_release))
+
+    MB_release_gid_redirect_fk_release = []
+    for value in MB_release_gid_redirect_data:
+        MB_release_gid_redirect_fk_release.append(value[1])
+    MB_release_gid_redirect_fk_release = list(set(MB_release_gid_redirect_fk_release))
+
+    result = connection.execute(release_query, {'gids': tuple(gids_in_AB),
+                                                'medium_data': tuple(MB_medium_fk_release),
+                                                'redirect_data': tuple(MB_release_gid_redirect_fk_release)
+                                               })
+    global MB_release_data
+    MB_release_data = result.fetchall()
+
+
+def load_release_gid_redirect(connection, gids_in_AB):
+    release_gid_redirect_query = text("""
+        SELECT DISTINCT release_gid_redirect.gid,
+               release_gid_redirect.new_id,
+               release_gid_redirect.created
+          FROM release_gid_redirect
+    INNER JOIN release
+            ON release.id = release_gid_redirect.new_id
+    INNER JOIN recording
+            ON recording.artist_credit = release.artist_credit
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(release_gid_redirect_query, {'gids': tuple(gids_in_AB)})
+    global MB_release_gid_redirect_data
+    MB_release_gid_redirect_data = result.fetchall()
+
+
+def load_medium(connection, gids_in_AB):
+    medium_query = text("""
+        SELECT DISTINCT medium.id,
+               medium.release,
+               medium.position,
+               medium.format,
+               medium.name,
+               medium.edits_pending,
+               medium.last_updated,
+               medium.track_count
+          FROM medium
+    INNER JOIN release
+            ON release.id = medium.release
+    INNER JOIN recording
+            ON recording.artist_credit=release.artist_credit
+         WHERE recording.gid in :gids OR medium.id in :data
+    """)
+    MB_track_fk_medium = []
+    for value in MB_track_data:
+        MB_track_fk_medium.append(value[3])
+
+    result = connection.execute(medium_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_track_fk_medium)})
+    global MB_medium_data
+    MB_medium_data = result.fetchall()
+
+
+def load_track(connection, gids_in_AB):
+    track_query = text("""
+        SELECT DISTINCT track.id,
+               track.gid,
+               track.recording,
+               track.medium,
+               track.position,
+               track.number,
+               track.name,
+               track.artist_credit,
+               track.length,
+               track.edits_pending,
+               track.last_updated,
+               track.is_data_track
+          FROM track
+    INNER JOIN recording
+            ON track.recording = recording.id
+         WHERE recording.gid in :gids
+    """)
+    result = connection.execute(track_query, {'gids': tuple(gids_in_AB)})
+    global MB_track_data
+    MB_track_data = result.fetchall()
+
+
+print("--------------------------------------------------------------------------------------------------")
+
+
+# TO ACOUSTICBRAINZ
+def write_artist_credit(transaction, connection):
+    artist_credit_query = text("""
+        INSERT INTO musicbrainz.artist_credit
+            VALUES (:id, :name, :artist_count, :ref_count, :created)
+    """)
+    values = [{
+        "id" : value[0],
+        "name" : value[1],
+        "artist_count" : value[2],
+        "ref_count" : value[3],
+        "created" : value[4]} for value in MB_artist_credit_data
+    ]
+    connection.execute(artist_credit_query, values)
+    transaction.commit()
+    print("INSERTED artist_credit data\n")
+
+
+def write_artist_type(transaction, connection):
+    artist_type_query = text("""
+        INSERT INTO musicbrainz.artist_type
+            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+    """)
+    values = [{
+        "id": value[0],
+        "name" : value[01],
+        "parent" : value[2],
+        "child_order" : value[3],
+        "description" : value[4],
+        "gid" : value[5]} for value in MB_artist_type_data
+    ]
+    connection.execute(artist_type_query, values)
+    transaction.commit()
+    print("INSERTED artist_type data\n")
+
+
+def write_area_type(transaction, connection):
+    area_type_query = text("""
+        INSERT INTO musicbrainz.area_type
+            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+    """)
+    values = [{
+        "id": value[0],
+        "name": value[1],
+        "parent": value[2],
+        "child_order": value[3],
+        "description": value[4],
+        "gid": value[5]} for value in MB_area_type_data
+    ]
+    connection.execute(area_type_query, values)
+    transaction.commit()
+    print("INSERTED area_type data\n")
+
+
+def write_begin_area_type(transaction, connection):
+    begin_area_type_query = text("""
+        INSERT INTO musicbrainz.area_type
+            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+    """)
+    values = [{
+        "id": value[0],
+        "name": value[1],
+        "parent": value[2],
+        "child_order": value[3],
+        "description": value[4],
+        "gid": value[5]} for value in MB_begin_area_type_data
+    ]
+    connection.execute(begin_area_type_query, values)
+    transaction.commit()
+    print("INSERTED begin_area_type data\n")
+
+
+def write_end_area_type(transaction, connection):
+    end_area_type_query = text("""
+        INSERT INTO musicbrainz.area_type
+            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+    """)
+    values = [{
+        "id": value[0],
+        "name": value[1],
+        "parent": value[2],
+        "child_order": value[3],
+        "description": value[4],
+        "gid": value[5]} for value in MB_end_area_type_data
+    ]
+    connection.execute(end_area_type_query, values)
+    transaction.commit()
+    print("INSERTED end_area_type data\n")
+
+
+def write_release_status(transaction, connection):
+    release_status_query = text("""
+        INSERT INTO musicbrainz.release_status
+            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+    """)
+    values= [{
+        "id": value[0],
+        "name":  value[1],
+        "parent": value[2],
+        "child_order": value[3],
+        "description": value[4],
+        "gid": value[5]} for value in MB_release_status_data
+    ]
+    result = connection.execute(release_status_query, values)
+    transaction.commit()
+    print("INSERTED release_status data\n")
+
+
+def write_release_group_primary_type(transaction, connection):
+    release_group_primary_type_query = text("""
+        INSERT INTO musicbrainz.release_group_primary_type
+            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+    """)
+    values = [{
+        "id": value[0],
+        "name": value[1],
+        "parent": value[2],
+        "child_order": value[3],
+        "description": value[4],
+        "gid": value[5]} for value in MB_release_group_primary_type_data
+    ]
+    connection.execute(release_group_primary_type_query, values)
+    transaction.commit()
+    print("INSERTED release_group_primary_type data\n")
+
+
+def write_medium_format(transaction, connection):
+    medium_format_query = text("""
+        INSERT INTO musicbrainz.medium_format
+            VALUES (:id, :name, :parent, :child_order, :year, :has_discids, :description, :gid)
+    """)
+    values = [{
+        "id": value[0],
+        "name": value[1],
+        "parent": value[2],
+        "child_order": value[3],
+        "year": value[4],
+        "has_discids": value[5],
+        "description": value[6],
+        "gid": value[7]} for value in MB_medium_format_data
+    ]
+    connection.execute(text("""ALTER TABLE musicbrainz.medium_format DROP CONSTRAINT IF EXISTS medium_format_fk_parent"""))
+    connection.execute(medium_format_query, values)
+    transaction.commit()
+    print("INSERTED medium_format data\n")
+
+
+def write_release_packaging(transaction, connection):
+    release_packaging_query = text("""
+        INSERT INTO musicbrainz.release_packaging
+            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+    """)
+    values = [{
+        "id": value[0],
+        "name": value[1],
+        "parent": value[2],
+        "child_order": value[3],
+        "description": value[4],
+        "gid": value[5]} for value in MB_release_packaging_data
+    ]
+    connection.execute(release_packaging_query, values)
+    transaction.commit()
+    print("INSERTED release_packaging data\n")
+
+
+def write_language(transaction, connection):
+    language_query = text("""
+        INSERT INTO musicbrainz.language
+            VALUES (:iso_code_2t, :iso_code_2b, :iso_code_1, :name, :frequency, :iso_code_3)
+    """)
+    values = [{
+        "iso_code_2t": value[0],
+        "iso_code_2b": value[1],
+        "iso_code_1": value[2],
+        "name": value[3],
+        "frequency": value[4],
+        "iso_code_3": value[5]} for value in MB_language_data
+    ]
+    connection.execute(language_query, values)
+    transaction.commit()
+    print("INSERTED language data\n")
+
+
+def write_script(transaction, connection):
+    script_query = text("""
+        INSERT INTO musicbrainz.script
+            VALUES (:id, :iso_code, :iso_number, :name, :frequency)
+    """)
+    values = [{
+        "id": value[0],
+        "iso_code": value[1],
+        "iso_number": value[2],
+        "name": value[3],
+        "frequency": value[4]} for value in MB_script_data
+    ]
+    connection.execute(script_query, values)
+    transaction.commit()
+    print("INSERTED script data\n")
+
+
+def write_gender(transaction, connection):
+    gender_query = text("""
+        INSERT INTO musicbrainz.gender
+            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+    """)
+    values = [{
+        "id": value[0],
+        "name": value[1],
+        "parent": value[2],
+        "child_order": value[3],
+        "description": value[4],
+        "gid": value[5]} for value in MB_gender_data
+    ]
+    connection.execute(gender_query, values)
+    transaction.commit()
+    print("INSERTED gender data\n")
+
+
+def write_area(transaction, connection):
+    area_query = text("""
+        INSERT INTO musicbrainz.area
+            VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
+                    :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
+                    :ended, :comment)
+    """)
+    values = [{
+        "id": value[0],
+        "gid": value[1],
+        "name": value[2],
+        "type": value[3],
+        "edits_pending": value[4],
+        "last_updated": value[5],
+        "begin_date_year": value[6],
+        "begin_date_month": value[7],
+        "begin_date_day": value[8],
+        "end_date_year": value[9],
+        "end_date_month": value[10],
+        "end_date_day": value[11],
+        "ended": value[12],
+        "comment": value[13]} for value in MB_area_data
+    ]
+    connection.execute(area_query, values)
+    transaction.commit()
+    print("INSERTED area data\n")
+
+
+def write_begin_area(transaction, connection):
+    begin_area_query = text("""
+        INSERT INTO musicbrainz.area
+            VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
+                    :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
+                    :ended, :comment)
+    """)
+    values = [{
+        "id": value[0],
+        "gid": value[1],
+        "name": value[2],
+        "type": value[3],
+        "edits_pending": value[4],
+        "last_updated": value[5],
+        "begin_date_year": value[6],
+        "begin_date_month": value[7],
+        "begin_date_day": value[8],
+        "end_date_year": value[9],
+        "end_date_month": value[10],
+        "end_date_day": value[11],
+        "ended": value[12],
+        "comment": value[13]} for value in MB_begin_area_data
+    ]
+    connection.execute(begin_area_query, values)
+    transaction.commit()
+    print("INSERTED begin_area data\n")
+
+
+def write_end_area(transaction, connection):
+    end_area_query = text("""
+        INSERT INTO musicbrainz.area
+            VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
+                    :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
+                    :ended, :comment)
+    """)
+    values = [{
+        "id": value[0],
+        "gid": value[1],
+        "name": value[2],
+        "type": value[3],
+        "edits_pending": value[4],
+        "last_updated": value[5],
+        "begin_date_year": value[6],
+        "begin_date_month": value[7],
+        "begin_date_day": value[8],
+        "end_date_year": value[9],
+        "end_date_month": value[10],
+        "end_date_day": value[11],
+        "ended": value[12],
+        "comment": value[13]} for value in MB_end_area_data
+    ]
+    connection.execute(end_area_query, values)
+    transaction.commit()
+    print("INSERTED end_area data\n")
+
+
+def write_artist(transaction, connection):
+    artist_query = text("""
+      INSERT INTO musicbrainz.artist
+          VALUES (:id, :gid, :name, :sort_name, :begin_date_year, :begin_date_month, :begin_date_day,
+                :end_date_year, :end_date_month, :end_date_day, :type, :area, :gender, :comment, :edits_pending,
+                :last_updated, :ended, :begin_area, :end_area)
+          ON conflict do nothing
+    """)
+    values = [{
+        "id": value[0],
+        "gid": value[1],
+        "name": value[2],
+        "sort_name": value[3],
+        "begin_date_year": value[4],
+        "begin_date_month": value[5],
+        "begin_date_day": value[6],
+        "end_date_year": value[7],
+        "end_date_month": value[8],
+        "end_date_day": value[9],
+        "type": value[10],
+        "area": value[11],
+        "gender": value[12],
+        "comment": value[13],
+        "edits_pending": value[14],
+        "last_updated": value[15],
+        "ended": value[16],
+        "begin_area": value[17],
+        "end_area": value[18]} for value in MB_artist_data
+    ]
+    connection.execute(artist_query, values)
+    transaction.commit()
+    print("INSERTED artist data\n")
+
+
+def write_artist_credit_name(transaction, connection):
+    artist_credit_name_query = text("""
+        INSERT INTO musicbrainz.artist_credit_name
+            VALUES (:artist_credit, :position, :artist, :name, :join_phrase)
+    """)
+    values = [{
+        "artist_credit": value[0],
+        "position": value[1],
+        "artist": value[2],
+        "name": value[3],
+        "join_phrase": value[4]} for value in MB_artist_credit_name_data
+    ]
+    connection.execute(artist_credit_name_query, values)
+    transaction.commit()
+    print("INSERTED artist_credit_name data\n")
+
+
+def write_artist_gid_redirect(transaction, connection):
+    artist_gid_redirect_query = text("""
+        INSERT INTO musicbrainz.artist_gid_redirect
+            VALUES (:gid, :new_id, :created)
+    """)
+    values = [{
+        "gid": value[0],
+        "new_id": value[1],
+        "created": value[2]} for value in MB_artist_gid_redirect_data
+    ]
+    connection.execute(artist_gid_redirect_query, values)
+    transaction.commit()
+    print("INSERTED artist_gid_redirect data\n")
+
+
+def write_recording(transaction, connection):
+    recording_query = text("""
+        INSERT INTO musicbrainz.recording
+            VALUES (:id, :gid, :name, :artist_credit, :length, :comment, :edits_pending, :last_updated, :video)
+    """)
+    values = [{
+        "id": value[0],
+        "gid": value[1],
+        "name": value[2],
+        "artist_credit": value[3],
+        "length": value[4],
+        "comment": value[5],
+        "edits_pending": value[6],
+        "last_updated": value[7],
+        "video": value[8]} for value in MB_recording_data
+    ]
+    connection.execute(recording_query, values)
+    transaction.commit()
+    print("INSERTED recording data\n")
+
+
+def write_recording_gid_redirect(transaction, connection):
+    recording_gid_redirect_query = text("""
+        INSERT INTO musicbrainz.recording_gid_redirect
+            VALUES (:gid, :new_id, :created)
+    """)
+    values = [{"gid": value[0],
+        "new_id": value[1],
+        "created": value[2]} for value in MB_recording_gid_redirect_data
+    ]
+    connection.execute(recording_gid_redirect_query, values)
+    transaction.commit()
+    print("INSERTED recording_gid_redirect data\n")
+
+
+def write_release_group(transaction, connection):
+    release_group_query = text("""
+        INSERT INTO musicbrainz.release_group
+            VALUES (:id, :gid, :name, :artist_credit, :type, :comment, :edits_pending, :last_updated)
+    """)
+    values = [{
+        "id": value[0],
+        "gid": value[1],
+        "name": value[2],
+        "artist_credit": value[3],
+        "type": value[4],
+        "comment": value[5],
+        "edits_pending": value[6],
+        "last_updated": value[7]} for value in MB_release_group_data
+    ]
+    connection.execute(release_group_query, values)
+    transaction.commit()
+    print("INSERTED release_group data\n")
+
+
+def write_release_group_gid_redirect(transaction, connection):
+    release_group_gid_redirect_query = text("""
+        INSERT INTO musicbrainz.release_group_gid_redirect
+            VALUES (:gid, :new_id, :created)
+    """)
+    values = [{
+        "gid": value[0],
+        "new_id": value[1],
+        "created": value[2]} for value in MB_release_gid_redirect_data
+    ]
+    connection.execute(release_group_gid_redirect_query, values)
+    transaction.commit()
+    print("INSERTED release_gid_redirect data\n")
+
+
+def write_release(transaction, connection):
+    release_query = text("""
+        INSERT INTO musicbrainz.release
+            VALUES (:id, :gid, :name, :artist_credit, :release_group, :status, :packaging, :language,
+                    :script, :barcode, :comment, :edits_pending, :quality, :last_updated)
+    """)
+    values = [{
+        "id": value[0],
+        "gid": value[1],
+        "name": value[2],
+        "artist_credit": value[3],
+        "release_group": value[4],
+        "status": value[5],
+        "packaging": value[6],
+        "language": value[7],
+        "script": value[8],
+        "barcode": value[9],
+        "comment": value[10],
+        "edits_pending": value[11],
+        "quality": value[12],
+        "last_updated": value[13]} for value in MB_release_data
+    ]
+    connection.execute(release_query, values)
+    transaction.commit()
+    print("INSERTED release data\n")
+
+
+def write_release_gid_redirect(transaction, connection):
+    release_gid_redirect_query = text("""
+        INSERT INTO musicbrainz.release_gid_redirect
+            VALUES (:gid, :new_id, :created)
+    """)
+    values = [{
+        "gid": value[0],
+        "new_id": value[1],
+        "created": value[2]} for value in MB_release_gid_redirect_data
+    ]
+    connection.execute(release_gid_redirect_query, values)
+    transaction.commit()
+    print("INSERTED release_gid_redirect data\n")
+
+
+def write_medium(transaction, connection):
+    medium_query = text("""
+        INSERT INTO musicbrainz.medium
+            VALUES (:id, :release, :position, :format, :name, :edits_pending, :last_updated, :track_count)
+    """)
+    values = [{
+        "id": value[0],
+        "release": value[1],
+        "position": value[2],
+        "format": value[3],
+        "name": value[4],
+        "edits_pending": value[5],
+        "last_updated": value[6],
+        "track_count": value[7]} for value in MB_medium_data
+    ]
+    connection.execute(medium_query, values)
+    transaction.commit()
+    print("INSERTED medium data\n")
+
+
+def write_track(transaction, connection):
+    track_query = text("""
+        INSERT INTO musicbrainz.track
+            VALUES (:id, :gid, :recording, :medium, :position, :number, :name, :artist_credit, :length,
+                    :edits_pending, :last_updated, :is_data_track)
+    """)
+    values = [{
+        "id": value[0],
+        "gid": value[1],
+        "recording": value[2],
+        "medium": value[3],
+        "position": value[4],
+        "number": value[5],
+        "name": value[6],
+        "artist_credit": value[7],
+        "length": value[8],
+        "edits_pending": value[9],
+        "last_updated": value[10],
+        "is_data_track": value[11]} for value in MB_track_data
+    ]
+    connection.execute(track_query, values)
+    transaction.commit()
+    print("INSERTED track data\n")
+
+
+
+
+# FUNCTION TO CALL ALL INSERTS
+
+def insert_MB_data_AB():
+    with db.engine.connect() as connection:
+        if MB_artist_credit_data:
+            transaction = connection.begin()
+            try:
+                write_artist_credit(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_artist_type_data:
+            transaction = connection.begin()
+            try:
+                write_artist_type(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_area_type_data:
+            transaction = connection.begin()
+            try:
+                write_area_type(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_begin_area_type_data:
+            transaction = connection.begin()
+            try:
+                write_begin_area_type(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_end_area_type_data:
+            transaction = connection.begin()
+            try:
+                write_end_area_type(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_release_status_data:
+            transaction = connection.begin()
+            try:
+                write_release_status(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_release_group_primary_type_data:
+            transaction = connection.begin()
+            try:
+                write_release_group_primary_type(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_medium_format_data:
+            transaction = connection.begin()
+            try:
+                write_medium_format(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_release_packaging_data:
+            transaction = connection.begin()
+            try:
+                write_release_packaging(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_language_data:
+            transaction = connection.begin()
+            try:
+                write_language(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_script_data:
+            transaction = connection.begin()
+            try:
+                write_script(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_gender_data:
+            transaction = connection.begin()
+            try:
+                write_gender(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_area_data:
+            transaction = connection.begin()
+            try:
+                write_area(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_begin_area_data:
+            transaction = connection.begin()
+            try:
+                write_begin_area(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_end_area_data:
+            transaction = connection.begin()
+            try:
+                write_end_area(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_artist_data:
+            transaction = connection.begin()
+            try:
+                write_artist(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_artist_credit_name_data:
+            transaction = connection.begin()
+            try:
+                write_artist_credit_name(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_artist_gid_redirect_data:
+            transaction = connection.begin()
+            try:
+                write_artist_gid_redirect(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+
+        if MB_recording_data:
+            transaction = connection.begin()
+            try:
+                write_recording(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_recording_gid_redirect_data:
+            transaction = connection.begin()
+            try:
+                write_recording_gid_redirect(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_release_group_data:
+            transaction = connection.begin()
+            try:
+                write_release_group(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_release_group_gid_redirect_data:
+            transaction = connection.begin()
+            try:
+                write_release_group_gid_redirect(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_release_data:
+            transaction = connection.begin()
+            try:
+                write_release(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_release_gid_redirect_data:
+            transaction = connection.begin()
+            try:
+                write_release_gid_redirect(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_medium_data:
+            transaction = connection.begin()
+            try:
+                write_medium(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+        if MB_track_data:
+            transaction = connection.begin()
+            try:
+                write_track(transaction, connection)
+            except IntegrityError as e:
+                print(e.message)
+                transaction.rollback()
+
+
+def fetch_musicbrainz_data(gids_in_AB):
+    with musicbrainz_db.engine.begin() as connection:
+        # track
+        try:
+            load_track(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # MEDIUM
+        try:
+            load_medium(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # release_gid_redirect
+        try:
+            load_release_gid_redirect(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # RELEASE
+        try:
+            load_release(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # ARTIST CREDIT
+        try:
+            load_artist_credit(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # ARTIST CREDIT NAME
+        try:
+            load_artist_credit_name(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # ARTIST
+        try:
+            load_artist(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # ARTIST TYPE
+        try:
+            load_artist_type(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # RECORDING
+        try:
+            load_recording(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # AREA
+        try:
+            load_area(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # BEGIN AREA
+        try:
+            load_begin_area(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # END AREA
+        try:
+            load_end_area(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # AREA TYPE
+        try:
+            load_area_type(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # BEGIN AREA TYPE
+        try:
+            load_begin_area_type(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # END AREA TYPE
+        try:
+            load_end_area_type(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # ARTIST GID REDIRECT
+        try:
+            load_artist_gid_redirect(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # GENDER
+        try:
+            load_gender(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # LANGUAGE
+        try:
+            load_language(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # MEDIUM FORMAT
+        try:
+            load_medium_format(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # RECORDING GID REDIRECT
+        try:
+            load_recording_gid_redirect(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # release_group gid redirect
+        try:
+            load_release_group_gid_redirect(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # release_group
+        try:
+            load_release_group(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # release_group_primary_type
+        try:
+            load_release_group_primary_type(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # release_packaging
+        try:
+            load_release_packaging(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # release_status
+        try:
+            load_release_status(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+        # script
+        try:
+            load_script(connection, gids_in_AB)
+        except ValueError:
+            print("No Data found for the recordings")
+
+    insert_MB_data_AB()
+    print("--------------------------------DONE-----------------------------------")
+
+
 def start_import():
-    with db.engine.begin() as conn:
+    with db.engine.begin() as connection:
         lowlevel_query = text("""SELECT gid from lowlevel""")
-        gids = conn.execute(lowlevel_query)
-        gids_in_AB = gids.fetchall()
-        for recording_gid in gids_in_AB:
-            MB_artist_credit_data, MB_recording_data, MB_artist_data, MB_artist_type_data, MB_area_data, \
-            MB_script_data, MB_release_data, MB_release_group_primary_type_data, MB_medium_data, \
-            MB_track_data, MB_gender_data, MB_language_data, MB_medium_format_data, MB_release_group_data, \
-            MB_release_status_data, MB_artist_gid_redirect_data, MB_recording_gid_redirect_data, \
-            MB_release_group_gid_redirect_data, MB_release_gid_redirect_data, MB_artist_credit_name_data, \
-            MB_area_type_data, MB_release_packaging_data = (0,)*22
-
-            # FROM MUSICBRAINZ
-            with musicbrainz_db.engine.begin() as connection:
-                # ARTIST CREDIT
-                try:
-                    artist_credit_query = text("""SELECT artist_credit.id, artist_credit.name, artist_credit.artist_count,
-                                                    artist_credit.ref_count, artist_credit.created
-                                                    FROM artist_credit
-                                                    INNER JOIN recording
-                                                    ON artist_credit.id = recording.artist_credit
-                                                    WHERE recording.gid= :recording_gid
-                    """)
-                    result = connection.execute(artist_credit_query, {"recording_gid" : recording_gid[0]})
-                    MB_artist_credit_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                try:
-                    artist_query = text("""
-                        SELECT artist.id, artist.gid, artist.name, artist.sort_name, artist.begin_date_year,
-                               artist.begin_date_month, artist.begin_date_day, artist.end_date_year, artist.end_date_month,
-                               artist.end_date_day, artist.type, artist.area, artist.gender, artist.comment, artist.edits_pending,
-                               artist.last_updated, artist.ended, artist.begin_area, artist.end_area
-                          FROM artist
-                    INNER JOIN artist_credit 
-                            ON artist_credit.id = artist.id
-                    INNER JOIN recording
-                            ON artist_credit.id = recording.artist_credit
-                    WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(artist_query, {"recording_gid": recording_gid[0]})
-                    MB_artist_data = result.fetchall()
-                except ValueError:
-                    pass
-                    
-                # ARTIST TYPE
-                try:
-                    artist_type_query = text("""SELECT artist_type.id,
-                                                        artist_type.name,
-                                                        artist_type.parent,
-                               artist_type.child_order,
-                               artist_type.description,
-                               artist_type.gid
-                          FROM artist_type
-                    INNER JOIN artist
-                            ON artist.type = artist_type.id
-                    INNER JOIN artist_credit
-                            ON artist.id = artist_credit.id
-                    INNER JOIN recording
-                            ON artist_credit.id = recording.artist_credit
-                         WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(artist_type_query, {"recording_gid": recording_gid[0]})
-                    MB_artist_type_data = result.fetchall()
-                except ValueError:
-                    pass
-                    
-                # RECORDING
-                try:
-                    recording_query = text("""SELECT recording.id, recording.gid, recording.name, recording.artist_credit,
-                                          recording.length, recording.comment, recording.edits_pending, recording.last_updated,
-                                          recording.video
-                                     FROM recording
-                                    WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(recording_query, {"recording_gid": recording_gid[0]})
-                    MB_recording_data = result.fetchall()
-                except ValueError:
-                    pass
-                    
-                # AREA
-                try:
-                    area_query = text("""
-                        SELECT area.id,
-                               area.gid,
-                               area.name,
-                               area.type,
-                               area.edits_pending,
-                               area.last_updated,
-                               area.begin_date_year,
-                               area.begin_date_month,
-                               area.begin_date_day,
-                               area.end_date_year,
-                               area.end_date_month,
-                               area.end_date_day,
-                               area.ended, 
-                               area.comment
-                          FROM area
-                    INNER JOIN artist
-                            ON area.id = artist.area
-                    INNER JOIN artist_credit
-                            ON artist.id = artist_credit.id
-                    INNER JOIN recording
-                            ON artist_credit.id = recording.artist_credit
-                         WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(area_query, {"recording_gid": recording_gid[0]})
-                    MB_area_data = result.fetchall()
-                except ValueError:
-                    pass
-                
-                # BEGIN AREA
-                try:
-                    begin_area_query = text("""
-                        SELECT area.id,
-                               area.gid,
-                               area.name,
-                               area.type,
-                               area.edits_pending,
-                               area.last_updated,
-                               area.begin_date_year,
-                               area.begin_date_month,
-                               area.begin_date_day,
-                               area.end_date_year,
-                               area.end_date_month,
-                               area.end_date_day,
-                               area.ended, 
-                               area.comment
-                          FROM area
-                    INNER JOIN artist
-                            ON area.id = artist.begin_area
-                    INNER JOIN artist_credit
-                            ON artist.id = artist_credit.id
-                    INNER JOIN recording
-                            ON artist_credit.id = recording.artist_credit
-                         WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(begin_area_query, {"recording_gid": recording_gid[0]})
-                    MB_begin_area_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # END AREA
-                try:
-                    end_area_query = text("""
-                        SELECT area.id,
-                               area.gid,
-                               area.name,
-                               area.type,
-                               area.edits_pending,
-                               area.last_updated,
-                               area.begin_date_year,
-                               area.begin_date_month,
-                               area.begin_date_day,
-                               area.end_date_year,
-                               area.end_date_month,
-                               area.end_date_day,
-                               area.ended, 
-                               area.comment
-                          FROM area
-                    INNER JOIN artist
-                            ON area.id = artist.end_area
-                    INNER JOIN artist_credit
-                            ON artist.id = artist_credit.id
-                    INNER JOIN recording
-                            ON artist_credit.id = recording.artist_credit
-                         WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(end_area_query, {"recording_gid": recording_gid[0]})
-                    MB_end_area_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # AREA TYPE
-                try:
-                    area_type_query =   text("""SELECT area_type.id,
-                                                       area_type.name,
-                                                       area_type.parent,
-                                                       area_type.child_order,
-                                                       area_type.description,
-                                                       area_type.gid
-                                                  FROM area_type
-                                            INNER JOIN area
-                                                    ON area.type = area_type.id
-                                            INNER JOIN artist
-                                                    ON area.id = artist.area
-                                            INNER JOIN artist_credit
-                                                    ON artist.id = artist_credit.id
-                                            INNER JOIN recording
-                                                    ON artist_credit.id = recording.artist_credit
-                                                 WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(area_type_query, {"recording_gid": recording_gid[0]})
-                    MB_area_type_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # BEGIN AREA TYPE
-                try:
-                    begin_area_type_query =   text("""SELECT area_type.id,
-                                                       area_type.name,
-                                                       area_type.parent,
-                                                       area_type.child_order,
-                                                       area_type.description,
-                                                       area_type.gid
-                                                  FROM area_type
-                                            INNER JOIN area
-                                                    ON area.type = area_type.id
-                                            INNER JOIN artist
-                                                    ON area.id = artist.begin_area
-                                            INNER JOIN artist_credit
-                                                    ON artist.id = artist_credit.id
-                                            INNER JOIN recording
-                                                    ON artist_credit.id = recording.artist_credit
-                                                 WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(begin_area_type_query, {"recording_gid": recording_gid[0]})
-                    MB_begin_area_type_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # END AREA TYPE
-                try:
-                    end_area_type_query =   text("""SELECT area_type.id,
-                                                       area_type.name,
-                                                       area_type.parent,
-                                                       area_type.child_order,
-                                                       area_type.description,
-                                                       area_type.gid
-                                                  FROM area_type
-                                            INNER JOIN area
-                                                    ON area.type = area_type.id
-                                            INNER JOIN artist
-                                                    ON area.id = artist.end_area
-                                            INNER JOIN artist_credit
-                                                    ON artist.id = artist_credit.id
-                                            INNER JOIN recording
-                                                    ON artist_credit.id = recording.artist_credit
-                                                 WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(end_area_type_query, {"recording_gid": recording_gid[0]})
-                    MB_end_area_type_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # ARTIST CREDIT NAME
-                try:    
-                    artist_credit_name_query = text("""SELECT artist_credit_name.artist_credit,
-                                           artist_credit_name.position,
-                                           artist_credit_name.artist,
-                                           artist_credit_name.name,
-                                           artist_credit_name.join_phrase
-                                      FROM artist_credit_name
-                                INNER JOIN artist_credit
-                                        ON artist_credit_name.artist_credit = artist_credit.id
-                                INNER JOIN recording
-                                        ON artist_credit.id = recording.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(artist_credit_name_query, {"recording_gid": recording_gid[0]})
-                    MB_artist_credit_name_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # ARTIST GID REDIRECT
-                try:
-                    artist_gid_redirect_query = text("""SELECT artist_gid_redirect.gid,
-                                           artist_gid_redirect.new_id,
-                                           artist_gid_redirect.created
-                                      FROM artist_gid_redirect
-                                INNER JOIN artist
-                                        ON artist.id = artist_gid_redirect.new_id
-                                INNER JOIN artist_credit
-                                        ON artist.id = artist_credit.id
-                                INNER JOIN recording
-                                        ON artist_credit.id = recording.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(artist_gid_redirect_query, {"recording_gid": recording_gid[0]})
-                    MB_artist_gid_redirect_data = result.fetchall()
-                except ValueError:
-                    pass
-
-
-                # GENDER
-                try:
-                    gender_query = text("""SELECT gender.id,
-                                           gender.name,
-                                           gender.parent,
-                                           gender.child_order,
-                                           gender.description,
-                                           gender.gid
-                                      FROM gender
-                                INNER JOIN artist
-                                        ON artist.gender = gender.id
-                                INNER JOIN artist_credit
-                                        ON artist.id = artist_credit.id
-                                INNER JOIN recording
-                                        ON artist_credit.id = recording.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(gender_query, {"recording_gid": recording_gid[0]})
-                    MB_gender_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # RELEASE
-                try:
-                    release_query = text("""SELECT release.id,
-                                           release.gid,
-                                           release.name,
-                                           release.artist_credit,
-                                           release.release_group,
-                                           release.status,
-                                           release.packaging,
-                                           release.language,
-                                           release.script,
-                                           release.barcode,
-                                           release.comment,
-                                           release.edits_pending,
-                                           release.quality,
-                                           release.last_updated
-                                      FROM release
-                                INNER JOIN recording
-                                        ON recording.artist_credit = release.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(release_query, {"recording_gid": recording_gid[0]})
-                    MB_release_data = result.fetchall()
-                except ValueError:
-                    pass                  
-
-                # LANGUAGE
-                try:
-                    language_query = text("""SELECT language.id,
-                                           language.iso_code_2t,
-                                           language.iso_code_2b,
-                                           language.iso_code_1,
-                                           language.name,
-                                           language.frequency,
-                                           language.iso_code_3
-                                      FROM language
-                                INNER JOIN release
-                                        ON release.language = language.id
-                                INNER JOIN recording
-                                        ON recording.artist_credit=release.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(language_query, {"recording_gid": recording_gid[0]})
-                    MB_language_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # MEDIUM
-                try:
-                    medium_query = text("""SELECT medium.id,
-                                           medium.release,
-                                           medium.position,
-                                           medium.format,
-                                           medium.name,
-                                           medium.edits_pending,
-                                           medium.last_updated,
-                                           medium.track_count
-                                      FROM medium
-                                INNER JOIN release
-                                        ON release.id = medium.release
-                                INNER JOIN recording
-                                        ON recording.artist_credit=release.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(medium_query, {"recording_gid": recording_gid[0]})
-                    MB_medium_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # MEDIUM FORMAT
-                try:
-                    medium_format_query = text("""SELECT medium_format.id,
-                                           medium_format.name,
-                                           medium_format.parent,
-                                           medium_format.child_order,
-                                           medium_format.year,
-                                           medium_format.has_discids,
-                                           medium_format.description,
-                                           medium_format.gid
-                                      FROM medium_format
-                                INNER JOIN medium
-                                        ON medium_format.id = medium.format
-                                INNER JOIN release
-                                        ON release.id = medium.release
-                                INNER JOIN recording
-                                        ON recording.artist_credit = release.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(medium_format_query, {"recording_gid": recording_gid[0]})
-                    MB_medium_format_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # RECORDING GID REDIRECT
-                try:    
-                    recording_gid_redirect_query = text("""SELECT recording_gid_redirect.gid,
-                                           recording_gid_redirect.new_id,
-                                           recording_gid_redirect.created
-                                      FROM recording_gid_redirect
-                                INNER JOIN recording
-                                        ON recording.id = recording_gid_redirect.new_id
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(recording_gid_redirect_query, {"recording_gid": recording_gid[0]})
-                    MB_recording_gid_redirect_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # release_gid_redirect
-                try:    
-                    release_gid_redirect_query = text("""SELECT release_gid_redirect.gid,
-                                           release_gid_redirect.new_id,
-                                           release_gid_redirect.created
-                                      FROM release_gid_redirect
-                                INNER JOIN release
-                                        ON release.id = release_gid_redirect.new_id
-                                INNER JOIN recording
-                                        ON recording.artist_credit = release.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(release_gid_redirect_query, {"recording_gid": recording_gid[0]})
-                    MB_release_gid_redirect_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # release_group
-                try:
-                    release_group_query = text("""SELECT release_group.id,
-                                                         release_group.gid,
-                                                         release_group.name,
-                                                         release_group.artist_credit,
-                                                         release_group.type,
-                                                         release_group.comment,
-                                                         release_group.edits_pending,
-                                                         release_group.last_updated
-                                                    FROM release_group
-                                              INNER JOIN recording
-                                                      ON recording.artist_credit = release_group.artist_credit
-                                                   WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(release_group_query, {"recording_gid": recording_gid[0]})
-                    MB_release_group_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # release_group gid redirect
-                try:
-                    release_group_gid_redirect_query = text("""SELECT release_group_gid_redirect.gid,
-                                           release_group_gid_redirect.new_id,
-                                           release_group_gid_redirect.created
-                                      FROM release_group_gid_redirect
-                                INNER JOIN release_group
-                                        ON release_group.id = release_group_gid_redirect.new_id
-                                INNER JOIN recording
-                                        ON recording.artist_credit = release_group.artist_credit
-                                     WHERE recording.gid = :recording_gid 
-                    """)
-                    result = connection.execute(release_group_gid_redirect_query, {"recording_gid": recording_gid[0]})
-                    MB_release_group_gid_redirect_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # release_group_primary_type
-                try:    
-                    release_group_primary_type_query = text("""SELECT release_group_primary_type.id, release_group_primary_type.name,
-                                           release_group_primary_type.parent, release_group_primary_type.child_order,
-                                           release_group_primary_type.description, release_group_primary_type.gid
-                                    FROM release_group_primary_type INNER JOIN release_group 
-                                    ON release_group_primary_type.id = release_group.type
-                                    INNER JOIN recording
-                                            ON recording.artist_credit = release_group.artist_credit
-                                         WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(release_group_primary_type_query, {"recording_gid": recording_gid[0]})
-                    MB_release_group_primary_type_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # release_packaging
-                try:    
-                    release_packaging_query = text("""SELECT release_packaging.id,
-                                           release_packaging.name,
-                                           release_packaging.parent,
-                                           release_packaging.child_order,
-                                           release_packaging.description,
-                                           release_packaging.gid
-                                      FROM release_packaging
-                                INNER JOIN release
-                                        ON release.packaging = release_packaging.id
-                                INNER JOIN recording
-                                        ON recording.artist_credit = release.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(release_packaging_query, {"recording_gid": recording_gid[0]})
-                    MB_release_packaging_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # release_status
-                try:        
-                    release_status_query = text("""SELECT release_status.id,
-                                           release_status.name,
-                                           release_status.parent,
-                                           release_status.child_order,
-                                           release_status.description,
-                                           release_status.gid
-                                      FROM release_status
-                                INNER JOIN release
-                                        ON release.status = release_status.id
-                                INNER JOIN recording
-                                        ON recording.artist_credit = release.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(release_status_query, {"recording_gid": recording_gid[0]})
-                    MB_release_status_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # script
-                try:
-                    script_query = text("""SELECT script.id,
-                                           script.iso_code,
-                                           script.iso_number,
-                                           script.name,
-                                           script.frequency
-                                      FROM script
-                                INNER JOIN release
-                                        ON release.script = script.id
-                                INNER JOIN recording
-                                        ON recording.artist_credit = release.artist_credit
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(script_query, {"recording_gid": recording_gid[0]})
-                    MB_script_data = result.fetchall()
-                except ValueError:
-                    pass
-
-                # track
-                try:
-                    track_query = text("""SELECT track.id,
-                                           track.gid,
-                                           track.recording,
-                                           track.medium,
-                                           track.position,
-                                           track.number,
-                                           track.name,
-                                           track.artist_credit,
-                                           track.length,
-                                           track.edits_pending,
-                                           track.last_updated,
-                                           track.is_data_track
-                                      FROM track
-                                INNER JOIN recording
-                                        ON track.recording = recording.id
-                                     WHERE recording.gid = :recording_gid
-                    """)
-                    result = connection.execute(track_query, {"recording_gid": recording_gid[0]})
-                    MB_track_data = result.fetchall()
-                except ValueError:
-                    pass
-
-
-            # TO ACOUSTICBRAINZ
-            with db.engine.connect() as connection:
-                if MB_artist_credit_data:
-                    for value in MB_artist_credit_data:
-                        transaction = connection.begin()
-                        try:
-                            artist_credit_query = text("""
-                                INSERT INTO musicbrainz.artist_credit
-                                    VALUES (:id, :name, :artist_count, :ref_count, :created)""")
-                            connection.execute(artist_credit_query, {"id" : value[0],
-                                                                              "name" : value[1],
-                                                                              "artist_count" : value[2],
-                                                                              "ref_count" : value[3],
-                                                                              "created" : value[4]
-                            })
-                            transaction.commit()
-                            print("INSERTED artist_credit data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_artist_type_data:
-                    for value in MB_artist_type_data:
-                        transaction = connection.begin()
-                        try:
-                            artist_type_query = text("""
-                                INSERT INTO musicbrainz.artist_type
-                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
-                            connection.execute(artist_type_query, {"id":value[0],
-                                                                            "name":value[1],
-                                                                            "parent":value[2],
-                                                                            "child_order":value[3],
-                                                                            "description":value[4],
-                                                                            "gid":value[5]
-                            })
-                            transaction.commit()
-                            print("INSERTED artist_type data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_area_type_data:
-                    for value in MB_area_type_data:
-                        transaction = connection.begin()
-                        try:
-                            area_type_query = text("""
-                                INSERT INTO musicbrainz.area_type
-                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
-                            connection.execute(area_type_query, {"id": value[0],
-                                                                            "name": value[1],
-                                                                            "parent": value[2],
-                                                                            "child_order": value[3],
-                                                                            "description": value[4],
-                                                                            "gid": value[5]})
-                            transaction.commit()
-                            print("INSERTED area_type data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-                
-                if MB_begin_area_type_data:
-                    for value in MB_begin_area_type_data:
-                        transaction = connection.begin()
-                        try:
-                            begin_area_type_query = text("""
-                                INSERT INTO musicbrainz.area_type
-                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
-                            connection.execute(begin_area_type_query, {"id": value[0],
-                                                                            "name": value[1],
-                                                                            "parent": value[2],
-                                                                            "child_order": value[3],
-                                                                            "description": value[4],
-                                                                            "gid": value[5]})
-                            transaction.commit()
-                            print("INSERTED begin_area_type data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_end_area_type_data:
-                    for value in MB_end_area_type_data:
-                        transaction = connection.begin()
-                        try:
-                            end_area_type_query = text("""
-                                INSERT INTO musicbrainz.area_type
-                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
-                            connection.execute(end_area_type_query, {"id": value[0],
-                                                                            "name": value[1],
-                                                                            "parent": value[2],
-                                                                            "child_order": value[3],
-                                                                            "description": value[4],
-                                                                            "gid": value[5]})
-                            transaction.commit()
-                            print("INSERTED end_area_type data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_release_status_data:
-                    for value in MB_release_status_data:
-                        transaction = connection.begin()
-                        try:
-                            release_status_query = text("""
-                                INSERT INTO musicbrainz.release_status
-                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
-                            result = connection.execute(release_status_query, {"id": value[0],
-                                                                                "name":  value[1],
-                                                                                "parent": value[2],
-                                                                                "child_order": value[3],
-                                                                                "description": value[4],
-                                                                                "gid": value[5]})
-                            transaction.commit()
-                            print("INSERTED release_status data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_release_group_primary_type_data:
-                    for value in MB_release_group_primary_type_data:
-                        transaction = connection.begin()
-                        try:
-                            release_group_primary_type_query = text("""
-                                INSERT INTO musicbrainz.release_group_primary_type
-                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
-                            connection.execute(release_group_primary_type_query, {"id": value[0],
-                                                                                            "name": value[1],
-                                                                                            "parent": value[2],
-                                                                                            "child_order": value[3],
-                                                                                            "description": value[4],
-                                                                                            "gid": value[5]})
-                            transaction.commit()
-                            print("INSERTED release_group_primary_type data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_medium_format_data:
-                    for value in MB_medium_format_data:
-                        transaction = connection.begin()
-                        try:
-                            medium_format_query = text("""
-                                INSERT INTO musicbrainz.medium_format
-                                    VALUES (:id, :name, :parent, :child_order, :year, :has_discids, :description, :gid)""")
-                            connection.execute(medium_format_query, {"id": value[0], 
-                                                                              "name": value[1],
-                                                                              "parent": value[2],
-                                                                              "child_order": value[3],
-                                                                              "year": value[4],
-                                                                              "has_discids": value[5],
-                                                                              "description": value[6],
-                                                                              "gid": value[7]})
-                            transaction.commit()
-                            print("INSERTED medium_format data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_release_packaging_data:
-                    for value in MB_release_packaging_data:
-                        transaction = connection.begin()
-                        try:
-                            release_packaging_query = text("""
-                                INSERT INTO musicbrainz.release_packaging
-                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
-                            connection.execute(release_packaging_query, {"id": value[0],
-                                                                                  "name": value[1],
-                                                                                  "parent": value[2],
-                                                                                  "child_order": value[3],
-                                                                                  "description": value[4],
-                                                                                  "gid": value[5]})
-                            transaction.commit()
-                            print("INSERTED release_packaging data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_language_data:
-                    for value in MB_language_data:
-                        transaction = connection.begin()
-                        try:
-                            language_query = text("""
-                                INSERT INTO musicbrainz.language
-                                    VALUES (:iso_code_2t, :iso_code_2b, :iso_code_1, :name, :frequency, :iso_code_3)""")
-                            connection.execute(language_query, {"iso_code_2t": value[0],
-                                                                        "iso_code_2b": value[1],
-                                                                        "iso_code_1": value[2], 
-                                                                        "name": value[3],
-                                                                        "frequency": value[4],
-                                                                        "iso_code_3": value[5]})
-                            transaction.commit()
-                            print("INSERTED language data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_script_data:
-                    for value in MB_script_data:
-                        transaction = connection.begin()
-                        try:
-                            script_query = text("""
-                                INSERT INTO musicbrainz.script
-                                    VALUES (:id, :iso_code, :iso_number, :name, :frequency)""")
-                            connection.execute(script_query, {"id": value[0],
-                                                                       "iso_code": value[1],
-                                                                       "iso_number": value[2],
-                                                                       "name": value[3],
-                                                                       "frequency": value[4]})
-                            transaction.commit()
-                            print("INSERTED script data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_gender_data:
-                    for value in MB_gender_data:
-                        transaction = connection.begin()
-                        try:
-                            gender_query = text("""
-                                INSERT INTO musicbrainz.gender
-                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
-                            connection.execute(gender_query, {"id": value[0],
-                                                              "name": value[1],
-                                                              "parent": value[2],
-                                                              "child_order": value[3],
-                                                              "description": value[4],
-                                                              "gid": value[5]})
-                            transaction.commit()
-                            print("INSERTED gender data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_area_data:
-                    for value in MB_area_data:
-                        transaction = connection.begin()
-                        try:
-                            area_query = text("""
-                                INSERT INTO musicbrainz.area
-                                    VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
-                                            :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
-                                            :ended, :comment)""")
-                            connection.execute(area_query, {"id": value[0],
-                                                                     "gid": value[1],
-                                                                     "name": value[2],
-                                                                     "type": value[3],
-                                                                     "edits_pending": value[4],
-                                                                     "last_updated": value[5],
-                                                                     "begin_date_year": value[6],
-                                                                     "begin_date_month": value[7],
-                                                                     "begin_date_day": value[8],
-                                                                     "end_date_year": value[9],
-                                                                     "end_date_month": value[10],
-                                                                     "end_date_day": value[11],
-                                                                     "ended": value[12],
-                                                                     "comment": value[13]})
-                            transaction.commit()
-                            print("INSERTED area data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_begin_area_data:
-                    for value in MB_begin_area_data:
-                        transaction = connection.begin()
-                        try:
-                            begin_area_query = text("""
-                                INSERT INTO musicbrainz.area
-                                    VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
-                                            :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
-                                            :ended, :comment)""")
-                            connection.execute(begin_area_query, {"id": value[0],
-                                                                     "gid": value[1],
-                                                                     "name": value[2],
-                                                                     "type": value[3],
-                                                                     "edits_pending": value[4],
-                                                                     "last_updated": value[5],
-                                                                     "begin_date_year": value[6],
-                                                                     "begin_date_month": value[7],
-                                                                     "begin_date_day": value[8],
-                                                                     "end_date_year": value[9],
-                                                                     "end_date_month": value[10],
-                                                                     "end_date_day": value[11],
-                                                                     "ended": value[12],
-                                                                     "comment": value[13]})
-                            transaction.commit()
-                            print("INSERTED begin_area data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_end_area_data:
-                    for value in MB_end_area_data:
-                        transaction = connection.begin()
-                        try:
-                            end_area_query = text("""
-                                INSERT INTO musicbrainz.area
-                                    VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
-                                            :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
-                                            :ended, :comment)""")
-                            connection.execute(end_area_query, {"id": value[0],
-                                                                     "gid": value[1],
-                                                                     "name": value[2],
-                                                                     "type": value[3],
-                                                                     "edits_pending": value[4],
-                                                                     "last_updated": value[5],
-                                                                     "begin_date_year": value[6],
-                                                                     "begin_date_month": value[7],
-                                                                     "begin_date_day": value[8],
-                                                                     "end_date_year": value[9],
-                                                                     "end_date_month": value[10],
-                                                                     "end_date_day": value[11],
-                                                                     "ended": value[12],
-                                                                     "comment": value[13]})
-                            transaction.commit()
-                            print("INSERTED end_area data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_artist_data:
-                    for value in MB_artist_data:
-                        transaction = connection.begin()
-                        try:
-                            artist_query = text("""
-                              INSERT INTO musicbrainz.artist
-                                  VALUES (:id, :gid, :name, :sort_name, :begin_date_year, :begin_date_month, :begin_date_day,
-                                        :end_date_year, :end_date_month, :end_date_day, :type, :area, :gender, :comment, :edits_pending,
-                                        :last_updated, :ended, :begin_area, :end_area)""")
-                            connection.execute(artist_query, {"id": value[0],
-                                                                       "gid": value[1],
-                                                                       "name": value[2],
-                                                                       "sort_name": value[3],
-                                                                       "begin_date_year": value[4],
-                                                                       "begin_date_month": value[5],
-                                                                       "begin_date_day": value[6],
-                                                                       "end_date_year": value[7],
-                                                                       "end_date_month": value[8],
-                                                                       "end_date_day": value[9],
-                                                                       "type": value[10],
-                                                                       "area": value[11],
-                                                                       "gender": value[12], 
-                                                                       "comment": value[13],
-                                                                       "edits_pending": value[14],
-                                                                       "last_updated": value[15],
-                                                                       "ended": value[16],
-                                                                       "begin_area": value[17],
-                                                                       "end_area": value[18]})
-                            transaction.commit()
-                            print("INSERTED artist data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_artist_credit_name_data:
-                    for value in MB_artist_credit_name_data:
-                        transaction = connection.begin()
-                        try:
-                            artist_credit_name_query = text("""
-                                INSERT INTO musicbrainz.artist_credit_name
-                                    VALUES (:artist_credit, :position, :artist, :name, :join_phrase)""")
-                            connection.execute(artist_credit_name_query, {"artist_credit": value[0],
-                                                                          "position": value[1],
-                                                                          "artist": value[2],
-                                                                          "name": value[3],
-                                                                          "join_phrase": value[4]})
-                            transaction.commit()
-                            print("INSERTED artist_credit_name data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_artist_gid_redirect_data:
-                    for value in MB_artist_gid_redirect_data:
-                        transaction = connection.begin()
-                        try:
-                            artist_gid_redirect_query = text("""
-                                INSERT INTO musicbrainz.artist_gid_redirect
-                                    VALUES (:gid, :new_id, :created)""")
-                            connection.execute(artist_gid_redirect_query, {"gid": value[0],
-                                                                            "new_id": value[1],
-                                                                            "created": value[2]})
-                            transaction.commit()
-                            print("INSERTED artist_gid_redirect data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-
-                if MB_recording_data:
-                    for value in MB_recording_data:
-                        transaction = connection.begin()
-                        try:
-                            recording_query = text("""
-                                INSERT INTO musicbrainz.recording
-                                    VALUES (:id, :gid, :name, :artist_credit, :length, :comment, :edits_pending, :last_updated, :video)""")
-                            connection.execute(recording_query, {"id": value[0],
-                                                                          "gid": value[1],
-                                                                          "name": value[2],
-                                                                          "artist_credit": value[3],
-                                                                          "length": value[4],
-                                                                          "comment": value[5],
-                                                                          "edits_pending": value[6],
-                                                                          "last_updated": value[7],
-                                                                          "video": value[8]})
-                            transaction.commit()
-                            print("INSERTED recording data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_recording_gid_redirect_data:
-                    for value in MB_recording_gid_redirect_data:
-                        transaction = connection.begin()
-                        try:
-                            recording_gid_redirect_query = text("""
-                                INSERT INTO musicbrainz.recording_gid_redirect
-                                    VALUES (:gid, :new_id, :created)""")
-                            connection.execute(recording_gid_redirect_query, {"gid": value[0],
-                                                                                       "new_id": value[1],
-                                                                                       "created": value[2]})
-                            transaction.commit()
-                            print("INSERTED recording_gid_redirect data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_release_group_data:
-                    for value in MB_release_group_data:
-                        transaction = connection.begin()
-                        try:
-                            release_group_query = text("""
-                                INSERT INTO musicbrainz.release_group
-                                    VALUES (:id, :gid, :name, :artist_credit, :type, :comment, :edits_pending, :last_updated)""")
-                            connection.execute(release_group_query, {"id": value[0],
-                                                                              "gid": value[1],
-                                                                              "name": value[2],
-                                                                              "artist_credit": value[3],
-                                                                              "type": value[4],
-                                                                              "comment": value[5],
-                                                                              "edits_pending": value[6],
-                                                                              "last_updated": value[7]})
-                            transaction.commit()
-                            print("INSERTED release_group data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_release_group_gid_redirect_data:
-                    for value in MB_release_group_gid_redirect_data:
-                        transaction = connection.begin()
-                        try:
-                            release_group_gid_redirect_query = text("""
-                                INSERT INTO musicbrainz.release_group_gid_redirect
-                                    VALUES (:gid, :new_id, :created)""")
-                            connection.execute(release_group_gid_redirect_query, {"gid": value[0],
-                                                                                           "new_id": value[1],
-                                                                                           "created": value[2]})
-                            transaction.commit()
-                            print("INSERTED release_gid_redirect data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_release_data:
-                    for value in MB_release_data:
-                        transaction = connection.begin()
-                        try:
-                            release_query = text("""
-                                INSERT INTO musicbrainz.release
-                                    VALUES (:id, :gid, :name, :artist_credit, :release_group, :status, :packaging, :language,
-                                            :script, :barcode, :comment, :edits_pending, :quality, :last_updated)""")
-                            connection.execute(release_query, {"id": value[0],
-                                                                        "gid": value[1],
-                                                                        "name": value[2],
-                                                                        "artist_credit": value[3],
-                                                                        "release_group": value[4],
-                                                                        "status": value[5],
-                                                                        "packaging": value[6],
-                                                                        "language": value[7],
-                                                                        "script": value[8],
-                                                                        "barcode": value[9],
-                                                                        "comment": value[10],
-                                                                        "edits_pending": value[11],
-                                                                        "quality": value[12],
-                                                                        "last_updated": value[13]})
-                            transaction.commit()
-                            print("INSERTED release data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_release_gid_redirect_data:
-                    for value in MB_release_gid_redirect_data:
-                        transaction = connection.begin()
-                        try:
-                            release_gid_redirect_query = text("""
-                                INSERT INTO musicbrainz.release_gid_redirect
-                                    VALUES (:gid, :new_id, :created)""")
-                            connection.execute(release_gid_redirect_query, {"gid": value[0],
-                                                                                           "new_id": value[1],
-                                                                                           "created": value[2]})
-                            transaction.commit()
-                            print("INSERTED release_gid_redirect data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_medium_data:
-                    for value in MB_medium_data:
-                        transaction = connection.begin()
-                        try:
-                            medium_query = text("""
-                                INSERT INTO musicbrainz.medium
-                                    VALUES (:id, :release, :position, :format, :name, :edits_pending, :last_updated, :track_count)""")
-                            connection.execute(medium_query, {"id": value[0],
-                                                                       "release": value[1],
-                                                                       "position": value[2],
-                                                                       "format": value[3],
-                                                                       "name": value[4],
-                                                                       "edits_pending": value[5],
-                                                                       "last_updated": value[6],
-                                                                       "track_count": value[7]})
-                            transaction.commit()
-                            print("INSERTED medium data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-                if MB_track_data:
-                    for value in MB_track_data:
-                        transaction = connection.begin()
-                        try:
-                            track_query = text("""
-                                INSERT INTO musicbrainz.track
-                                    VALUES (:id, :gid, :recording, :medium, :position, :number, :name, :artist_credit, :length,
-                                            :edits_pending, :last_updated, :is_data_track)""")
-                            connection.execute(track_query, {"id": value[0],
-                                                   "gid": value[1],
-                                                   "recording": value[2],
-                                                   "medium": value[3],
-                                                   "position": value[4],
-                                                   "number": value[5],
-                                                   "name": value[6],
-                                                   "artist_credit": value[7],
-                                                   "length": value[8],
-                                                   "edits_pending": value[9],
-                                                   "last_updated": value[10],
-                                                   "is_data_track": value[11]})
-                            transaction.commit()
-                            print("INSERTED track data\n")
-                        except IntegrityError as e:
-                            print(e.message)
-                            transaction.rollback()
-
-        print("--------------------------------DONE-----------------------------------")
+        gids = connection.execute(lowlevel_query)
+        gids = gids.fetchall()
+        gids_in_AB = [value[0] for value in gids]
+        no_of_rows = len(gids_in_AB)
+        start = 0
+        rows_to_fetch = 10000
+        for value in range(0, (no_of_rows/rows_to_fetch) + 1):
+            fetch_musicbrainz_data(gids_in_AB[start : start + rows_to_fetch])
+            start = start + rows_to_fetch

--- a/db/import_mb_data.py
+++ b/db/import_mb_data.py
@@ -1,0 +1,1130 @@
+import db
+from brainzutils import musicbrainz_db
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+def start_import():
+    with db.engine.begin() as conn:
+        lowlevel_query = text("""SELECT gid from lowlevel""")
+        gids = conn.execute(lowlevel_query)
+        gids_in_AB = gids.fetchall()
+        for recording_gid in gids_in_AB:
+            MB_artist_credit_data, MB_recording_data, MB_artist_data, MB_artist_type_data, MB_area_data, \
+            MB_script_data, MB_release_data, MB_release_group_primary_type_data, MB_medium_data, \
+            MB_track_data, MB_gender_data, MB_language_data, MB_medium_format_data, MB_release_group_data, \
+            MB_release_status_data, MB_artist_gid_redirect_data, MB_recording_gid_redirect_data, \
+            MB_release_group_gid_redirect_data, MB_release_gid_redirect_data, MB_artist_credit_name_data, \
+            MB_area_type_data, MB_release_packaging_data = (0,)*22
+
+            # FROM MUSICBRAINZ
+            with musicbrainz_db.engine.begin() as connection:
+                # ARTIST CREDIT
+                try:
+                    artist_credit_query = text("""SELECT artist_credit.id, artist_credit.name, artist_credit.artist_count,
+                                                    artist_credit.ref_count, artist_credit.created
+                                                    FROM artist_credit
+                                                    INNER JOIN recording
+                                                    ON artist_credit.id = recording.artist_credit
+                                                    WHERE recording.gid= :recording_gid
+                    """)
+                    result = connection.execute(artist_credit_query, {"recording_gid" : recording_gid[0]})
+                    MB_artist_credit_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                try:
+                    artist_query = text("""
+                        SELECT artist.id, artist.gid, artist.name, artist.sort_name, artist.begin_date_year,
+                               artist.begin_date_month, artist.begin_date_day, artist.end_date_year, artist.end_date_month,
+                               artist.end_date_day, artist.type, artist.area, artist.gender, artist.comment, artist.edits_pending,
+                               artist.last_updated, artist.ended, artist.begin_area, artist.end_area
+                          FROM artist
+                    INNER JOIN artist_credit 
+                            ON artist_credit.id = artist.id
+                    INNER JOIN recording
+                            ON artist_credit.id = recording.artist_credit
+                    WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(artist_query, {"recording_gid": recording_gid[0]})
+                    MB_artist_data = result.fetchall()
+                except ValueError:
+                    pass
+                    
+                # ARTIST TYPE
+                try:
+                    artist_type_query = text("""SELECT artist_type.id,
+                                                        artist_type.name,
+                                                        artist_type.parent,
+                               artist_type.child_order,
+                               artist_type.description,
+                               artist_type.gid
+                          FROM artist_type
+                    INNER JOIN artist
+                            ON artist.type = artist_type.id
+                    INNER JOIN artist_credit
+                            ON artist.id = artist_credit.id
+                    INNER JOIN recording
+                            ON artist_credit.id = recording.artist_credit
+                         WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(artist_type_query, {"recording_gid": recording_gid[0]})
+                    MB_artist_type_data = result.fetchall()
+                except ValueError:
+                    pass
+                    
+                # RECORDING
+                try:
+                    recording_query = text("""SELECT recording.id, recording.gid, recording.name, recording.artist_credit,
+                                          recording.length, recording.comment, recording.edits_pending, recording.last_updated,
+                                          recording.video
+                                     FROM recording
+                                    WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(recording_query, {"recording_gid": recording_gid[0]})
+                    MB_recording_data = result.fetchall()
+                except ValueError:
+                    pass
+                    
+                # AREA
+                try:
+                    area_query = text("""
+                        SELECT area.id,
+                               area.gid,
+                               area.name,
+                               area.type,
+                               area.edits_pending,
+                               area.last_updated,
+                               area.begin_date_year,
+                               area.begin_date_month,
+                               area.begin_date_day,
+                               area.end_date_year,
+                               area.end_date_month,
+                               area.end_date_day,
+                               area.ended, 
+                               area.comment
+                          FROM area
+                    INNER JOIN artist
+                            ON area.id = artist.area
+                    INNER JOIN artist_credit
+                            ON artist.id = artist_credit.id
+                    INNER JOIN recording
+                            ON artist_credit.id = recording.artist_credit
+                         WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(area_query, {"recording_gid": recording_gid[0]})
+                    MB_area_data = result.fetchall()
+                except ValueError:
+                    pass
+                
+                # BEGIN AREA
+                try:
+                    begin_area_query = text("""
+                        SELECT area.id,
+                               area.gid,
+                               area.name,
+                               area.type,
+                               area.edits_pending,
+                               area.last_updated,
+                               area.begin_date_year,
+                               area.begin_date_month,
+                               area.begin_date_day,
+                               area.end_date_year,
+                               area.end_date_month,
+                               area.end_date_day,
+                               area.ended, 
+                               area.comment
+                          FROM area
+                    INNER JOIN artist
+                            ON area.id = artist.begin_area
+                    INNER JOIN artist_credit
+                            ON artist.id = artist_credit.id
+                    INNER JOIN recording
+                            ON artist_credit.id = recording.artist_credit
+                         WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(begin_area_query, {"recording_gid": recording_gid[0]})
+                    MB_begin_area_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # END AREA
+                try:
+                    end_area_query = text("""
+                        SELECT area.id,
+                               area.gid,
+                               area.name,
+                               area.type,
+                               area.edits_pending,
+                               area.last_updated,
+                               area.begin_date_year,
+                               area.begin_date_month,
+                               area.begin_date_day,
+                               area.end_date_year,
+                               area.end_date_month,
+                               area.end_date_day,
+                               area.ended, 
+                               area.comment
+                          FROM area
+                    INNER JOIN artist
+                            ON area.id = artist.end_area
+                    INNER JOIN artist_credit
+                            ON artist.id = artist_credit.id
+                    INNER JOIN recording
+                            ON artist_credit.id = recording.artist_credit
+                         WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(end_area_query, {"recording_gid": recording_gid[0]})
+                    MB_end_area_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # AREA TYPE
+                try:
+                    area_type_query =   text("""SELECT area_type.id,
+                                                       area_type.name,
+                                                       area_type.parent,
+                                                       area_type.child_order,
+                                                       area_type.description,
+                                                       area_type.gid
+                                                  FROM area_type
+                                            INNER JOIN area
+                                                    ON area.type = area_type.id
+                                            INNER JOIN artist
+                                                    ON area.id = artist.area
+                                            INNER JOIN artist_credit
+                                                    ON artist.id = artist_credit.id
+                                            INNER JOIN recording
+                                                    ON artist_credit.id = recording.artist_credit
+                                                 WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(area_type_query, {"recording_gid": recording_gid[0]})
+                    MB_area_type_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # BEGIN AREA TYPE
+                try:
+                    begin_area_type_query =   text("""SELECT area_type.id,
+                                                       area_type.name,
+                                                       area_type.parent,
+                                                       area_type.child_order,
+                                                       area_type.description,
+                                                       area_type.gid
+                                                  FROM area_type
+                                            INNER JOIN area
+                                                    ON area.type = area_type.id
+                                            INNER JOIN artist
+                                                    ON area.id = artist.begin_area
+                                            INNER JOIN artist_credit
+                                                    ON artist.id = artist_credit.id
+                                            INNER JOIN recording
+                                                    ON artist_credit.id = recording.artist_credit
+                                                 WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(begin_area_type_query, {"recording_gid": recording_gid[0]})
+                    MB_begin_area_type_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # END AREA TYPE
+                try:
+                    end_area_type_query =   text("""SELECT area_type.id,
+                                                       area_type.name,
+                                                       area_type.parent,
+                                                       area_type.child_order,
+                                                       area_type.description,
+                                                       area_type.gid
+                                                  FROM area_type
+                                            INNER JOIN area
+                                                    ON area.type = area_type.id
+                                            INNER JOIN artist
+                                                    ON area.id = artist.end_area
+                                            INNER JOIN artist_credit
+                                                    ON artist.id = artist_credit.id
+                                            INNER JOIN recording
+                                                    ON artist_credit.id = recording.artist_credit
+                                                 WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(end_area_type_query, {"recording_gid": recording_gid[0]})
+                    MB_end_area_type_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # ARTIST CREDIT NAME
+                try:    
+                    artist_credit_name_query = text("""SELECT artist_credit_name.artist_credit,
+                                           artist_credit_name.position,
+                                           artist_credit_name.artist,
+                                           artist_credit_name.name,
+                                           artist_credit_name.join_phrase
+                                      FROM artist_credit_name
+                                INNER JOIN artist_credit
+                                        ON artist_credit_name.artist_credit = artist_credit.id
+                                INNER JOIN recording
+                                        ON artist_credit.id = recording.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(artist_credit_name_query, {"recording_gid": recording_gid[0]})
+                    MB_artist_credit_name_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # ARTIST GID REDIRECT
+                try:
+                    artist_gid_redirect_query = text("""SELECT artist_gid_redirect.gid,
+                                           artist_gid_redirect.new_id,
+                                           artist_gid_redirect.created
+                                      FROM artist_gid_redirect
+                                INNER JOIN artist
+                                        ON artist.id = artist_gid_redirect.new_id
+                                INNER JOIN artist_credit
+                                        ON artist.id = artist_credit.id
+                                INNER JOIN recording
+                                        ON artist_credit.id = recording.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(artist_gid_redirect_query, {"recording_gid": recording_gid[0]})
+                    MB_artist_gid_redirect_data = result.fetchall()
+                except ValueError:
+                    pass
+
+
+                # GENDER
+                try:
+                    gender_query = text("""SELECT gender.id,
+                                           gender.name,
+                                           gender.parent,
+                                           gender.child_order,
+                                           gender.description,
+                                           gender.gid
+                                      FROM gender
+                                INNER JOIN artist
+                                        ON artist.gender = gender.id
+                                INNER JOIN artist_credit
+                                        ON artist.id = artist_credit.id
+                                INNER JOIN recording
+                                        ON artist_credit.id = recording.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(gender_query, {"recording_gid": recording_gid[0]})
+                    MB_gender_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # RELEASE
+                try:
+                    release_query = text("""SELECT release.id,
+                                           release.gid,
+                                           release.name,
+                                           release.artist_credit,
+                                           release.release_group,
+                                           release.status,
+                                           release.packaging,
+                                           release.language,
+                                           release.script,
+                                           release.barcode,
+                                           release.comment,
+                                           release.edits_pending,
+                                           release.quality,
+                                           release.last_updated
+                                      FROM release
+                                INNER JOIN recording
+                                        ON recording.artist_credit = release.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(release_query, {"recording_gid": recording_gid[0]})
+                    MB_release_data = result.fetchall()
+                except ValueError:
+                    pass                  
+
+                # LANGUAGE
+                try:
+                    language_query = text("""SELECT language.id,
+                                           language.iso_code_2t,
+                                           language.iso_code_2b,
+                                           language.iso_code_1,
+                                           language.name,
+                                           language.frequency,
+                                           language.iso_code_3
+                                      FROM language
+                                INNER JOIN release
+                                        ON release.language = language.id
+                                INNER JOIN recording
+                                        ON recording.artist_credit=release.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(language_query, {"recording_gid": recording_gid[0]})
+                    MB_language_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # MEDIUM
+                try:
+                    medium_query = text("""SELECT medium.id,
+                                           medium.release,
+                                           medium.position,
+                                           medium.format,
+                                           medium.name,
+                                           medium.edits_pending,
+                                           medium.last_updated,
+                                           medium.track_count
+                                      FROM medium
+                                INNER JOIN release
+                                        ON release.id = medium.release
+                                INNER JOIN recording
+                                        ON recording.artist_credit=release.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(medium_query, {"recording_gid": recording_gid[0]})
+                    MB_medium_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # MEDIUM FORMAT
+                try:
+                    medium_format_query = text("""SELECT medium_format.id,
+                                           medium_format.name,
+                                           medium_format.parent,
+                                           medium_format.child_order,
+                                           medium_format.year,
+                                           medium_format.has_discids,
+                                           medium_format.description,
+                                           medium_format.gid
+                                      FROM medium_format
+                                INNER JOIN medium
+                                        ON medium_format.id = medium.format
+                                INNER JOIN release
+                                        ON release.id = medium.release
+                                INNER JOIN recording
+                                        ON recording.artist_credit = release.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(medium_format_query, {"recording_gid": recording_gid[0]})
+                    MB_medium_format_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # RECORDING GID REDIRECT
+                try:    
+                    recording_gid_redirect_query = text("""SELECT recording_gid_redirect.gid,
+                                           recording_gid_redirect.new_id,
+                                           recording_gid_redirect.created
+                                      FROM recording_gid_redirect
+                                INNER JOIN recording
+                                        ON recording.id = recording_gid_redirect.new_id
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(recording_gid_redirect_query, {"recording_gid": recording_gid[0]})
+                    MB_recording_gid_redirect_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # release_gid_redirect
+                try:    
+                    release_gid_redirect_query = text("""SELECT release_gid_redirect.gid,
+                                           release_gid_redirect.new_id,
+                                           release_gid_redirect.created
+                                      FROM release_gid_redirect
+                                INNER JOIN release
+                                        ON release.id = release_gid_redirect.new_id
+                                INNER JOIN recording
+                                        ON recording.artist_credit = release.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(release_gid_redirect_query, {"recording_gid": recording_gid[0]})
+                    MB_release_gid_redirect_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # release_group
+                try:
+                    release_group_query = text("""SELECT release_group.id,
+                                                         release_group.gid,
+                                                         release_group.name,
+                                                         release_group.artist_credit,
+                                                         release_group.type,
+                                                         release_group.comment,
+                                                         release_group.edits_pending,
+                                                         release_group.last_updated
+                                                    FROM release_group
+                                              INNER JOIN recording
+                                                      ON recording.artist_credit = release_group.artist_credit
+                                                   WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(release_group_query, {"recording_gid": recording_gid[0]})
+                    MB_release_group_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # release_group gid redirect
+                try:
+                    release_group_gid_redirect_query = text("""SELECT release_group_gid_redirect.gid,
+                                           release_group_gid_redirect.new_id,
+                                           release_group_gid_redirect.created
+                                      FROM release_group_gid_redirect
+                                INNER JOIN release_group
+                                        ON release_group.id = release_group_gid_redirect.new_id
+                                INNER JOIN recording
+                                        ON recording.artist_credit = release_group.artist_credit
+                                     WHERE recording.gid = :recording_gid 
+                    """)
+                    result = connection.execute(release_group_gid_redirect_query, {"recording_gid": recording_gid[0]})
+                    MB_release_group_gid_redirect_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # release_group_primary_type
+                try:    
+                    release_group_primary_type_query = text("""SELECT release_group_primary_type.id, release_group_primary_type.name,
+                                           release_group_primary_type.parent, release_group_primary_type.child_order,
+                                           release_group_primary_type.description, release_group_primary_type.gid
+                                    FROM release_group_primary_type INNER JOIN release_group 
+                                    ON release_group_primary_type.id = release_group.type
+                                    INNER JOIN recording
+                                            ON recording.artist_credit = release_group.artist_credit
+                                         WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(release_group_primary_type_query, {"recording_gid": recording_gid[0]})
+                    MB_release_group_primary_type_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # release_packaging
+                try:    
+                    release_packaging_query = text("""SELECT release_packaging.id,
+                                           release_packaging.name,
+                                           release_packaging.parent,
+                                           release_packaging.child_order,
+                                           release_packaging.description,
+                                           release_packaging.gid
+                                      FROM release_packaging
+                                INNER JOIN release
+                                        ON release.packaging = release_packaging.id
+                                INNER JOIN recording
+                                        ON recording.artist_credit = release.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(release_packaging_query, {"recording_gid": recording_gid[0]})
+                    MB_release_packaging_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # release_status
+                try:        
+                    release_status_query = text("""SELECT release_status.id,
+                                           release_status.name,
+                                           release_status.parent,
+                                           release_status.child_order,
+                                           release_status.description,
+                                           release_status.gid
+                                      FROM release_status
+                                INNER JOIN release
+                                        ON release.status = release_status.id
+                                INNER JOIN recording
+                                        ON recording.artist_credit = release.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(release_status_query, {"recording_gid": recording_gid[0]})
+                    MB_release_status_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # script
+                try:
+                    script_query = text("""SELECT script.id,
+                                           script.iso_code,
+                                           script.iso_number,
+                                           script.name,
+                                           script.frequency
+                                      FROM script
+                                INNER JOIN release
+                                        ON release.script = script.id
+                                INNER JOIN recording
+                                        ON recording.artist_credit = release.artist_credit
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(script_query, {"recording_gid": recording_gid[0]})
+                    MB_script_data = result.fetchall()
+                except ValueError:
+                    pass
+
+                # track
+                try:
+                    track_query = text("""SELECT track.id,
+                                           track.gid,
+                                           track.recording,
+                                           track.medium,
+                                           track.position,
+                                           track.number,
+                                           track.name,
+                                           track.artist_credit,
+                                           track.length,
+                                           track.edits_pending,
+                                           track.last_updated,
+                                           track.is_data_track
+                                      FROM track
+                                INNER JOIN recording
+                                        ON track.recording = recording.id
+                                     WHERE recording.gid = :recording_gid
+                    """)
+                    result = connection.execute(track_query, {"recording_gid": recording_gid[0]})
+                    MB_track_data = result.fetchall()
+                except ValueError:
+                    pass
+
+
+            # TO ACOUSTICBRAINZ
+            with db.engine.connect() as connection:
+                if MB_artist_credit_data:
+                    for value in MB_artist_credit_data:
+                        transaction = connection.begin()
+                        try:
+                            artist_credit_query = text("""
+                                INSERT INTO musicbrainz.artist_credit
+                                    VALUES (:id, :name, :artist_count, :ref_count, :created)""")
+                            connection.execute(artist_credit_query, {"id" : value[0],
+                                                                              "name" : value[1],
+                                                                              "artist_count" : value[2],
+                                                                              "ref_count" : value[3],
+                                                                              "created" : value[4]
+                            })
+                            transaction.commit()
+                            print("INSERTED artist_credit data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_artist_type_data:
+                    for value in MB_artist_type_data:
+                        transaction = connection.begin()
+                        try:
+                            artist_type_query = text("""
+                                INSERT INTO musicbrainz.artist_type
+                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
+                            connection.execute(artist_type_query, {"id":value[0],
+                                                                            "name":value[1],
+                                                                            "parent":value[2],
+                                                                            "child_order":value[3],
+                                                                            "description":value[4],
+                                                                            "gid":value[5]
+                            })
+                            transaction.commit()
+                            print("INSERTED artist_type data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_area_type_data:
+                    for value in MB_area_type_data:
+                        transaction = connection.begin()
+                        try:
+                            area_type_query = text("""
+                                INSERT INTO musicbrainz.area_type
+                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
+                            connection.execute(area_type_query, {"id": value[0],
+                                                                            "name": value[1],
+                                                                            "parent": value[2],
+                                                                            "child_order": value[3],
+                                                                            "description": value[4],
+                                                                            "gid": value[5]})
+                            transaction.commit()
+                            print("INSERTED area_type data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+                
+                if MB_begin_area_type_data:
+                    for value in MB_begin_area_type_data:
+                        transaction = connection.begin()
+                        try:
+                            begin_area_type_query = text("""
+                                INSERT INTO musicbrainz.area_type
+                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
+                            connection.execute(begin_area_type_query, {"id": value[0],
+                                                                            "name": value[1],
+                                                                            "parent": value[2],
+                                                                            "child_order": value[3],
+                                                                            "description": value[4],
+                                                                            "gid": value[5]})
+                            transaction.commit()
+                            print("INSERTED begin_area_type data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_end_area_type_data:
+                    for value in MB_end_area_type_data:
+                        transaction = connection.begin()
+                        try:
+                            end_area_type_query = text("""
+                                INSERT INTO musicbrainz.area_type
+                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
+                            connection.execute(end_area_type_query, {"id": value[0],
+                                                                            "name": value[1],
+                                                                            "parent": value[2],
+                                                                            "child_order": value[3],
+                                                                            "description": value[4],
+                                                                            "gid": value[5]})
+                            transaction.commit()
+                            print("INSERTED end_area_type data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_release_status_data:
+                    for value in MB_release_status_data:
+                        transaction = connection.begin()
+                        try:
+                            release_status_query = text("""
+                                INSERT INTO musicbrainz.release_status
+                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
+                            result = connection.execute(release_status_query, {"id": value[0],
+                                                                                "name":  value[1],
+                                                                                "parent": value[2],
+                                                                                "child_order": value[3],
+                                                                                "description": value[4],
+                                                                                "gid": value[5]})
+                            transaction.commit()
+                            print("INSERTED release_status data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_release_group_primary_type_data:
+                    for value in MB_release_group_primary_type_data:
+                        transaction = connection.begin()
+                        try:
+                            release_group_primary_type_query = text("""
+                                INSERT INTO musicbrainz.release_group_primary_type
+                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
+                            connection.execute(release_group_primary_type_query, {"id": value[0],
+                                                                                            "name": value[1],
+                                                                                            "parent": value[2],
+                                                                                            "child_order": value[3],
+                                                                                            "description": value[4],
+                                                                                            "gid": value[5]})
+                            transaction.commit()
+                            print("INSERTED release_group_primary_type data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_medium_format_data:
+                    for value in MB_medium_format_data:
+                        transaction = connection.begin()
+                        try:
+                            medium_format_query = text("""
+                                INSERT INTO musicbrainz.medium_format
+                                    VALUES (:id, :name, :parent, :child_order, :year, :has_discids, :description, :gid)""")
+                            connection.execute(medium_format_query, {"id": value[0], 
+                                                                              "name": value[1],
+                                                                              "parent": value[2],
+                                                                              "child_order": value[3],
+                                                                              "year": value[4],
+                                                                              "has_discids": value[5],
+                                                                              "description": value[6],
+                                                                              "gid": value[7]})
+                            transaction.commit()
+                            print("INSERTED medium_format data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_release_packaging_data:
+                    for value in MB_release_packaging_data:
+                        transaction = connection.begin()
+                        try:
+                            release_packaging_query = text("""
+                                INSERT INTO musicbrainz.release_packaging
+                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
+                            connection.execute(release_packaging_query, {"id": value[0],
+                                                                                  "name": value[1],
+                                                                                  "parent": value[2],
+                                                                                  "child_order": value[3],
+                                                                                  "description": value[4],
+                                                                                  "gid": value[5]})
+                            transaction.commit()
+                            print("INSERTED release_packaging data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_language_data:
+                    for value in MB_language_data:
+                        transaction = connection.begin()
+                        try:
+                            language_query = text("""
+                                INSERT INTO musicbrainz.language
+                                    VALUES (:iso_code_2t, :iso_code_2b, :iso_code_1, :name, :frequency, :iso_code_3)""")
+                            connection.execute(language_query, {"iso_code_2t": value[0],
+                                                                        "iso_code_2b": value[1],
+                                                                        "iso_code_1": value[2], 
+                                                                        "name": value[3],
+                                                                        "frequency": value[4],
+                                                                        "iso_code_3": value[5]})
+                            transaction.commit()
+                            print("INSERTED language data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_script_data:
+                    for value in MB_script_data:
+                        transaction = connection.begin()
+                        try:
+                            script_query = text("""
+                                INSERT INTO musicbrainz.script
+                                    VALUES (:id, :iso_code, :iso_number, :name, :frequency)""")
+                            connection.execute(script_query, {"id": value[0],
+                                                                       "iso_code": value[1],
+                                                                       "iso_number": value[2],
+                                                                       "name": value[3],
+                                                                       "frequency": value[4]})
+                            transaction.commit()
+                            print("INSERTED script data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_gender_data:
+                    for value in MB_gender_data:
+                        transaction = connection.begin()
+                        try:
+                            gender_query = text("""
+                                INSERT INTO musicbrainz.gender
+                                    VALUES (:id, :name, :parent, :child_order, :description, :gid)""")
+                            connection.execute(gender_query, {"id": value[0],
+                                                              "name": value[1],
+                                                              "parent": value[2],
+                                                              "child_order": value[3],
+                                                              "description": value[4],
+                                                              "gid": value[5]})
+                            transaction.commit()
+                            print("INSERTED gender data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_area_data:
+                    for value in MB_area_data:
+                        transaction = connection.begin()
+                        try:
+                            area_query = text("""
+                                INSERT INTO musicbrainz.area
+                                    VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
+                                            :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
+                                            :ended, :comment)""")
+                            connection.execute(area_query, {"id": value[0],
+                                                                     "gid": value[1],
+                                                                     "name": value[2],
+                                                                     "type": value[3],
+                                                                     "edits_pending": value[4],
+                                                                     "last_updated": value[5],
+                                                                     "begin_date_year": value[6],
+                                                                     "begin_date_month": value[7],
+                                                                     "begin_date_day": value[8],
+                                                                     "end_date_year": value[9],
+                                                                     "end_date_month": value[10],
+                                                                     "end_date_day": value[11],
+                                                                     "ended": value[12],
+                                                                     "comment": value[13]})
+                            transaction.commit()
+                            print("INSERTED area data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_begin_area_data:
+                    for value in MB_begin_area_data:
+                        transaction = connection.begin()
+                        try:
+                            begin_area_query = text("""
+                                INSERT INTO musicbrainz.area
+                                    VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
+                                            :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
+                                            :ended, :comment)""")
+                            connection.execute(begin_area_query, {"id": value[0],
+                                                                     "gid": value[1],
+                                                                     "name": value[2],
+                                                                     "type": value[3],
+                                                                     "edits_pending": value[4],
+                                                                     "last_updated": value[5],
+                                                                     "begin_date_year": value[6],
+                                                                     "begin_date_month": value[7],
+                                                                     "begin_date_day": value[8],
+                                                                     "end_date_year": value[9],
+                                                                     "end_date_month": value[10],
+                                                                     "end_date_day": value[11],
+                                                                     "ended": value[12],
+                                                                     "comment": value[13]})
+                            transaction.commit()
+                            print("INSERTED begin_area data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_end_area_data:
+                    for value in MB_end_area_data:
+                        transaction = connection.begin()
+                        try:
+                            end_area_query = text("""
+                                INSERT INTO musicbrainz.area
+                                    VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
+                                            :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
+                                            :ended, :comment)""")
+                            connection.execute(end_area_query, {"id": value[0],
+                                                                     "gid": value[1],
+                                                                     "name": value[2],
+                                                                     "type": value[3],
+                                                                     "edits_pending": value[4],
+                                                                     "last_updated": value[5],
+                                                                     "begin_date_year": value[6],
+                                                                     "begin_date_month": value[7],
+                                                                     "begin_date_day": value[8],
+                                                                     "end_date_year": value[9],
+                                                                     "end_date_month": value[10],
+                                                                     "end_date_day": value[11],
+                                                                     "ended": value[12],
+                                                                     "comment": value[13]})
+                            transaction.commit()
+                            print("INSERTED end_area data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_artist_data:
+                    for value in MB_artist_data:
+                        transaction = connection.begin()
+                        try:
+                            artist_query = text("""
+                              INSERT INTO musicbrainz.artist
+                                  VALUES (:id, :gid, :name, :sort_name, :begin_date_year, :begin_date_month, :begin_date_day,
+                                        :end_date_year, :end_date_month, :end_date_day, :type, :area, :gender, :comment, :edits_pending,
+                                        :last_updated, :ended, :begin_area, :end_area)""")
+                            connection.execute(artist_query, {"id": value[0],
+                                                                       "gid": value[1],
+                                                                       "name": value[2],
+                                                                       "sort_name": value[3],
+                                                                       "begin_date_year": value[4],
+                                                                       "begin_date_month": value[5],
+                                                                       "begin_date_day": value[6],
+                                                                       "end_date_year": value[7],
+                                                                       "end_date_month": value[8],
+                                                                       "end_date_day": value[9],
+                                                                       "type": value[10],
+                                                                       "area": value[11],
+                                                                       "gender": value[12], 
+                                                                       "comment": value[13],
+                                                                       "edits_pending": value[14],
+                                                                       "last_updated": value[15],
+                                                                       "ended": value[16],
+                                                                       "begin_area": value[17],
+                                                                       "end_area": value[18]})
+                            transaction.commit()
+                            print("INSERTED artist data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_artist_credit_name_data:
+                    for value in MB_artist_credit_name_data:
+                        transaction = connection.begin()
+                        try:
+                            artist_credit_name_query = text("""
+                                INSERT INTO musicbrainz.artist_credit_name
+                                    VALUES (:artist_credit, :position, :artist, :name, :join_phrase)""")
+                            connection.execute(artist_credit_name_query, {"artist_credit": value[0],
+                                                                          "position": value[1],
+                                                                          "artist": value[2],
+                                                                          "name": value[3],
+                                                                          "join_phrase": value[4]})
+                            transaction.commit()
+                            print("INSERTED artist_credit_name data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_artist_gid_redirect_data:
+                    for value in MB_artist_gid_redirect_data:
+                        transaction = connection.begin()
+                        try:
+                            artist_gid_redirect_query = text("""
+                                INSERT INTO musicbrainz.artist_gid_redirect
+                                    VALUES (:gid, :new_id, :created)""")
+                            connection.execute(artist_gid_redirect_query, {"gid": value[0],
+                                                                            "new_id": value[1],
+                                                                            "created": value[2]})
+                            transaction.commit()
+                            print("INSERTED artist_gid_redirect data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+
+                if MB_recording_data:
+                    for value in MB_recording_data:
+                        transaction = connection.begin()
+                        try:
+                            recording_query = text("""
+                                INSERT INTO musicbrainz.recording
+                                    VALUES (:id, :gid, :name, :artist_credit, :length, :comment, :edits_pending, :last_updated, :video)""")
+                            connection.execute(recording_query, {"id": value[0],
+                                                                          "gid": value[1],
+                                                                          "name": value[2],
+                                                                          "artist_credit": value[3],
+                                                                          "length": value[4],
+                                                                          "comment": value[5],
+                                                                          "edits_pending": value[6],
+                                                                          "last_updated": value[7],
+                                                                          "video": value[8]})
+                            transaction.commit()
+                            print("INSERTED recording data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_recording_gid_redirect_data:
+                    for value in MB_recording_gid_redirect_data:
+                        transaction = connection.begin()
+                        try:
+                            recording_gid_redirect_query = text("""
+                                INSERT INTO musicbrainz.recording_gid_redirect
+                                    VALUES (:gid, :new_id, :created)""")
+                            connection.execute(recording_gid_redirect_query, {"gid": value[0],
+                                                                                       "new_id": value[1],
+                                                                                       "created": value[2]})
+                            transaction.commit()
+                            print("INSERTED recording_gid_redirect data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_release_group_data:
+                    for value in MB_release_group_data:
+                        transaction = connection.begin()
+                        try:
+                            release_group_query = text("""
+                                INSERT INTO musicbrainz.release_group
+                                    VALUES (:id, :gid, :name, :artist_credit, :type, :comment, :edits_pending, :last_updated)""")
+                            connection.execute(release_group_query, {"id": value[0],
+                                                                              "gid": value[1],
+                                                                              "name": value[2],
+                                                                              "artist_credit": value[3],
+                                                                              "type": value[4],
+                                                                              "comment": value[5],
+                                                                              "edits_pending": value[6],
+                                                                              "last_updated": value[7]})
+                            transaction.commit()
+                            print("INSERTED release_group data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_release_group_gid_redirect_data:
+                    for value in MB_release_group_gid_redirect_data:
+                        transaction = connection.begin()
+                        try:
+                            release_group_gid_redirect_query = text("""
+                                INSERT INTO musicbrainz.release_group_gid_redirect
+                                    VALUES (:gid, :new_id, :created)""")
+                            connection.execute(release_group_gid_redirect_query, {"gid": value[0],
+                                                                                           "new_id": value[1],
+                                                                                           "created": value[2]})
+                            transaction.commit()
+                            print("INSERTED release_gid_redirect data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_release_data:
+                    for value in MB_release_data:
+                        transaction = connection.begin()
+                        try:
+                            release_query = text("""
+                                INSERT INTO musicbrainz.release
+                                    VALUES (:id, :gid, :name, :artist_credit, :release_group, :status, :packaging, :language,
+                                            :script, :barcode, :comment, :edits_pending, :quality, :last_updated)""")
+                            connection.execute(release_query, {"id": value[0],
+                                                                        "gid": value[1],
+                                                                        "name": value[2],
+                                                                        "artist_credit": value[3],
+                                                                        "release_group": value[4],
+                                                                        "status": value[5],
+                                                                        "packaging": value[6],
+                                                                        "language": value[7],
+                                                                        "script": value[8],
+                                                                        "barcode": value[9],
+                                                                        "comment": value[10],
+                                                                        "edits_pending": value[11],
+                                                                        "quality": value[12],
+                                                                        "last_updated": value[13]})
+                            transaction.commit()
+                            print("INSERTED release data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_release_gid_redirect_data:
+                    for value in MB_release_gid_redirect_data:
+                        transaction = connection.begin()
+                        try:
+                            release_gid_redirect_query = text("""
+                                INSERT INTO musicbrainz.release_gid_redirect
+                                    VALUES (:gid, :new_id, :created)""")
+                            connection.execute(release_gid_redirect_query, {"gid": value[0],
+                                                                                           "new_id": value[1],
+                                                                                           "created": value[2]})
+                            transaction.commit()
+                            print("INSERTED release_gid_redirect data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_medium_data:
+                    for value in MB_medium_data:
+                        transaction = connection.begin()
+                        try:
+                            medium_query = text("""
+                                INSERT INTO musicbrainz.medium
+                                    VALUES (:id, :release, :position, :format, :name, :edits_pending, :last_updated, :track_count)""")
+                            connection.execute(medium_query, {"id": value[0],
+                                                                       "release": value[1],
+                                                                       "position": value[2],
+                                                                       "format": value[3],
+                                                                       "name": value[4],
+                                                                       "edits_pending": value[5],
+                                                                       "last_updated": value[6],
+                                                                       "track_count": value[7]})
+                            transaction.commit()
+                            print("INSERTED medium data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+                if MB_track_data:
+                    for value in MB_track_data:
+                        transaction = connection.begin()
+                        try:
+                            track_query = text("""
+                                INSERT INTO musicbrainz.track
+                                    VALUES (:id, :gid, :recording, :medium, :position, :number, :name, :artist_credit, :length,
+                                            :edits_pending, :last_updated, :is_data_track)""")
+                            connection.execute(track_query, {"id": value[0],
+                                                   "gid": value[1],
+                                                   "recording": value[2],
+                                                   "medium": value[3],
+                                                   "position": value[4],
+                                                   "number": value[5],
+                                                   "name": value[6],
+                                                   "artist_credit": value[7],
+                                                   "length": value[8],
+                                                   "edits_pending": value[9],
+                                                   "last_updated": value[10],
+                                                   "is_data_track": value[11]})
+                            transaction.commit()
+                            print("INSERTED track data\n")
+                        except IntegrityError as e:
+                            print(e.message)
+                            transaction.rollback()
+
+        print("--------------------------------DONE-----------------------------------")

--- a/db/import_mb_data.py
+++ b/db/import_mb_data.py
@@ -3,10 +3,10 @@ from brainzutils import musicbrainz_db
 from sqlalchemy import text
 
 def load_artist_credit(connection, gids_in_AB, MB_release_data):
-    """Fetches artist_credit table data from MusicBrainz database for the
+    """Fetch artist_credit table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
 
-    Also fetches data corresponding to release table.
+    Also fetch data corresponding to release table.
     """
     filters = []
     filter_data = {}
@@ -46,7 +46,7 @@ def load_artist_credit(connection, gids_in_AB, MB_release_data):
 
 
 def load_artist_type(connection, gids_in_AB):
-    """Fetches artist_type table data from MusicBrainz database for the
+    """Fetch artist_type table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     artist_type_query = text("""
@@ -72,7 +72,7 @@ def load_artist_type(connection, gids_in_AB):
 
 
 def load_area_type(connection, gids_in_AB):
-    """Fetches area_type table data from MusicBrainz database for the
+    """Fetch area_type table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     area_type_query =   text("""
@@ -100,7 +100,7 @@ def load_area_type(connection, gids_in_AB):
 
 
 def load_begin_area_type(connection, gids_in_AB):
-    """Fetches area_type table data from MusicBrainz database for the
+    """Fetch area_type table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database for the begin area column
     in artist table.
     """
@@ -129,7 +129,7 @@ def load_begin_area_type(connection, gids_in_AB):
 
 
 def load_end_area_type(connection, gids_in_AB):
-    """Fetches area_type table data from MusicBrainz database for the
+    """Fetch area_type table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database for the end area column in
     artist table.
     """
@@ -158,7 +158,7 @@ def load_end_area_type(connection, gids_in_AB):
 
 
 def load_release_status(connection, gids_in_AB):
-    """Fetches release_status table data from MusicBrainz database for the
+    """Fetch release_status table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     release_status_query = text("""
@@ -182,10 +182,10 @@ def load_release_status(connection, gids_in_AB):
 
 
 def load_release_group_primary_type(connection, gids_in_AB, MB_release_group_data):
-    """Fetches release_group_primary_type table data from MusicBrainz database for the
+    """Fetch release_group_primary_type table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
 
-    Also fetches data corresponding to release_group table.
+    Also fetch data corresponding to release_group table.
     """
     filters = []
     filter_data = {}
@@ -227,7 +227,7 @@ def load_release_group_primary_type(connection, gids_in_AB, MB_release_group_dat
 
 
 def load_medium_format(connection, gids_in_AB):
-    """Fetches medium_format table data from MusicBrainz database for the
+    """Fetch medium_format table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     medium_format_query = text("""
@@ -241,10 +241,10 @@ def load_medium_format(connection, gids_in_AB):
 
 
 def load_release_packaging(connection, gids_in_AB, MB_release_data):
-    """Fetches release_packaging table data from MusicBrainz database for the
+    """Fetch release_packaging table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
 
-    Also fetches data corresponding to release table.
+    Also fetch data corresponding to release table.
     """
     filters = []
     filter_data = {}
@@ -290,7 +290,7 @@ def load_release_packaging(connection, gids_in_AB, MB_release_data):
 
 
 def load_language(connection, gids_in_AB):
-    """Fetches language table data from MusicBrainz database for the
+    """Fetch language table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     language_query = text("""
@@ -315,7 +315,7 @@ def load_language(connection, gids_in_AB):
 
 
 def load_script(connection, gids_in_AB):
-    """Fetches script table data from MusicBrainz database for the
+    """Fetch script table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     script_query = text("""
@@ -338,7 +338,7 @@ def load_script(connection, gids_in_AB):
 
 
 def load_gender(connection, gids_in_AB):
-    """ Fetches gender table data from MusicBrainz database for the
+    """ Fetch gender table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     gender_query = text("""
@@ -364,7 +364,7 @@ def load_gender(connection, gids_in_AB):
 
 
 def load_area(connection, gids_in_AB):
-    """ Fetches area table data from MusicBrainz database for the
+    """ Fetch area table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     area_query = text("""
@@ -398,10 +398,10 @@ def load_area(connection, gids_in_AB):
 
 
 def load_begin_area(connection, gids_in_AB, MB_artist_data):
-    """Fetches area table data from MusicBrainz database for the
+    """Fetch area table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database for begin area column.
 
-    Also fetches data corresponding to artist table.
+    Also fetch data corresponding to artist table.
     """
     filters = []
     filter_data = {}
@@ -456,7 +456,7 @@ def load_begin_area(connection, gids_in_AB, MB_artist_data):
 
 
 def load_end_area(connection, gids_in_AB):
-    """Fetches area table data from MusicBrainz database for the
+    """Fetch area table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database for end area column.
     """
     end_area_query = text("""
@@ -490,7 +490,7 @@ def load_end_area(connection, gids_in_AB):
 
 
 def load_artist_credit_name(connection, gids_in_AB):
-    """Fetches artist_credit_name table data from MusicBrainz database
+    """Fetch artist_credit_name table data from MusicBrainz database
     for the recording MBIDs in AcousticBrainz database.
     """
     artist_credit_name_query = text("""
@@ -513,7 +513,7 @@ def load_artist_credit_name(connection, gids_in_AB):
 
 
 def load_artist(connection, gids_in_AB, MB_artist_credit_name_data):
-    """Fetches artist table data from MusicBrainz database for the
+    """Fetch artist table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
 
     Also fetch data corresponding to artist_credit_name table.
@@ -559,7 +559,7 @@ def load_artist(connection, gids_in_AB, MB_artist_credit_name_data):
 
 
 def load_artist_gid_redirect(connection, gids_in_AB):
-    """Fetches artist_gid_redirect table data from MusicBrainz database for the
+    """Fetch artist_gid_redirect table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     artist_gid_redirect_query = text("""
@@ -582,7 +582,7 @@ def load_artist_gid_redirect(connection, gids_in_AB):
 
 
 def load_recording(connection, gids_in_AB):
-    """Fetches recording table data from MusicBrainz database for the
+    """Fetch recording table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     recording_query = text("""
@@ -599,7 +599,7 @@ def load_recording(connection, gids_in_AB):
 
 
 def load_recording_gid_redirect(connection, gids_in_AB):
-    """Fetches recording_gid_redirect table data from MusicBrainz database for the
+    """Fetch recording_gid_redirect table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     recording_gid_redirect_query = text("""
@@ -618,7 +618,7 @@ def load_recording_gid_redirect(connection, gids_in_AB):
 
 
 def load_release_group(connection, gids_in_AB, MB_release_group_gid_redirect_data, MB_release_data):
-    """Fetches release_group table data from MusicBrainz database for the
+    """Fetch release_group table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
 
     Also fetch data corresponding to release_group_gid_redirect and
@@ -678,7 +678,7 @@ def load_release_group(connection, gids_in_AB, MB_release_group_gid_redirect_dat
 
 
 def load_release_group_gid_redirect(connection, gids_in_AB):
-    """Fetches release_group_gid_redirect table data from MusicBrainz database for the
+    """Fetch release_group_gid_redirect table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     release_group_gid_redirect_query = text("""
@@ -699,7 +699,7 @@ def load_release_group_gid_redirect(connection, gids_in_AB):
 
 
 def load_release(connection, gids_in_AB, MB_medium_data, MB_release_gid_redirect_data):
-    """Fetches release table data from MusicBrainz database for the
+    """Fetch release table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
 
     Also fetch data corresponding to medium and release_gid_redirect table.
@@ -764,7 +764,7 @@ def load_release(connection, gids_in_AB, MB_medium_data, MB_release_gid_redirect
 
 
 def load_release_gid_redirect(connection, gids_in_AB):
-    """Fetches release_gid_redirect table data from MusicBrainz database for the
+    """Fetch release_gid_redirect table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     release_gid_redirect_query = text("""
@@ -785,7 +785,7 @@ def load_release_gid_redirect(connection, gids_in_AB):
 
 
 def load_medium(connection, gids_in_AB, MB_track_data):
-    """Fetches medium table data from MusicBrainz database for the
+    """Fetch medium table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
 
     Also fetch data corresponding to track table.
@@ -835,7 +835,7 @@ def load_medium(connection, gids_in_AB, MB_track_data):
 
 
 def load_track(connection, gids_in_AB):
-    """Fetches track table data from MusicBrainz database for the
+    """Fetch track table data from MusicBrainz database for the
     recording MBIDs in AcousticBrainz database.
     """
     track_query = text("""

--- a/db/import_mb_data.py
+++ b/db/import_mb_data.py
@@ -1,36 +1,61 @@
 import db
 from brainzutils import musicbrainz_db
 from sqlalchemy import text
-from sqlalchemy.exc import IntegrityError
 
+def load_artist_credit(connection, gids_in_AB, MB_release_data):
+    """Fetches artist_credit table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
 
-def load_artist_credit(connection, gids_in_AB):
-    artist_credit_query = text("""
-        SELECT DISTINCT artist_credit.id, artist_credit.name, artist_credit.artist_count,
-                artist_credit.ref_count, artist_credit.created
-                FROM artist_credit
-                INNER JOIN recording
-                ON artist_credit.id = recording.artist_credit
-                WHERE recording.gid in :gids OR artist_credit.id in :data
-    """)
+    Also fetches data corresponding to release table.
+    """
+    filters = []
+    filter_data = {}
+
+    # Get data corresponding to artist_credit column in release table
     MB_release_fk_artist_credit = []
     for value in MB_release_data:
         MB_release_fk_artist_credit.append(value[3])
     MB_release_fk_artist_credit = list(set(MB_release_fk_artist_credit))
 
-    result = connection.execute(artist_credit_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_release_fk_artist_credit)})
-    global MB_artist_credit_data
+    if gids_in_AB:
+        filters.append("recording.gid in :gids")
+        filter_data["gids"] = tuple(gids_in_AB)
+
+    if MB_release_data:
+        filters.append("artist_credit.id in :data")
+        filter_data["data"] = tuple(MB_release_fk_artist_credit)
+
+    filterstr = " OR ".join(filters)
+    if filterstr:
+        filterstr = " WHERE " + filterstr
+
+    artist_credit_query = text("""
+        SELECT DISTINCT artist_credit.id, artist_credit.name, artist_credit.artist_count,
+                artist_credit.ref_count, artist_credit.created
+           FROM artist_credit
+     INNER JOIN recording
+             ON artist_credit.id = recording.artist_credit
+             {filterstr}
+    """.format(filterstr=filterstr)
+    )
+
+    result = connection.execute(artist_credit_query, filter_data)
     MB_artist_credit_data = result.fetchall()
+
+    return MB_artist_credit_data
 
 
 def load_artist_type(connection, gids_in_AB):
+    """Fetches artist_type table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     artist_type_query = text("""
         SELECT DISTINCT artist_type.id,
-                artist_type.name,
-                artist_type.parent,
-                artist_type.child_order,
-                artist_type.description,
-                artist_type.gid
+               artist_type.name,
+               artist_type.parent,
+               artist_type.child_order,
+               artist_type.description,
+               artist_type.gid
           FROM artist_type
     INNER JOIN artist
             ON artist.type = artist_type.id
@@ -41,11 +66,15 @@ def load_artist_type(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(artist_type_query, {'gids': tuple(gids_in_AB)})
-    global MB_artist_type_data
     MB_artist_type_data = result.fetchall()
+
+    return MB_artist_type_data
 
 
 def load_area_type(connection, gids_in_AB):
+    """Fetches area_type table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     area_type_query =   text("""
         SELECT DISTINCT area_type.id,
                area_type.name,
@@ -65,11 +94,16 @@ def load_area_type(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(area_type_query, {'gids': tuple(gids_in_AB)})
-    global MB_area_type_data
     MB_area_type_data = result.fetchall()
+
+    return MB_area_type_data
 
 
 def load_begin_area_type(connection, gids_in_AB):
+    """Fetches area_type table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database for the begin area column
+    in artist table.
+    """
     begin_area_type_query =   text("""
         SELECT DISTINCT area_type.id,
                area_type.name,
@@ -89,11 +123,16 @@ def load_begin_area_type(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(begin_area_type_query, {'gids': tuple(gids_in_AB)})
-    global MB_begin_area_type_data
     MB_begin_area_type_data = result.fetchall()
+
+    return MB_begin_area_type_data
 
 
 def load_end_area_type(connection, gids_in_AB):
+    """Fetches area_type table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database for the end area column in
+    artist table.
+    """
     end_area_type_query =   text("""
         SELECT DISTINCT area_type.id,
                area_type.name,
@@ -113,11 +152,15 @@ def load_end_area_type(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(end_area_type_query, {'gids': tuple(gids_in_AB)})
-    global MB_end_area_type_data
     MB_end_area_type_data = result.fetchall()
+
+    return MB_end_area_type_data
 
 
 def load_release_status(connection, gids_in_AB):
+    """Fetches release_status table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     release_status_query = text("""
         SELECT DISTINCT release_status.id,
                release_status.name,
@@ -133,42 +176,97 @@ def load_release_status(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(release_status_query, {'gids': tuple(gids_in_AB)})
-    global MB_release_status_data
     MB_release_status_data = result.fetchall()
 
+    return MB_release_status_data
 
-def load_release_group_primary_type(connection, gids_in_AB):
-    release_group_primary_type_query = text("""
-        SELECT DISTINCT release_group_primary_type.id, release_group_primary_type.name,
-               release_group_primary_type.parent, release_group_primary_type.child_order,
-               release_group_primary_type.description, release_group_primary_type.gid
-        FROM release_group_primary_type INNER JOIN release_group
-        ON release_group_primary_type.id = release_group.type
-        INNER JOIN recording
-                ON recording.artist_credit = release_group.artist_credit
-             WHERE recording.gid in :gids OR release_group_primary_type.id in :data
-    """)
+
+def load_release_group_primary_type(connection, gids_in_AB, MB_release_group_data):
+    """Fetches release_group_primary_type table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+
+    Also fetches data corresponding to release_group table.
+    """
+    filters = []
+    filter_data = {}
+
+    # Get data corresponding to release_group_primary_type column in release_group table
     MB_release_group_fk_type = []
     for value in MB_release_group_data:
         MB_release_group_fk_type.append(value[4])
     MB_release_group_fk_type = list(set(MB_release_group_fk_type))
 
-    result = connection.execute(release_group_primary_type_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_release_group_fk_type)})
-    global MB_release_group_primary_type_data
+    if gids_in_AB:
+        filters.append("recording.gid in :gids")
+        filter_data["gids"] = tuple(gids_in_AB)
+
+    if MB_release_group_data:
+        filters.append("release_group_primary_type.id in :data")
+        filter_data["data"] = tuple(MB_release_group_fk_type)
+
+    filterstr = " OR ".join(filters)
+    if filterstr:
+        filterstr = " WHERE " + filterstr
+
+    release_group_primary_type_query = text("""
+        SELECT DISTINCT release_group_primary_type.id, release_group_primary_type.name,
+               release_group_primary_type.parent, release_group_primary_type.child_order,
+               release_group_primary_type.description, release_group_primary_type.gid
+          FROM release_group_primary_type INNER JOIN release_group
+            ON release_group_primary_type.id = release_group.type
+    INNER JOIN recording
+            ON recording.artist_credit = release_group.artist_credit
+            {filterstr}
+    """.format(filterstr=filterstr)
+    )
+
+    result = connection.execute(release_group_primary_type_query, filter_data)
     MB_release_group_primary_type_data = result.fetchall()
+
+    return MB_release_group_primary_type_data
 
 
 def load_medium_format(connection, gids_in_AB):
+    """Fetches medium_format table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     medium_format_query = text("""
         SELECT * FROM medium_format
         ORDER BY id
     """)
     result = connection.execute(medium_format_query)
-    global MB_medium_format_data
     MB_medium_format_data = result.fetchall()
 
+    return MB_medium_format_data
 
-def load_release_packaging(connection, gids_in_AB):
+
+def load_release_packaging(connection, gids_in_AB, MB_release_data):
+    """Fetches release_packaging table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+
+    Also fetches data corresponding to release table.
+    """
+    filters = []
+    filter_data = {}
+
+    # Get data corresponding to release_packaging column in release table
+    MB_release_fk_packaging = []
+    for value in MB_release_data:
+        MB_release_fk_packaging.append(value[6])
+    MB_release_fk_packaging = list(set(MB_release_fk_packaging))
+
+    if gids_in_AB:
+        filters.append("recording.gid in :gids")
+        filter_data["gids"] = tuple(gids_in_AB)
+
+    if MB_release_data:
+        filters.append("release_packaging.id in :data")
+        filter_data["data"] = tuple(MB_release_fk_packaging)
+
+    filterstr = " OR ".join(filters)
+    if filterstr:
+        filterstr = " WHERE " + filterstr
+
     release_packaging_query = text("""
         SELECT DISTINCT release_packaging.id,
                release_packaging.name,
@@ -181,19 +279,20 @@ def load_release_packaging(connection, gids_in_AB):
             ON release.packaging = release_packaging.id
     INNER JOIN recording
             ON recording.artist_credit = release.artist_credit
-         WHERE recording.gid in :gids OR release_packaging.id in :data
-    """)
-    MB_release_fk_packaging = []
-    for value in MB_release_data:
-        MB_release_fk_packaging.append(value[6])
-    MB_release_fk_packaging = list(set(MB_release_fk_packaging))
+            {filterstr}
+    """.format(filterstr=filterstr)
+    )
 
-    result = connection.execute(release_packaging_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_release_fk_packaging)})
-    global MB_release_packaging_data
+    result = connection.execute(release_packaging_query, filter_data)
     MB_release_packaging_data = result.fetchall()
+
+    return MB_release_packaging_data
 
 
 def load_language(connection, gids_in_AB):
+    """Fetches language table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     language_query = text("""
         SELECT DISTINCT language.id,
                language.iso_code_2t,
@@ -210,11 +309,15 @@ def load_language(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(language_query, {'gids': tuple(gids_in_AB)})
-    global MB_language_data
     MB_language_data = result.fetchall()
+
+    return MB_language_data
 
 
 def load_script(connection, gids_in_AB):
+    """Fetches script table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     script_query = text("""
         SELECT DISTINCT script.id,
                script.iso_code,
@@ -229,11 +332,15 @@ def load_script(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(script_query, {'gids': tuple(gids_in_AB)})
-    global MB_script_data
     MB_script_data = result.fetchall()
+
+    return MB_script_data
 
 
 def load_gender(connection, gids_in_AB):
+    """ Fetches gender table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     gender_query = text("""
         SELECT DISTINCT gender.id,
                gender.name,
@@ -251,11 +358,15 @@ def load_gender(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(gender_query, {'gids': tuple(gids_in_AB)})
-    global MB_gender_data
     MB_gender_data = result.fetchall()
+
+    return MB_gender_data
 
 
 def load_area(connection, gids_in_AB):
+    """ Fetches area table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     area_query = text("""
         SELECT DISTINCT area.id,
                area.gid,
@@ -281,11 +392,37 @@ def load_area(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(area_query, {'gids': tuple(gids_in_AB)})
-    global MB_area_data
     MB_area_data = result.fetchall()
 
+    return MB_area_data
 
-def load_begin_area(connection, gids_in_AB):
+
+def load_begin_area(connection, gids_in_AB, MB_artist_data):
+    """Fetches area table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database for begin area column.
+
+    Also fetches data corresponding to artist table.
+    """
+    filters = []
+    filter_data = {}
+
+    # Get data corresponding to begin_area column in artist table
+    MB_artist_fk_begin_area = []
+    for value in MB_artist_data:
+        MB_artist_fk_begin_area.append(value[17])
+
+    if gids_in_AB:
+        filters.append("recording.gid in :gids")
+        filter_data["gids"] = tuple(gids_in_AB)
+
+    if MB_artist_data:
+        filters.append("area.id in :data")
+        filter_data["data"] = tuple(MB_artist_fk_begin_area)
+
+    filterstr = " OR ".join(filters)
+    if filterstr:
+        filterstr = " WHERE " + filterstr
+
     begin_area_query = text("""
         SELECT DISTINCT area.id,
                area.gid,
@@ -308,18 +445,20 @@ def load_begin_area(connection, gids_in_AB):
             ON artist.id = artist_credit.id
     INNER JOIN recording
             ON artist_credit.id = recording.artist_credit
-         WHERE recording.gid in :gids OR area.id in :data
-    """)
-    MB_artist_fk_begin_area = []
-    for value in MB_artist_data:
-        MB_artist_fk_begin_area.append(value[17])
+            {filterstr}
+    """.format(filterstr=filterstr)
+    )
 
-    result = connection.execute(begin_area_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_artist_fk_begin_area)})
-    global MB_begin_area_data
+    result = connection.execute(begin_area_query, filter_data)
     MB_begin_area_data = result.fetchall()
+
+    return MB_begin_area_data
 
 
 def load_end_area(connection, gids_in_AB):
+    """Fetches area table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database for end area column.
+    """
     end_area_query = text("""
         SELECT DISTINCT area.id,
                area.gid,
@@ -345,11 +484,15 @@ def load_end_area(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(end_area_query, {'gids': tuple(gids_in_AB)})
-    global MB_end_area_data
     MB_end_area_data = result.fetchall()
+
+    return MB_end_area_data
 
 
 def load_artist_credit_name(connection, gids_in_AB):
+    """Fetches artist_credit_name table data from MusicBrainz database
+    for the recording MBIDs in AcousticBrainz database.
+    """
     artist_credit_name_query = text("""
         SELECT DISTINCT artist_credit_name.artist_credit,
                artist_credit_name.position,
@@ -364,11 +507,37 @@ def load_artist_credit_name(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(artist_credit_name_query, {'gids': tuple(gids_in_AB)})
-    global MB_artist_credit_name_data
     MB_artist_credit_name_data = result.fetchall()
 
+    return MB_artist_credit_name_data
 
-def load_artist(connection, gids_in_AB):
+
+def load_artist(connection, gids_in_AB, MB_artist_credit_name_data):
+    """Fetches artist table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+
+    Also fetch data corresponding to artist_credit_name table.
+    """
+    filters = []
+    filter_data = {}
+
+    # Get data corresponding to artist column in artist_credit_name table.
+    MB_artist_credit_name_fk_artist = []
+    for value in MB_artist_credit_name_data:
+        MB_artist_credit_name_fk_artist.append(value[2])
+
+    if gids_in_AB:
+        filters.append("recording.gid in :gids")
+        filter_data["gids"] = tuple(gids_in_AB)
+
+    if MB_artist_credit_name_data:
+        filters.append("artist.id in :data")
+        filter_data["data"] = tuple(MB_artist_credit_name_fk_artist)
+
+    filterstr = " OR ".join(filters)
+    if filterstr:
+        filterstr = " WHERE " + filterstr
+
     artist_query = text("""
         SELECT DISTINCT artist.id, artist.gid, artist.name, artist.sort_name, artist.begin_date_year,
                artist.begin_date_month, artist.begin_date_day, artist.end_date_year, artist.end_date_month,
@@ -379,18 +548,20 @@ def load_artist(connection, gids_in_AB):
             ON artist_credit.id = artist.id
     INNER JOIN recording
             ON artist_credit.id = recording.artist_credit
-         WHERE recording.gid in :gids OR artist.id in :data
-    """)
-    MB_artist_credit_name_fk_artist = []
-    for value in MB_artist_credit_name_data:
-        MB_artist_credit_name_fk_artist.append(value[2])
+            {filterstr}
+    """.format(filterstr=filterstr)
+    )
 
-    result = connection.execute(artist_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_artist_credit_name_fk_artist)})
-    global MB_artist_data
+    result = connection.execute(artist_query, filter_data)
     MB_artist_data = result.fetchall()
+
+    return MB_artist_data
 
 
 def load_artist_gid_redirect(connection, gids_in_AB):
+    """Fetches artist_gid_redirect table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     artist_gid_redirect_query = text("""
         SELECT DISTINCT artist_gid_redirect.gid,
                artist_gid_redirect.new_id,
@@ -405,11 +576,15 @@ def load_artist_gid_redirect(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(artist_gid_redirect_query, {'gids': tuple(gids_in_AB)})
-    global MB_artist_gid_redirect_data
     MB_artist_gid_redirect_data = result.fetchall()
+
+    return MB_artist_gid_redirect_data
 
 
 def load_recording(connection, gids_in_AB):
+    """Fetches recording table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     recording_query = text("""
         SELECT DISTINCT recording.id, recording.gid, recording.name, recording.artist_credit,
                recording.length, recording.comment, recording.edits_pending, recording.last_updated,
@@ -418,11 +593,15 @@ def load_recording(connection, gids_in_AB):
         WHERE  recording.gid in :gids
     """)
     result = connection.execute(recording_query, {'gids': tuple(gids_in_AB)})
-    global MB_recording_data
     MB_recording_data = result.fetchall()
+
+    return MB_recording_data
 
 
 def load_recording_gid_redirect(connection, gids_in_AB):
+    """Fetches recording_gid_redirect table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     recording_gid_redirect_query = text("""
         SELECT DISTINCT recording_gid_redirect.gid,
                recording_gid_redirect.new_id,
@@ -433,11 +612,49 @@ def load_recording_gid_redirect(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(recording_gid_redirect_query, {'gids': tuple(gids_in_AB)})
-    global MB_recording_gid_redirect_data
     MB_recording_gid_redirect_data = result.fetchall()
 
+    return MB_recording_gid_redirect_data
 
-def load_release_group(connection, gids_in_AB):
+
+def load_release_group(connection, gids_in_AB, MB_release_group_gid_redirect_data, MB_release_data):
+    """Fetches release_group table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+
+    Also fetch data corresponding to release_group_gid_redirect and
+    release table.
+    """
+    filters = []
+    filter_data = {}
+
+    # Get data corresponding to release_group column in release_group_gid_redirect table.
+    MB_release_group_gid_redirect_fk_release_group = []
+    for value in MB_release_group_gid_redirect_data:
+        MB_release_group_gid_redirect_fk_release_group.append(value[1])
+    MB_release_group_gid_redirect_fk_release_group = list(set(MB_release_group_gid_redirect_fk_release_group))
+
+    # Get data corresponding to release_group column in release table.
+    MB_release_fk_release_group = []
+    for value in MB_release_data:
+        MB_release_fk_release_group.append(value[4])
+    MB_release_fk_release_group = list(set(MB_release_fk_release_group))
+
+    if gids_in_AB:
+        filters.append("recording.gid in :gids")
+        filter_data["gids"] = tuple(gids_in_AB)
+
+    if MB_release_group_gid_redirect_data:
+        filters.append("release_group.id in :redirect_data")
+        filter_data["redirect_data"] = tuple(MB_release_group_gid_redirect_fk_release_group)
+
+    if MB_release_data:
+        filters.append("release_group.id in :release_data")
+        filter_data["release_data"] = tuple(MB_release_fk_release_group)
+
+    filterstr = " OR ".join(filters)
+    if filterstr:
+        filterstr = " WHERE " + filterstr
+
     release_group_query = text("""
         SELECT DISTINCT release_group.id,
                release_group.gid,
@@ -450,26 +667,20 @@ def load_release_group(connection, gids_in_AB):
           FROM release_group
     INNER JOIN recording
             ON recording.artist_credit = release_group.artist_credit
-         WHERE recording.gid in :gids OR release_group.id in :redirect_data OR release_group.id in :release_data
-    """)
-    MB_release_group_gid_redirect_fk_release_group = []
-    for value in MB_release_group_gid_redirect_data:
-        MB_release_group_gid_redirect_fk_release_group.append(value[1])
-    MB_release_group_gid_redirect_fk_release_group = list(set(MB_release_group_gid_redirect_fk_release_group))
+            {filterstr}
+    """.format(filterstr=filterstr)
+    )
 
-    MB_release_fk_release_group = []
-    for value in MB_release_data:
-        MB_release_fk_release_group.append(value[4])
-    MB_release_fk_release_group = list(set(MB_release_fk_release_group))
-
-    result = connection.execute(release_group_query, {'gids': tuple(gids_in_AB),
-                                                      'redirect_data': tuple(MB_release_group_gid_redirect_fk_release_group),
-                                                      'release_data': tuple(MB_release_fk_release_group)})
-    global MB_release_group_data
+    result = connection.execute(release_group_query, filter_data)
     MB_release_group_data = result.fetchall()
+
+    return MB_release_group_data
 
 
 def load_release_group_gid_redirect(connection, gids_in_AB):
+    """Fetches release_group_gid_redirect table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     release_group_gid_redirect_query = text("""
         SELECT DISTINCT release_group_gid_redirect.gid,
                release_group_gid_redirect.new_id,
@@ -482,11 +693,48 @@ def load_release_group_gid_redirect(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(release_group_gid_redirect_query, {'gids': tuple(gids_in_AB)})
-    global MB_release_group_gid_redirect_data
     MB_release_group_gid_redirect_data = result.fetchall()
 
+    return MB_release_group_gid_redirect_data
 
-def load_release(connection, gids_in_AB):
+
+def load_release(connection, gids_in_AB, MB_medium_data, MB_release_gid_redirect_data):
+    """Fetches release table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+
+    Also fetch data corresponding to medium and release_gid_redirect table.
+    """
+    filters = []
+    filter_data = {}
+
+    # Get data corresponding to release column in medium table.
+    MB_medium_fk_release = []
+    for value in MB_medium_data:
+        MB_medium_fk_release.append(value[1])
+    MB_medium_fk_release = list(set(MB_medium_fk_release))
+
+    # Get data corresponding to release column in release_gid_redirect table.
+    MB_release_gid_redirect_fk_release = []
+    for value in MB_release_gid_redirect_data:
+        MB_release_gid_redirect_fk_release.append(value[1])
+    MB_release_gid_redirect_fk_release = list(set(MB_release_gid_redirect_fk_release))
+
+    if gids_in_AB:
+        filters.append("recording.gid in :gids")
+        filter_data["gids"] = tuple(gids_in_AB)
+
+    if MB_medium_data:
+        filters.append("release.id in :medium_data")
+        filter_data["medium_data"] = tuple(MB_medium_fk_release)
+
+    if MB_release_gid_redirect_data:
+        filters.append("release.id in :redirect_data")
+        filter_data["redirect_data"] = tuple(MB_release_gid_redirect_fk_release)
+
+    filterstr = " OR ".join(filters)
+    if filterstr:
+        filterstr = " WHERE " + filterstr
+
     release_query = text("""
         SELECT DISTINCT release.id,
                release.gid,
@@ -505,27 +753,20 @@ def load_release(connection, gids_in_AB):
           FROM release
     INNER JOIN recording
             ON recording.artist_credit = release.artist_credit
-         WHERE recording.gid in :gids OR release.id in :medium_data OR release.id in :redirect_data
-    """)
-    MB_medium_fk_release = []
-    for value in MB_medium_data:
-        MB_medium_fk_release.append(value[1])
-    MB_medium_fk_release = list(set(MB_medium_fk_release))
+            {filterstr}
+    """.format(filterstr=filterstr)
+    )
 
-    MB_release_gid_redirect_fk_release = []
-    for value in MB_release_gid_redirect_data:
-        MB_release_gid_redirect_fk_release.append(value[1])
-    MB_release_gid_redirect_fk_release = list(set(MB_release_gid_redirect_fk_release))
-
-    result = connection.execute(release_query, {'gids': tuple(gids_in_AB),
-                                                'medium_data': tuple(MB_medium_fk_release),
-                                                'redirect_data': tuple(MB_release_gid_redirect_fk_release)
-                                               })
-    global MB_release_data
+    result = connection.execute(release_query, filter_data)
     MB_release_data = result.fetchall()
+
+    return MB_release_data
 
 
 def load_release_gid_redirect(connection, gids_in_AB):
+    """Fetches release_gid_redirect table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     release_gid_redirect_query = text("""
         SELECT DISTINCT release_gid_redirect.gid,
                release_gid_redirect.new_id,
@@ -538,11 +779,37 @@ def load_release_gid_redirect(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(release_gid_redirect_query, {'gids': tuple(gids_in_AB)})
-    global MB_release_gid_redirect_data
     MB_release_gid_redirect_data = result.fetchall()
 
+    return MB_release_gid_redirect_data
 
-def load_medium(connection, gids_in_AB):
+
+def load_medium(connection, gids_in_AB, MB_track_data):
+    """Fetches medium table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+
+    Also fetch data corresponding to track table.
+    """
+    filters = []
+    filter_data = {}
+
+    # Get data corresponding to medium column in track table.
+    MB_track_fk_medium = []
+    for value in MB_track_data:
+        MB_track_fk_medium.append(value[3])
+
+    if gids_in_AB:
+        filters.append("recording.gid in :gids")
+        filter_data["gids"] = tuple(gids_in_AB)
+
+    if MB_track_data:
+        filters.append("medium.id in :data")
+        filter_data["data"] = tuple(MB_track_fk_medium)
+
+    filterstr = " OR ".join(filters)
+    if filterstr:
+        filterstr = " WHERE " + filterstr
+
     medium_query = text("""
         SELECT DISTINCT medium.id,
                medium.release,
@@ -557,18 +824,20 @@ def load_medium(connection, gids_in_AB):
             ON release.id = medium.release
     INNER JOIN recording
             ON recording.artist_credit=release.artist_credit
-         WHERE recording.gid in :gids OR medium.id in :data
-    """)
-    MB_track_fk_medium = []
-    for value in MB_track_data:
-        MB_track_fk_medium.append(value[3])
+            {filterstr}
+    """.format(filterstr=filterstr)
+    )
 
-    result = connection.execute(medium_query, {'gids': tuple(gids_in_AB), 'data': tuple(MB_track_fk_medium)})
-    global MB_medium_data
+    result = connection.execute(medium_query, filter_data)
     MB_medium_data = result.fetchall()
+
+    return MB_medium_data
 
 
 def load_track(connection, gids_in_AB):
+    """Fetches track table data from MusicBrainz database for the
+    recording MBIDs in AcousticBrainz database.
+    """
     track_query = text("""
         SELECT DISTINCT track.id,
                track.gid,
@@ -588,18 +857,19 @@ def load_track(connection, gids_in_AB):
          WHERE recording.gid in :gids
     """)
     result = connection.execute(track_query, {'gids': tuple(gids_in_AB)})
-    global MB_track_data
     MB_track_data = result.fetchall()
 
+    return MB_track_data
 
-print("--------------------------------------------------------------------------------------------------")
 
-
-# TO ACOUSTICBRAINZ
-def write_artist_credit(transaction, connection):
+def write_artist_credit(connection, MB_artist_credit_data):
+    """Insert data into artist_credit table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     artist_credit_query = text("""
         INSERT INTO musicbrainz.artist_credit
-            VALUES (:id, :name, :artist_count, :ref_count, :created)
+             VALUES (:id, :name, :artist_count, :ref_count, :created)
+                 ON CONFLICT (id) DO NOTHING
     """)
     values = [{
         "id" : value[0],
@@ -609,14 +879,17 @@ def write_artist_credit(transaction, connection):
         "created" : value[4]} for value in MB_artist_credit_data
     ]
     connection.execute(artist_credit_query, values)
-    transaction.commit()
     print("INSERTED artist_credit data\n")
 
 
-def write_artist_type(transaction, connection):
+def write_artist_type(connection, MB_artist_type_data):
+    """Insert data in artist_type table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     artist_type_query = text("""
-        INSERT INTO musicbrainz.artist_type
-            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+        INSERT INTO musicbrainz.artist_type(id, name, parent, child_order, description, gid)
+             VALUES (:id, :name, :parent, :child_order, :description, :gid)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -627,14 +900,17 @@ def write_artist_type(transaction, connection):
         "gid" : value[5]} for value in MB_artist_type_data
     ]
     connection.execute(artist_type_query, values)
-    transaction.commit()
     print("INSERTED artist_type data\n")
 
 
-def write_area_type(transaction, connection):
+def write_area_type(connection, MB_area_type_data):
+    """Insert data in area_type table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     area_type_query = text("""
         INSERT INTO musicbrainz.area_type
-            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+             VALUES (:id, :name, :parent, :child_order, :description, :gid)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -645,14 +921,17 @@ def write_area_type(transaction, connection):
         "gid": value[5]} for value in MB_area_type_data
     ]
     connection.execute(area_type_query, values)
-    transaction.commit()
     print("INSERTED area_type data\n")
 
 
-def write_begin_area_type(transaction, connection):
+def write_begin_area_type(connection, MB_begin_area_type_data):
+    """Insert data in area_type table in musicbrainz schema in
+    AcousticBrainz database for begin_area column in artist table.
+    """
     begin_area_type_query = text("""
         INSERT INTO musicbrainz.area_type
-            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+             VALUES (:id, :name, :parent, :child_order, :description, :gid)
+                 ON CONFLICT (id) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -663,14 +942,17 @@ def write_begin_area_type(transaction, connection):
         "gid": value[5]} for value in MB_begin_area_type_data
     ]
     connection.execute(begin_area_type_query, values)
-    transaction.commit()
     print("INSERTED begin_area_type data\n")
 
 
-def write_end_area_type(transaction, connection):
+def write_end_area_type(connection, MB_end_area_type_data):
+    """Insert data in area_type table in musicbrainz schema in
+    AcousticBrainz database for end area column in artist table.
+    """
     end_area_type_query = text("""
-        INSERT INTO musicbrainz.area_type
-            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+        INSERT INTO musicbrainz.area_type(id, name, parent, child_order, description, gid)
+             VALUES (:id, :name, :parent, :child_order, :description, :gid)
+                 ON CONFLICT (id) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -681,14 +963,17 @@ def write_end_area_type(transaction, connection):
         "gid": value[5]} for value in MB_end_area_type_data
     ]
     connection.execute(end_area_type_query, values)
-    transaction.commit()
     print("INSERTED end_area_type data\n")
 
 
-def write_release_status(transaction, connection):
+def write_release_status(connection, MB_release_status_data):
+    """Insert data in release_status table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     release_status_query = text("""
         INSERT INTO musicbrainz.release_status
-            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+             VALUES (:id, :name, :parent, :child_order, :description, :gid)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values= [{
         "id": value[0],
@@ -699,14 +984,17 @@ def write_release_status(transaction, connection):
         "gid": value[5]} for value in MB_release_status_data
     ]
     result = connection.execute(release_status_query, values)
-    transaction.commit()
     print("INSERTED release_status data\n")
 
 
-def write_release_group_primary_type(transaction, connection):
+def write_release_group_primary_type(connection, MB_release_group_primary_type_data):
+    """Insert data in release_group_primary_type table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     release_group_primary_type_query = text("""
         INSERT INTO musicbrainz.release_group_primary_type
-            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+             VALUES (:id, :name, :parent, :child_order, :description, :gid)
+                 ON CONFLICT (id) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -717,14 +1005,17 @@ def write_release_group_primary_type(transaction, connection):
         "gid": value[5]} for value in MB_release_group_primary_type_data
     ]
     connection.execute(release_group_primary_type_query, values)
-    transaction.commit()
     print("INSERTED release_group_primary_type data\n")
 
 
-def write_medium_format(transaction, connection):
+def write_medium_format(connection, MB_medium_format_data):
+    """Insert data in medium_format table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     medium_format_query = text("""
         INSERT INTO musicbrainz.medium_format
-            VALUES (:id, :name, :parent, :child_order, :year, :has_discids, :description, :gid)
+             VALUES (:id, :name, :parent, :child_order, :year, :has_discids, :description, :gid)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -738,14 +1029,17 @@ def write_medium_format(transaction, connection):
     ]
     connection.execute(text("""ALTER TABLE musicbrainz.medium_format DROP CONSTRAINT IF EXISTS medium_format_fk_parent"""))
     connection.execute(medium_format_query, values)
-    transaction.commit()
     print("INSERTED medium_format data\n")
 
 
-def write_release_packaging(transaction, connection):
+def write_release_packaging(connection, MB_release_packaging_data):
+    """Insert data in release_packaging table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     release_packaging_query = text("""
         INSERT INTO musicbrainz.release_packaging
-            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+             VALUES (:id, :name, :parent, :child_order, :description, :gid)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -756,14 +1050,17 @@ def write_release_packaging(transaction, connection):
         "gid": value[5]} for value in MB_release_packaging_data
     ]
     connection.execute(release_packaging_query, values)
-    transaction.commit()
     print("INSERTED release_packaging data\n")
 
 
-def write_language(transaction, connection):
+def write_language(connection, MB_language_data):
+    """Insert data in language table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     language_query = text("""
         INSERT INTO musicbrainz.language
-            VALUES (:iso_code_2t, :iso_code_2b, :iso_code_1, :name, :frequency, :iso_code_3)
+             VALUES (:iso_code_2t, :iso_code_2b, :iso_code_1, :name, :frequency, :iso_code_3)
+                 ON CONFLICT (iso_code_2b) DO NOTHING
     """)
     values = [{
         "iso_code_2t": value[0],
@@ -774,14 +1071,17 @@ def write_language(transaction, connection):
         "iso_code_3": value[5]} for value in MB_language_data
     ]
     connection.execute(language_query, values)
-    transaction.commit()
     print("INSERTED language data\n")
 
 
-def write_script(transaction, connection):
+def write_script(connection, MB_script_data):
+    """Insert data in script table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     script_query = text("""
         INSERT INTO musicbrainz.script
-            VALUES (:id, :iso_code, :iso_number, :name, :frequency)
+             VALUES (:id, :iso_code, :iso_number, :name, :frequency)
+                 ON CONFLICT (iso_code) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -791,14 +1091,17 @@ def write_script(transaction, connection):
         "frequency": value[4]} for value in MB_script_data
     ]
     connection.execute(script_query, values)
-    transaction.commit()
     print("INSERTED script data\n")
 
 
-def write_gender(transaction, connection):
+def write_gender(connection, MB_gender_data):
+    """Insert data in gender table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     gender_query = text("""
         INSERT INTO musicbrainz.gender
-            VALUES (:id, :name, :parent, :child_order, :description, :gid)
+             VALUES (:id, :name, :parent, :child_order, :description, :gid)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -809,16 +1112,19 @@ def write_gender(transaction, connection):
         "gid": value[5]} for value in MB_gender_data
     ]
     connection.execute(gender_query, values)
-    transaction.commit()
     print("INSERTED gender data\n")
 
 
-def write_area(transaction, connection):
+def write_area(connection, MB_area_data):
+    """Insert data in area table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     area_query = text("""
         INSERT INTO musicbrainz.area
-            VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
-                    :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
-                    :ended, :comment)
+             VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
+                     :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
+                     :ended, :comment)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -837,16 +1143,20 @@ def write_area(transaction, connection):
         "comment": value[13]} for value in MB_area_data
     ]
     connection.execute(area_query, values)
-    transaction.commit()
     print("INSERTED area data\n")
 
 
-def write_begin_area(transaction, connection):
+def write_begin_area(connection, MB_begin_area_data):
+    """Insert data in area table in musicbrainz schema in
+    AcousticBrainz database for begin_area column in artist
+    table.
+    """
     begin_area_query = text("""
         INSERT INTO musicbrainz.area
-            VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
-                    :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
-                    :ended, :comment)
+             VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
+                     :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
+                     :ended, :comment)
+                 ON CONFLICT (id) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -865,16 +1175,20 @@ def write_begin_area(transaction, connection):
         "comment": value[13]} for value in MB_begin_area_data
     ]
     connection.execute(begin_area_query, values)
-    transaction.commit()
     print("INSERTED begin_area data\n")
 
 
-def write_end_area(transaction, connection):
+def write_end_area(connection, MB_end_area_data):
+    """Insert data in area table in musicbrainz schema in
+    AcousticBrainz database for end_area column in artist
+    table.
+    """
     end_area_query = text("""
         INSERT INTO musicbrainz.area
-            VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
-                    :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
-                    :ended, :comment)
+             VALUES (:id, :gid, :name, :type, :edits_pending, :last_updated, :begin_date_year,
+                     :begin_date_month, :begin_date_day, :end_date_year, :end_date_month, :end_date_day,
+                     :ended, :comment)
+                 ON CONFLICT (id) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -893,17 +1207,19 @@ def write_end_area(transaction, connection):
         "comment": value[13]} for value in MB_end_area_data
     ]
     connection.execute(end_area_query, values)
-    transaction.commit()
     print("INSERTED end_area data\n")
 
 
-def write_artist(transaction, connection):
+def write_artist(connection, MB_artist_data):
+    """Insert data in artist table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     artist_query = text("""
       INSERT INTO musicbrainz.artist
-          VALUES (:id, :gid, :name, :sort_name, :begin_date_year, :begin_date_month, :begin_date_day,
-                :end_date_year, :end_date_month, :end_date_day, :type, :area, :gender, :comment, :edits_pending,
-                :last_updated, :ended, :begin_area, :end_area)
-          ON conflict do nothing
+           VALUES (:id, :gid, :name, :sort_name, :begin_date_year, :begin_date_month, :begin_date_day,
+                   :end_date_year, :end_date_month, :end_date_day, :type, :area, :gender, :comment, :edits_pending,
+                   :last_updated, :ended, :begin_area, :end_area)
+               ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -927,14 +1243,17 @@ def write_artist(transaction, connection):
         "end_area": value[18]} for value in MB_artist_data
     ]
     connection.execute(artist_query, values)
-    transaction.commit()
     print("INSERTED artist data\n")
 
 
-def write_artist_credit_name(transaction, connection):
+def write_artist_credit_name(connection, MB_artist_credit_name_data):
+    """Insert data in artist_credit_name table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     artist_credit_name_query = text("""
         INSERT INTO musicbrainz.artist_credit_name
-            VALUES (:artist_credit, :position, :artist, :name, :join_phrase)
+             VALUES (:artist_credit, :position, :artist, :name, :join_phrase)
+                 ON CONFLICT (artist_credit, position) DO NOTHING
     """)
     values = [{
         "artist_credit": value[0],
@@ -944,14 +1263,17 @@ def write_artist_credit_name(transaction, connection):
         "join_phrase": value[4]} for value in MB_artist_credit_name_data
     ]
     connection.execute(artist_credit_name_query, values)
-    transaction.commit()
     print("INSERTED artist_credit_name data\n")
 
 
-def write_artist_gid_redirect(transaction, connection):
+def write_artist_gid_redirect(connection, MB_artist_gid_redirect_data):
+    """Insert data in artist_gid_redirect table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     artist_gid_redirect_query = text("""
         INSERT INTO musicbrainz.artist_gid_redirect
-            VALUES (:gid, :new_id, :created)
+             VALUES (:gid, :new_id, :created)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "gid": value[0],
@@ -959,14 +1281,17 @@ def write_artist_gid_redirect(transaction, connection):
         "created": value[2]} for value in MB_artist_gid_redirect_data
     ]
     connection.execute(artist_gid_redirect_query, values)
-    transaction.commit()
     print("INSERTED artist_gid_redirect data\n")
 
 
-def write_recording(transaction, connection):
+def write_recording(connection, MB_recording_data):
+    """Insert data in recording table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     recording_query = text("""
         INSERT INTO musicbrainz.recording
-            VALUES (:id, :gid, :name, :artist_credit, :length, :comment, :edits_pending, :last_updated, :video)
+             VALUES (:id, :gid, :name, :artist_credit, :length, :comment, :edits_pending, :last_updated, :video)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -980,28 +1305,34 @@ def write_recording(transaction, connection):
         "video": value[8]} for value in MB_recording_data
     ]
     connection.execute(recording_query, values)
-    transaction.commit()
     print("INSERTED recording data\n")
 
 
-def write_recording_gid_redirect(transaction, connection):
+def write_recording_gid_redirect(connection, MB_recording_gid_redirect_data):
+    """Insert data in recording_gid_redirect table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     recording_gid_redirect_query = text("""
         INSERT INTO musicbrainz.recording_gid_redirect
-            VALUES (:gid, :new_id, :created)
+             VALUES (:gid, :new_id, :created)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{"gid": value[0],
         "new_id": value[1],
         "created": value[2]} for value in MB_recording_gid_redirect_data
     ]
     connection.execute(recording_gid_redirect_query, values)
-    transaction.commit()
     print("INSERTED recording_gid_redirect data\n")
 
 
-def write_release_group(transaction, connection):
+def write_release_group(connection, MB_release_group_data):
+    """Insert data in release_group table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     release_group_query = text("""
         INSERT INTO musicbrainz.release_group
-            VALUES (:id, :gid, :name, :artist_credit, :type, :comment, :edits_pending, :last_updated)
+             VALUES (:id, :gid, :name, :artist_credit, :type, :comment, :edits_pending, :last_updated)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -1014,14 +1345,17 @@ def write_release_group(transaction, connection):
         "last_updated": value[7]} for value in MB_release_group_data
     ]
     connection.execute(release_group_query, values)
-    transaction.commit()
     print("INSERTED release_group data\n")
 
 
-def write_release_group_gid_redirect(transaction, connection):
+def write_release_group_gid_redirect(connection, MB_release_gid_redirect_data):
+    """Insert data in release_group_gid_redirect table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     release_group_gid_redirect_query = text("""
         INSERT INTO musicbrainz.release_group_gid_redirect
-            VALUES (:gid, :new_id, :created)
+             VALUES (:gid, :new_id, :created)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "gid": value[0],
@@ -1029,15 +1363,18 @@ def write_release_group_gid_redirect(transaction, connection):
         "created": value[2]} for value in MB_release_gid_redirect_data
     ]
     connection.execute(release_group_gid_redirect_query, values)
-    transaction.commit()
     print("INSERTED release_gid_redirect data\n")
 
 
-def write_release(transaction, connection):
+def write_release(connection, MB_release_data):
+    """Insert data in release table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     release_query = text("""
         INSERT INTO musicbrainz.release
-            VALUES (:id, :gid, :name, :artist_credit, :release_group, :status, :packaging, :language,
-                    :script, :barcode, :comment, :edits_pending, :quality, :last_updated)
+             VALUES (:id, :gid, :name, :artist_credit, :release_group, :status, :packaging, :language,
+                     :script, :barcode, :comment, :edits_pending, :quality, :last_updated)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -1056,14 +1393,17 @@ def write_release(transaction, connection):
         "last_updated": value[13]} for value in MB_release_data
     ]
     connection.execute(release_query, values)
-    transaction.commit()
     print("INSERTED release data\n")
 
 
-def write_release_gid_redirect(transaction, connection):
+def write_release_gid_redirect(connection, MB_release_gid_redirect_data):
+    """Insert data in release_gid_redirect table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     release_gid_redirect_query = text("""
         INSERT INTO musicbrainz.release_gid_redirect
-            VALUES (:gid, :new_id, :created)
+             VALUES (:gid, :new_id, :created)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "gid": value[0],
@@ -1071,14 +1411,17 @@ def write_release_gid_redirect(transaction, connection):
         "created": value[2]} for value in MB_release_gid_redirect_data
     ]
     connection.execute(release_gid_redirect_query, values)
-    transaction.commit()
     print("INSERTED release_gid_redirect data\n")
 
 
-def write_medium(transaction, connection):
+def write_medium(connection, MB_medium_data):
+    """Insert data in medium table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     medium_query = text("""
         INSERT INTO musicbrainz.medium
-            VALUES (:id, :release, :position, :format, :name, :edits_pending, :last_updated, :track_count)
+             VALUES (:id, :release, :position, :format, :name, :edits_pending, :last_updated, :track_count)
+                 ON CONFLICT (id) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -1091,15 +1434,18 @@ def write_medium(transaction, connection):
         "track_count": value[7]} for value in MB_medium_data
     ]
     connection.execute(medium_query, values)
-    transaction.commit()
     print("INSERTED medium data\n")
 
 
-def write_track(transaction, connection):
+def write_track(connection, MB_track_data):
+    """Insert data in track table in musicbrainz schema in
+    AcousticBrainz database.
+    """
     track_query = text("""
         INSERT INTO musicbrainz.track
-            VALUES (:id, :gid, :recording, :medium, :position, :number, :name, :artist_credit, :length,
-                    :edits_pending, :last_updated, :is_data_track)
+             VALUES (:id, :gid, :recording, :medium, :position, :number, :name, :artist_credit, :length,
+                     :edits_pending, :last_updated, :is_data_track)
+                 ON CONFLICT (gid) DO NOTHING
     """)
     values = [{
         "id": value[0],
@@ -1116,397 +1462,268 @@ def write_track(transaction, connection):
         "is_data_track": value[11]} for value in MB_track_data
     ]
     connection.execute(track_query, values)
-    transaction.commit()
     print("INSERTED track data\n")
 
 
-
-
-# FUNCTION TO CALL ALL INSERTS
-
-def insert_MB_data_AB():
-    with db.engine.connect() as connection:
-        if MB_artist_credit_data:
-            transaction = connection.begin()
-            try:
-                write_artist_credit(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_artist_type_data:
-            transaction = connection.begin()
-            try:
-                write_artist_type(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_area_type_data:
-            transaction = connection.begin()
-            try:
-                write_area_type(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_begin_area_type_data:
-            transaction = connection.begin()
-            try:
-                write_begin_area_type(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_end_area_type_data:
-            transaction = connection.begin()
-            try:
-                write_end_area_type(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_release_status_data:
-            transaction = connection.begin()
-            try:
-                write_release_status(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_release_group_primary_type_data:
-            transaction = connection.begin()
-            try:
-                write_release_group_primary_type(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_medium_format_data:
-            transaction = connection.begin()
-            try:
-                write_medium_format(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_release_packaging_data:
-            transaction = connection.begin()
-            try:
-                write_release_packaging(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_language_data:
-            transaction = connection.begin()
-            try:
-                write_language(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_script_data:
-            transaction = connection.begin()
-            try:
-                write_script(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_gender_data:
-            transaction = connection.begin()
-            try:
-                write_gender(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_area_data:
-            transaction = connection.begin()
-            try:
-                write_area(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_begin_area_data:
-            transaction = connection.begin()
-            try:
-                write_begin_area(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_end_area_data:
-            transaction = connection.begin()
-            try:
-                write_end_area(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_artist_data:
-            transaction = connection.begin()
-            try:
-                write_artist(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_artist_credit_name_data:
-            transaction = connection.begin()
-            try:
-                write_artist_credit_name(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_artist_gid_redirect_data:
-            transaction = connection.begin()
-            try:
-                write_artist_gid_redirect(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-
-        if MB_recording_data:
-            transaction = connection.begin()
-            try:
-                write_recording(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_recording_gid_redirect_data:
-            transaction = connection.begin()
-            try:
-                write_recording_gid_redirect(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_release_group_data:
-            transaction = connection.begin()
-            try:
-                write_release_group(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_release_group_gid_redirect_data:
-            transaction = connection.begin()
-            try:
-                write_release_group_gid_redirect(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_release_data:
-            transaction = connection.begin()
-            try:
-                write_release(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_release_gid_redirect_data:
-            transaction = connection.begin()
-            try:
-                write_release_gid_redirect(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_medium_data:
-            transaction = connection.begin()
-            try:
-                write_medium(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-        if MB_track_data:
-            transaction = connection.begin()
-            try:
-                write_track(transaction, connection)
-            except IntegrityError as e:
-                print(e.message)
-                transaction.rollback()
-
-
-def fetch_musicbrainz_data(gids_in_AB):
+def fetch_and_insert_musicbrainz_data(gids_in_AB):
+    # Get MusicBrainz data
     with musicbrainz_db.engine.begin() as connection:
         # track
         try:
-            load_track(connection, gids_in_AB)
+            MB_track_data = load_track(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # MEDIUM
+        # medium
         try:
-            load_medium(connection, gids_in_AB)
+            MB_medium_data = load_medium(connection, gids_in_AB, MB_track_data)
         except ValueError:
             print("No Data found for the recordings")
 
         # release_gid_redirect
         try:
-            load_release_gid_redirect(connection, gids_in_AB)
+            MB_release_gid_redirect_data = load_release_gid_redirect(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # RELEASE
+        # release
         try:
-            load_release(connection, gids_in_AB)
+            MB_release_data = load_release(connection, gids_in_AB, MB_medium_data, MB_release_gid_redirect_data)
         except ValueError:
             print("No Data found for the recordings")
 
-        # ARTIST CREDIT
+        # artist_credit
         try:
-            load_artist_credit(connection, gids_in_AB)
+            MB_artist_credit_data = load_artist_credit(connection, gids_in_AB, MB_release_data)
         except ValueError:
             print("No Data found for the recordings")
 
-        # ARTIST CREDIT NAME
+        # artist_credit_name
         try:
-            load_artist_credit_name(connection, gids_in_AB)
+            MB_artist_credit_name_data = load_artist_credit_name(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # ARTIST
+        # artist
         try:
-            load_artist(connection, gids_in_AB)
+            MB_artist_data = load_artist(connection, gids_in_AB, MB_artist_credit_name_data)
         except ValueError:
             print("No Data found for the recordings")
 
-        # ARTIST TYPE
+        # artist_type
         try:
-            load_artist_type(connection, gids_in_AB)
+            MB_artist_type_data = load_artist_type(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # RECORDING
+        # recording
         try:
-            load_recording(connection, gids_in_AB)
+            MB_recording_data = load_recording(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # AREA
+        # area
         try:
-            load_area(connection, gids_in_AB)
+            MB_area_data = load_area(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # BEGIN AREA
+        # begin_area
         try:
-            load_begin_area(connection, gids_in_AB)
+            MB_begin_area_data = load_begin_area(connection, gids_in_AB, MB_artist_data)
         except ValueError:
             print("No Data found for the recordings")
 
-        # END AREA
+        # end_area
         try:
-            load_end_area(connection, gids_in_AB)
+            MB_end_area_data = load_end_area(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # AREA TYPE
+        # area_type
         try:
-            load_area_type(connection, gids_in_AB)
+            MB_area_type_data = load_area_type(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # BEGIN AREA TYPE
+        # begin_area_type
         try:
-            load_begin_area_type(connection, gids_in_AB)
+            MB_begin_area_type_data = load_begin_area_type(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # END AREA TYPE
+        # end_area_type
         try:
-            load_end_area_type(connection, gids_in_AB)
+            MB_end_area_type_data = load_end_area_type(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # ARTIST GID REDIRECT
+        # artist_gid_redirect
         try:
-            load_artist_gid_redirect(connection, gids_in_AB)
+            MB_artist_gid_redirect_data = load_artist_gid_redirect(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # GENDER
+        # gender
         try:
-            load_gender(connection, gids_in_AB)
+            MB_gender_data = load_gender(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # LANGUAGE
+        # language
         try:
-            load_language(connection, gids_in_AB)
+            MB_language_data = load_language(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # MEDIUM FORMAT
+        # medium_format
         try:
-            load_medium_format(connection, gids_in_AB)
+            MB_medium_format_data = load_medium_format(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-        # RECORDING GID REDIRECT
+        # recording_gid_redirect
         try:
-            load_recording_gid_redirect(connection, gids_in_AB)
+            MB_recording_gid_redirect_data = load_recording_gid_redirect(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
         # release_group gid redirect
         try:
-            load_release_group_gid_redirect(connection, gids_in_AB)
+            MB_release_group_gid_redirect_data = load_release_group_gid_redirect(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
         # release_group
         try:
-            load_release_group(connection, gids_in_AB)
+            MB_release_group_data = load_release_group(connection, gids_in_AB, MB_release_group_gid_redirect_data, MB_release_data)
         except ValueError:
             print("No Data found for the recordings")
 
         # release_group_primary_type
         try:
-            load_release_group_primary_type(connection, gids_in_AB)
+            MB_release_group_primary_type_data = load_release_group_primary_type(connection, gids_in_AB, MB_release_group_data)
         except ValueError:
             print("No Data found for the recordings")
 
         # release_packaging
         try:
-            load_release_packaging(connection, gids_in_AB)
+            MB_release_packaging_data = load_release_packaging(connection, gids_in_AB, MB_release_data)
         except ValueError:
             print("No Data found for the recordings")
 
         # release_status
         try:
-            load_release_status(connection, gids_in_AB)
+            MB_release_status_data = load_release_status(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
         # script
         try:
-            load_script(connection, gids_in_AB)
+            MB_script_data = load_script(connection, gids_in_AB)
         except ValueError:
             print("No Data found for the recordings")
 
-    insert_MB_data_AB()
-    print("--------------------------------DONE-----------------------------------")
+        # Write MusicBrainz data into AcousticBrainz database
+        with db.engine.begin() as connection:
+            if MB_artist_credit_data:
+                write_artist_credit(connection, MB_artist_credit_data)
+
+            if MB_artist_type_data:
+                write_artist_type(connection, MB_artist_type_data)
+
+            if MB_area_type_data:
+                write_area_type(connection, MB_area_type_data)
+
+            if MB_begin_area_type_data:
+                write_begin_area_type(connection, MB_begin_area_type_data)
+
+            if MB_end_area_type_data:
+                write_end_area_type(connection, MB_end_area_type_data)
+
+            if MB_release_status_data:
+                write_release_status(connection, MB_release_status_data)
+
+            if MB_release_group_primary_type_data:
+                write_release_group_primary_type(connection, MB_release_group_primary_type_data)
+
+            if MB_medium_format_data:
+                write_medium_format(connection, MB_medium_format_data)
+
+            if MB_release_packaging_data:
+                write_release_packaging(connection, MB_release_packaging_data)
+
+            if MB_language_data:
+                write_language(connection, MB_language_data)
+
+            if MB_script_data:
+                write_script(connection, MB_script_data)
+
+            if MB_gender_data:
+                write_gender(connection, MB_gender_data)
+
+            if MB_area_data:
+                write_area(connection, MB_area_data)
+
+            if MB_begin_area_data:
+                write_begin_area(connection, MB_begin_area_data)
+
+            if MB_end_area_data:
+                write_end_area(connection, MB_end_area_data)
+
+            if MB_artist_data:
+                write_artist(connection, MB_artist_data)
+
+            if MB_artist_credit_name_data:
+                write_artist_credit_name(connection, MB_artist_credit_name_data)
+
+            if MB_artist_gid_redirect_data:
+                write_artist_gid_redirect(connection, MB_artist_gid_redirect_data)
+
+            if MB_recording_data:
+                write_recording(connection, MB_recording_data)
+
+            if MB_recording_gid_redirect_data:
+                write_recording_gid_redirect(connection, MB_recording_gid_redirect_data)
+
+            if MB_release_group_data:
+                write_release_group(connection, MB_release_group_data)
+
+            if MB_release_group_gid_redirect_data:
+                write_release_group_gid_redirect(connection, MB_release_group_gid_redirect_data)
+
+            if MB_release_data:
+                write_release(connection, MB_release_data)
+
+            if MB_release_gid_redirect_data:
+                write_release_gid_redirect(connection, MB_release_gid_redirect_data)
+
+            if MB_medium_data:
+                write_medium(connection, MB_medium_data)
+
+            if MB_track_data:
+                write_track(connection, MB_track_data)
 
 
 def start_import():
     with db.engine.begin() as connection:
-        lowlevel_query = text("""SELECT gid from lowlevel""")
-        gids = connection.execute(lowlevel_query)
-        gids = gids.fetchall()
-        gids_in_AB = [value[0] for value in gids]
-        no_of_rows = len(gids_in_AB)
-        start = 0
+        offset = 0
         rows_to_fetch = 10000
-        for value in range(0, (no_of_rows/rows_to_fetch) + 1):
-            fetch_musicbrainz_data(gids_in_AB[start : start + rows_to_fetch])
-            start = start + rows_to_fetch
+        while True:
+            lowlevel_query = text("""SELECT gid
+                                       FROM lowlevel
+                                       ORDER BY id
+                                       OFFSET :offset
+                                       LIMIT :rows_to_fetch
+                            """)
+            gids = connection.execute(lowlevel_query, {"offset": offset, "rows_to_fetch": rows_to_fetch})
+            gids = gids.fetchall()
+            gids_in_AB = [value[0] for value in gids]
+            offset = offset + rows_to_fetch
+
+            if gids_in_AB:
+                print('\nInserting %d recordings at a time...\n' % (rows_to_fetch))
+                fetch_and_insert_musicbrainz_data(gids_in_AB)
+            else:
+                break
+        print("--------------------------------DONE!-----------------------------------")

--- a/manage.py
+++ b/manage.py
@@ -187,7 +187,7 @@ def init_mb_db():
 
 @cli.command()
 def import_musicbrainz_db():
-    print("Importing MusicBrainz data...")
+    print("\nImporting MusicBrainz data...")
     db.import_mb_data.start_import()
 
 # Please keep additional sets of commands down there

--- a/manage.py
+++ b/manage.py
@@ -14,6 +14,8 @@ import db.dump_manage
 import db.exceptions
 import db.stats
 import db.user
+from brainzutils import musicbrainz_db
+import db.import_mb_data
 import webserver
 from brainzutils import musicbrainz_db
 from db.testing import DatabaseTestCase
@@ -178,6 +180,15 @@ def remove_admin(username):
         click.echo("Error: %s" % e, err=True)
         sys.exit(1)
 
+
+@cli.command()
+def init_mb_db():
+    musicbrainz_db.init_db_engine(current_app.config['MB_DATABASE_URI'])
+
+@cli.command()
+def import_musicbrainz_db():
+    print("Importing MusicBrainz data...")
+    db.import_mb_data.start_import()
 
 # Please keep additional sets of commands down there
 cli.add_command(db.dump_manage.cli, name="dump")

--- a/manage.py
+++ b/manage.py
@@ -182,10 +182,6 @@ def remove_admin(username):
 
 
 @cli.command()
-def init_mb_db():
-    musicbrainz_db.init_db_engine(current_app.config['MB_DATABASE_URI'])
-
-@cli.command()
 def import_musicbrainz_db():
     print("\nImporting MusicBrainz data...")
     db.import_mb_data.start_import()


### PR DESCRIPTION
* To initialize the musicbrainz database:
`./develop.sh run --rm  webserver python2 manage.py init_mb_db`

* To start the import:
`./develop.sh run --rm  webserver python2 manage.py import_musicbrainz_db`