### PR TITLE
AB-343: Move number of recordings fetched per batch into config.py

### DIFF
--- a/db/import_mb_data.py
+++ b/db/import_mb_data.py
@@ -1,6 +1,7 @@
 import db
 from brainzutils import musicbrainz_db
 from sqlalchemy import text
+from flask import current_app
 
 def load_artist_credit(connection, gids_in_AB, MB_release_data):
     """Fetch artist_credit table data from MusicBrainz database for the
@@ -1708,7 +1709,7 @@ def fetch_and_insert_musicbrainz_data(gids_in_AB):
 def start_import():
     with db.engine.begin() as connection:
         offset = 0
-        rows_to_fetch = 10000
+        rows_to_fetch = current_app.config['RECORDINGS_FETCHED_PER_BATCH']
         while True:
             lowlevel_query = text("""SELECT gid
                                        FROM lowlevel

--- a/default_config.py
+++ b/default_config.py
@@ -63,3 +63,6 @@ FILE_STORAGE_DIR = "/data/files"
 
 #Feature Flags
 FEATURE_EVAL_LOCATION = False
+
+# Maximum number of recordings to fetch at a time for importing MusicBrainz metadata.
+RECORDINGS_FETCHED_PER_BATCH = 10000


### PR DESCRIPTION
Add a variable for the number of recordings to fetch at a time in default_config.py file to import the MB metadata.