### PR TITLE
 AB-344: Add a force option to manage.py init_mb_db

### DIFF
--- a/admin/sql/drop_musicbrainz_schema.sql
+++ b/admin/sql/drop_musicbrainz_schema.sql
@@ -1,0 +1,1 @@
+DROP SCHEMA IF EXISTS musicbrainz CASCADE;

--- a/manage.py
+++ b/manage.py
@@ -99,7 +99,7 @@ def init_db(archive, force, skip_create_db=False):
 
 
 @cli.command()
-@click.option("--force", "-f", is_flag=True, help="Drop existing musicbrainz schema and tables.")
+@click.option("--force", "-f", is_flag=True, help="Drop existing MusicBrainz schema and tables.")
 def init_mb_db(force):
     """Initialize the MusicBrainz database.
 
@@ -113,6 +113,7 @@ def init_mb_db(force):
     musicbrainz_db.init_db_engine(current_app.config['MB_DATABASE_URI'])
 
     if force:
+        print('Dropping MusicBrainz schema...')
         res = db.run_sql_script_without_transaction(os.path.join(ADMIN_SQL_DIR, 'drop_musicbrainz_schema.sql'))
         if not res:
             raise Exception('Failed to drop existing musicbrainz schema and tables! Exit code: %i' % res)

--- a/manage.py
+++ b/manage.py
@@ -99,7 +99,8 @@ def init_db(archive, force, skip_create_db=False):
 
 
 @cli.command()
-def init_mb_db():
+@click.option("--force", "-f", is_flag=True, help="Drop existing musicbrainz schema and tables.")
+def init_mb_db(force):
     """Initialize the MusicBrainz database.
 
     This process involves several steps:
@@ -110,6 +111,11 @@ def init_mb_db():
     """
 
     musicbrainz_db.init_db_engine(current_app.config['MB_DATABASE_URI'])
+
+    if force:
+        res = db.run_sql_script_without_transaction(os.path.join(ADMIN_SQL_DIR, 'drop_musicbrainz_schema.sql'))
+        if not res:
+            raise Exception('Failed to drop existing musicbrainz schema and tables! Exit code: %i' % res)
 
     print('Creating MusicBrainz schema...')
     db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_musicbrainz_schema.sql'))


### PR DESCRIPTION
Add a force option to init_mb_db:
* That drops the musicbrainz schema if exists, along with all the tables and keys.
* And then recreates the schema structure.