### PR TITLE
 Limit size of files while dumping lowlevel_json 

### DIFF
--- a/db/dump.py
+++ b/db/dump.py
@@ -221,12 +221,12 @@ def _copy_table_into_multiple_files(cursor, table_name, query, tar, archive_name
     while True:
         more_rows_added = False
         file_count += 1
-        file_name = '{table_name}-{file_number}'.format(table_name=table_name, file_number=file_count)
+        file_name = "{table_name}-{file_number}".format(table_name=table_name, file_number=file_count)
         path = os.path.join(location, table_name, file_name)
         with open(path, "a") as f:
             logging.info(" - Copying table {table_name} to {file_name}...".format(table_name=table_name, file_name=file_name))
             current_query = query.format(limit=ROWS_PER_FILE, offset=offset)
-            copy_query = 'COPY ({query}) TO STDOUT'.format(query=current_query)
+            copy_query = "COPY ({query}) TO STDOUT".format(query=current_query)
             cursor.copy_expert(copy_query, f)
             offset += ROWS_PER_FILE
             if f.tell() > 0:

--- a/db/dump.py
+++ b/db/dump.py
@@ -147,6 +147,20 @@ def dump_db(location, threads=None, incremental=False, dump_id=None):
     return archive_path
 
 
+def _copy_table(cursor, location, table_name, query):
+    """Copies data from a table into a file within a specified location.
+
+    Args:
+        cursor: a psycopg2 cursor
+        location: the directory where the table should be copied.
+        table_name: the name of the table to be copied.
+        query: the select query for getting data from the table.
+    """
+    with open(os.path.join(location, table_name), "w") as f:
+        logging.info(" - Copying table {table_name}...".format(table_name=table_name))
+        cursor.copy_to(f, query)
+
+
 def _copy_tables(location, dataset_dump, start_time=None, end_time=None):
     """Copies all tables into separate files within a specified location (directory).
 
@@ -175,79 +189,58 @@ def _copy_tables(location, dataset_dump, start_time=None, end_time=None):
 
         if dataset_dump:
             # dataset
-            with open(os.path.join(location, "dataset"), "w") as f:
-                logging.info(" - Copying table dataset...")
-                cursor.copy_to(f, 'dataset', columns=_DATASET_TABLES['dataset'])
+            _copy_table(cursor, location, "dataset", "(SELECT %s FROM dataset)" %
+                        (", ".join(_DATASET_TABLES["dataset"])))
 
             # dataset_class
-            with open(os.path.join(location, "dataset_class"), "w") as f:
-                logging.info(" - Copying table dataset_class...")
-                cursor.copy_to(f, 'dataset_class', columns=_DATASET_TABLES['dataset_class'])
+            _copy_table(cursor, location, "dataset_class", "(SELECT %s FROM dataset_class)" %
+                        (", ".join(_DATASET_TABLES["dataset_class"])))
 
             # dataset_class_member
-            with open(os.path.join(location, "dataset_class_member"), "w") as f:
-                logging.info(" - Copying table dataset_class_member...")
-                cursor.copy_to(f, 'dataset_class_member', columns=_DATASET_TABLES['dataset_class_member'])
+            _copy_table(cursor, location, "dataset_class_member", "(SELECT %s FROM dataset_class_member)" %
+                        (", ".join(_DATASET_TABLES["dataset_class_member"])))
 
         else:
             # version
-            with open(os.path.join(location, "version"), "w") as f:
-                logging.info(" - Copying table version...")
-                cursor.copy_to(f, "(SELECT %s FROM version %s)" %
-                               (", ".join(_TABLES["version"]), generate_where("created")))
+            _copy_table(cursor, location, "version", "(SELECT %s FROM version %s)" %
+                        (", ".join(_TABLES["version"]), generate_where("created")))
 
             # lowlevel
-            with open(os.path.join(location, "lowlevel"), "w") as f:
-                logging.info(" - Copying table lowlevel...")
-                cursor.copy_to(f, "(SELECT %s FROM lowlevel %s)" %
-                               (", ".join(_TABLES["lowlevel"]), generate_where("submitted")))
+            _copy_table(cursor, location, "lowlevel", "(SELECT %s FROM lowlevel %s)" %
+                        (", ".join(_TABLES["lowlevel"]), generate_where("submitted")))
 
             # lowlevel_json
-            with open(os.path.join(location, "lowlevel_json"), "w") as f:
-                logging.info(" - Copying table lowlevel_json...")
-                query = "SELECT %s FROM lowlevel_json WHERE id IN (SELECT id FROM lowlevel %s)" \
-                        % (", ".join(_TABLES["lowlevel_json"]), generate_where("submitted"))
-                cursor.copy_to(f, "(%s)" % query)
+            query = "SELECT %s FROM lowlevel_json WHERE id IN (SELECT id FROM lowlevel %s)" \
+                    % (", ".join(_TABLES["lowlevel_json"]), generate_where("submitted"))
+            _copy_table(cursor, location, "lowlevel_json", "(%s)" % query)
 
             # model
-            with open(os.path.join(location, "model"), "w") as f:
-                logging.info(" - Copying table model...")
-                query = "SELECT %s FROM model %s" \
-                        % (", ".join(_TABLES["model"]), generate_where("date"))
-                cursor.copy_to(f, "(%s)" % query)
+            query = "SELECT %s FROM model %s" \
+                    % (", ".join(_TABLES["model"]), generate_where("date"))
+            _copy_table(cursor, location, "model", "(%s)" % query)
 
 
             # highlevel
-            with open(os.path.join(location, "highlevel"), "w") as f:
-                logging.info(" - Copying table highlevel...")
-                cursor.copy_to(f, "(SELECT %s FROM highlevel %s)" %
-                               (", ".join(_TABLES["highlevel"]), generate_where("submitted")))
+            _copy_table(cursor, location, "highlevel", "(SELECT %s FROM highlevel %s)" %
+                        (", ".join(_TABLES["highlevel"]), generate_where("submitted")))
 
             # highlevel_meta
-            with open(os.path.join(location, "highlevel_meta"), "w") as f:
-                logging.info(" - Copying table highlevel_meta...")
-                query = "SELECT %s FROM highlevel_meta WHERE id IN (SELECT id FROM highlevel %s)" \
-                        % (", ".join(_TABLES["highlevel_meta"]), generate_where("submitted"))
-                cursor.copy_to(f, "(%s)" % query)
+            query = "SELECT %s FROM highlevel_meta WHERE id IN (SELECT id FROM highlevel %s)" \
+                    % (", ".join(_TABLES["highlevel_meta"]), generate_where("submitted"))
+            _copy_table(cursor, location, "highlevel_meta", "(%s)" % query)
 
             # highlevel_model
-            with open(os.path.join(location, "highlevel_model"), "w") as f:
-                logging.info(" - Copying table highlevel_model...")
-                query = "SELECT %s FROM highlevel_model WHERE id IN (SELECT id FROM highlevel %s)" \
-                        % (", ".join(_TABLES["highlevel_model"]), generate_where("submitted"))
-                cursor.copy_to(f, "(%s)" % query)
+            query = "SELECT %s FROM highlevel_model WHERE id IN (SELECT id FROM highlevel %s)" \
+                    % (", ".join(_TABLES["highlevel_model"]), generate_where("submitted"))
+            _copy_table(cursor, location, "highlevel_model", "(%s)" % query)
 
             # statistics
-            with open(os.path.join(location, "statistics"), "w") as f:
-                logging.info(" - Copying table statistics...")
-                cursor.copy_to(f, "(SELECT %s FROM statistics %s)" %
-                               (", ".join(_TABLES["statistics"]), generate_where("collected")))
+            _copy_table(cursor, location, "statistics", "(SELECT %s FROM statistics %s)" %
+                        (", ".join(_TABLES["statistics"]), generate_where("collected")))
 
             # incremental_dumps
-            with open(os.path.join(location, "incremental_dumps"), "w") as f:
-                logging.info(" - Copying table incremental_dumps...")
-                cursor.copy_to(f, "(SELECT %s FROM incremental_dumps %s)" %
-                               (", ".join(_TABLES["incremental_dumps"]), generate_where("created")))
+            _copy_table(cursor, location, "incremental_dumps", "(SELECT %s FROM incremental_dumps %s)" %
+                        (", ".join(_TABLES["incremental_dumps"]), generate_where("created")))
     finally:
         connection.close()
 

--- a/db/dump.py
+++ b/db/dump.py
@@ -631,7 +631,6 @@ def _dump_tables(archive_path, threads, dataset_dump, time_now, start_t=None, en
         end_t (datetime): End time of the frame that will be used for data selection.
     """
     archive_name = os.path.basename(archive_path).split('.')[0]
-    print(archive_name)
     with open(archive_path, "w") as archive:
 
         pxz_command = ["pxz", "--compress"]

--- a/db/dump.py
+++ b/db/dump.py
@@ -18,7 +18,6 @@ import tempfile
 import logging
 import tarfile
 import shutil
-import uuid
 import os
 from sqlalchemy import text
 
@@ -836,11 +835,3 @@ def import_dump(archive_path):
 def import_datasets_dump(archive_path):
     """Import datasets from .tar.xz archive into the database."""
     import_db_dump(archive_path, _DATASET_TABLES)
-
-
-def _is_valid_uuid(text):
-    try:
-        x = uuid.UUID(text)
-        return True
-    except ValueError:
-        return False

--- a/db/dump.py
+++ b/db/dump.py
@@ -136,45 +136,18 @@ def dump_db(location, threads=None, incremental=False, dump_id=None):
         archive_name = "acousticbrainz-dump-%s" % time_now.strftime("%Y%m%d-%H%M%S")
 
     archive_path = os.path.join(location, archive_name + ".tar.xz")
-    with open(archive_path, "w") as archive:
-
-        pxz_command = ["pxz", "--compress"]
-        if threads is not None:
-            pxz_command.append("-T %s" % threads)
-        pxz = subprocess.Popen(pxz_command, stdin=subprocess.PIPE, stdout=archive)
-
-        # Creating the archive
-        with tarfile.open(fileobj=pxz.stdin, mode="w|") as tar:
-            # TODO(roman): Get rid of temporary directories and write directly to tar file if that's possible.
-            temp_dir = tempfile.mkdtemp()
-
-            # Adding metadata
-            schema_seq_path = os.path.join(temp_dir, "SCHEMA_SEQUENCE")
-            with open(schema_seq_path, "w") as f:
-                f.write(str(db.SCHEMA_VERSION))
-            tar.add(schema_seq_path,
-                    arcname=os.path.join(archive_name, "SCHEMA_SEQUENCE"))
-            timestamp_path = os.path.join(temp_dir, "TIMESTAMP")
-            with open(timestamp_path, "w") as f:
-                f.write(time_now.isoformat(" "))
-            tar.add(timestamp_path,
-                    arcname=os.path.join(archive_name, "TIMESTAMP"))
-            tar.add(DUMP_LICENSE_FILE_PATH,
-                    arcname=os.path.join(archive_name, "COPYING"))
-
-            archive_tables_dir = os.path.join(temp_dir, "abdump", "abdump")
-            utils.path.create_path(archive_tables_dir)
-            _copy_tables(archive_tables_dir, start_t, end_t)
-            tar.add(archive_tables_dir, arcname=os.path.join(archive_name, "abdump"))
-
-            shutil.rmtree(temp_dir)  # Cleanup
-
-        pxz.stdin.close()
-
+    _dump_tables(
+        archive_path=archive_path,
+        threads=threads,
+        dataset_dump=False,
+        time_now=time_now,
+        start_t=start_t,
+        end_t=end_t,
+    )
     return archive_path
 
 
-def _copy_tables(location, start_time=None, end_time=None):
+def _copy_tables(location, dataset_dump, start_time=None, end_time=None):
     """Copies all tables into separate files within a specified location (directory).
 
     You can also define time frame that will be used during data selection.
@@ -200,64 +173,81 @@ def _copy_tables(location, start_time=None, end_time=None):
     try:
         cursor = connection.cursor()
 
-        # version
-        with open(os.path.join(location, "version"), "w") as f:
-            logging.info(" - Copying table version...")
-            cursor.copy_to(f, "(SELECT %s FROM version %s)" %
-                           (", ".join(_TABLES["version"]), generate_where("created")))
+        if dataset_dump:
+            # dataset
+            with open(os.path.join(location, "dataset"), "w") as f:
+                logging.info(" - Copying table dataset...")
+                cursor.copy_to(f, 'dataset', columns=_DATASET_TABLES['dataset'])
 
-        # lowlevel
-        with open(os.path.join(location, "lowlevel"), "w") as f:
-            logging.info(" - Copying table lowlevel...")
-            cursor.copy_to(f, "(SELECT %s FROM lowlevel %s)" %
-                           (", ".join(_TABLES["lowlevel"]), generate_where("submitted")))
+            # dataset_class
+            with open(os.path.join(location, "dataset_class"), "w") as f:
+                logging.info(" - Copying table dataset_class...")
+                cursor.copy_to(f, 'dataset_class', columns=_DATASET_TABLES['dataset_class'])
 
-        # lowlevel_json
-        with open(os.path.join(location, "lowlevel_json"), "w") as f:
-            logging.info(" - Copying table lowlevel_json...")
-            query = "SELECT %s FROM lowlevel_json WHERE id IN (SELECT id FROM lowlevel %s)" \
-                    % (", ".join(_TABLES["lowlevel_json"]), generate_where("submitted"))
-            cursor.copy_to(f, "(%s)" % query)
+            # dataset_class_member
+            with open(os.path.join(location, "dataset_class_member"), "w") as f:
+                logging.info(" - Copying table dataset_class_member...")
+                cursor.copy_to(f, 'dataset_class_member', columns=_DATASET_TABLES['dataset_class_member'])
 
-        # model
-        with open(os.path.join(location, "model"), "w") as f:
-            logging.info(" - Copying table model...")
-            query = "SELECT %s FROM model %s" \
-                    % (", ".join(_TABLES["model"]), generate_where("date"))
-            cursor.copy_to(f, "(%s)" % query)
+        else:
+            # version
+            with open(os.path.join(location, "version"), "w") as f:
+                logging.info(" - Copying table version...")
+                cursor.copy_to(f, "(SELECT %s FROM version %s)" %
+                               (", ".join(_TABLES["version"]), generate_where("created")))
+
+            # lowlevel
+            with open(os.path.join(location, "lowlevel"), "w") as f:
+                logging.info(" - Copying table lowlevel...")
+                cursor.copy_to(f, "(SELECT %s FROM lowlevel %s)" %
+                               (", ".join(_TABLES["lowlevel"]), generate_where("submitted")))
+
+            # lowlevel_json
+            with open(os.path.join(location, "lowlevel_json"), "w") as f:
+                logging.info(" - Copying table lowlevel_json...")
+                query = "SELECT %s FROM lowlevel_json WHERE id IN (SELECT id FROM lowlevel %s)" \
+                        % (", ".join(_TABLES["lowlevel_json"]), generate_where("submitted"))
+                cursor.copy_to(f, "(%s)" % query)
+
+            # model
+            with open(os.path.join(location, "model"), "w") as f:
+                logging.info(" - Copying table model...")
+                query = "SELECT %s FROM model %s" \
+                        % (", ".join(_TABLES["model"]), generate_where("date"))
+                cursor.copy_to(f, "(%s)" % query)
 
 
-        # highlevel
-        with open(os.path.join(location, "highlevel"), "w") as f:
-            logging.info(" - Copying table highlevel...")
-            cursor.copy_to(f, "(SELECT %s FROM highlevel %s)" %
-                           (", ".join(_TABLES["highlevel"]), generate_where("submitted")))
+            # highlevel
+            with open(os.path.join(location, "highlevel"), "w") as f:
+                logging.info(" - Copying table highlevel...")
+                cursor.copy_to(f, "(SELECT %s FROM highlevel %s)" %
+                               (", ".join(_TABLES["highlevel"]), generate_where("submitted")))
 
-        # highlevel_meta
-        with open(os.path.join(location, "highlevel_meta"), "w") as f:
-            logging.info(" - Copying table highlevel_meta...")
-            query = "SELECT %s FROM highlevel_meta WHERE id IN (SELECT id FROM highlevel %s)" \
-                    % (", ".join(_TABLES["highlevel_meta"]), generate_where("submitted"))
-            cursor.copy_to(f, "(%s)" % query)
+            # highlevel_meta
+            with open(os.path.join(location, "highlevel_meta"), "w") as f:
+                logging.info(" - Copying table highlevel_meta...")
+                query = "SELECT %s FROM highlevel_meta WHERE id IN (SELECT id FROM highlevel %s)" \
+                        % (", ".join(_TABLES["highlevel_meta"]), generate_where("submitted"))
+                cursor.copy_to(f, "(%s)" % query)
 
-        # highlevel_model
-        with open(os.path.join(location, "highlevel_model"), "w") as f:
-            logging.info(" - Copying table highlevel_model...")
-            query = "SELECT %s FROM highlevel_model WHERE id IN (SELECT id FROM highlevel %s)" \
-                    % (", ".join(_TABLES["highlevel_model"]), generate_where("submitted"))
-            cursor.copy_to(f, "(%s)" % query)
+            # highlevel_model
+            with open(os.path.join(location, "highlevel_model"), "w") as f:
+                logging.info(" - Copying table highlevel_model...")
+                query = "SELECT %s FROM highlevel_model WHERE id IN (SELECT id FROM highlevel %s)" \
+                        % (", ".join(_TABLES["highlevel_model"]), generate_where("submitted"))
+                cursor.copy_to(f, "(%s)" % query)
 
-        # statistics
-        with open(os.path.join(location, "statistics"), "w") as f:
-            logging.info(" - Copying table statistics...")
-            cursor.copy_to(f, "(SELECT %s FROM statistics %s)" %
-                           (", ".join(_TABLES["statistics"]), generate_where("collected")))
+            # statistics
+            with open(os.path.join(location, "statistics"), "w") as f:
+                logging.info(" - Copying table statistics...")
+                cursor.copy_to(f, "(SELECT %s FROM statistics %s)" %
+                               (", ".join(_TABLES["statistics"]), generate_where("collected")))
 
-        # incremental_dumps
-        with open(os.path.join(location, "incremental_dumps"), "w") as f:
-            logging.info(" - Copying table incremental_dumps...")
-            cursor.copy_to(f, "(SELECT %s FROM incremental_dumps %s)" %
-                           (", ".join(_TABLES["incremental_dumps"]), generate_where("created")))
+            # incremental_dumps
+            with open(os.path.join(location, "incremental_dumps"), "w") as f:
+                logging.info(" - Copying table incremental_dumps...")
+                cursor.copy_to(f, "(SELECT %s FROM incremental_dumps %s)" %
+                               (", ".join(_TABLES["incremental_dumps"]), generate_where("created")))
     finally:
         connection.close()
 
@@ -636,6 +626,55 @@ class NoNewData(Exception):
     pass
 
 
+def _dump_tables(archive_path, threads, dataset_dump, time_now, start_t=None, end_t=None):
+    """Copies the metadata and the tables to the archive.
+
+    Args:
+        archive_path (str): Complete path of the archive that will be created.
+        threads (int): Maximal number of threads to run during compression.
+        dataset_dump (bool): If true, only dataset tables are copied to the archive.
+        time_now (datetime): Current time.
+        start_t (datetime): Start time of the frame that will be used for data selection. (in incremental dumps)
+        end_t (datetime): End time of the frame that will be used for data selection.
+    """
+    archive_name = os.path.basename(archive_path).split('.')[0]
+    print(archive_name)
+    with open(archive_path, "w") as archive:
+
+        pxz_command = ["pxz", "--compress"]
+        if threads is not None:
+            pxz_command.append("-T %s" % threads)
+        pxz = subprocess.Popen(pxz_command, stdin=subprocess.PIPE, stdout=archive)
+
+        # Creating the archive
+        with tarfile.open(fileobj=pxz.stdin, mode="w|") as tar:
+            # TODO: Get rid of temporary directories and write directly to tar file if that's possible
+            temp_dir = tempfile.mkdtemp()
+
+            # Adding metadata
+            schema_seq_path = os.path.join(temp_dir, "SCHEMA_SEQUENCE")
+            with open(schema_seq_path, "w") as f:
+                f.write(str(db.SCHEMA_VERSION))
+            tar.add(schema_seq_path,
+                    arcname=os.path.join(archive_name, "SCHEMA_SEQUENCE"))
+            timestamp_path = os.path.join(temp_dir, "TIMESTAMP")
+            with open(timestamp_path, "w") as f:
+                f.write(time_now.isoformat(" "))
+            tar.add(timestamp_path,
+                    arcname=os.path.join(archive_name, "TIMESTAMP"))
+            tar.add(DUMP_LICENSE_FILE_PATH,
+                    arcname=os.path.join(archive_name, "COPYING"))
+
+            archive_tables_dir = os.path.join(temp_dir, "abdump", "abdump")
+            utils.path.create_path(archive_tables_dir)
+            _copy_tables(archive_tables_dir, dataset_dump, start_t, end_t)
+            tar.add(archive_tables_dir, arcname=os.path.join(archive_name, "abdump"))
+
+            shutil.rmtree(temp_dir)
+
+        pxz.stdin.close()
+
+
 def dump_dataset_tables(location, threads=None):
     """Create full dump of dataset tables in a specified location.
 
@@ -649,60 +688,13 @@ def dump_dataset_tables(location, threads=None):
     archive_name = "acousticbrainz-dataset-dump-%s" % time_now.strftime("%Y%m%d-%H%M%S")
 
     archive_path = os.path.join(location, archive_name + ".tar.xz")
-    with open(archive_path, "w") as archive:
-
-        pxz_command = ["pxz", "--compress"]
-        if threads is not None:
-            pxz_command.append("-T %s" % threads)
-        pxz = subprocess.Popen(pxz_command, stdin=subprocess.PIPE, stdout=archive)
-
-        # Creating the archive
-        with tarfile.open(fileobj=pxz.stdin, mode="w|") as tar:
-            temp_dir = tempfile.mkdtemp()
-
-            # Adding SCHEMA_SEQUENCE and TIMESTAMP
-            schema_seq_path = os.path.join(temp_dir, "SCHEMA_SEQUENCE")
-            with open(schema_seq_path, "w") as f:
-                f.write(str(db.SCHEMA_VERSION))
-            tar.add(schema_seq_path,
-                    arcname=os.path.join(archive_name, "SCHEMA_SEQUENCE"))
-            timestamp_path = os.path.join(temp_dir, "TIMESTAMP")
-            with open(timestamp_path, "w") as f:
-                f.write(time_now.isoformat(" "))
-            tar.add(timestamp_path,
-                    arcname=os.path.join(archive_name, "TIMESTAMP"))
-
-            dataset_tables_dir = os.path.join(temp_dir, "datasets", "datasets")
-            utils.path.create_path(dataset_tables_dir)
-            _copy_dataset_tables(dataset_tables_dir)
-            tar.add(dataset_tables_dir, arcname=os.path.join(archive_name, "abdatasetdump"))
-
-            shutil.rmtree(temp_dir)  # Cleanup
-
-        pxz.stdin.close()
+    _dump_tables(
+        archive_path=archive_path,
+        threads=threads,
+        dataset_dump=True,
+        time_now=time_now,
+    )
     return archive_path
-
-
-def _copy_dataset_tables(location):
-    """Copies all dataset tables into separate files within a specified location."""
-    connection = db.engine.raw_connection()
-    try:
-        cursor = connection.cursor()
-
-        with open(os.path.join(location, "dataset"), "w") as f:
-            logging.info(" - Copying table dataset...")
-            cursor.copy_to(f, 'dataset', columns=_DATASET_TABLES['dataset'])
-
-        with open(os.path.join(location, "dataset_class"), "w") as f:
-            logging.info(" - Copying table dataset_class...")
-            cursor.copy_to(f, 'dataset_class', columns=_DATASET_TABLES['dataset_class'])
-
-        with open(os.path.join(location, "dataset_class_member"), "w") as f:
-            logging.info(" - Copying table dataset_class_member...")
-            cursor.copy_to(f, 'dataset_class_member', columns=_DATASET_TABLES['dataset_class_member'])
-
-    finally:
-        connection.close()
 
 
 def import_datasets_dump(archive_path):
@@ -720,7 +712,7 @@ def import_datasets_dump(archive_path):
             tar.extractall(temp_dir)
 
             for table in table_names:
-                with open(os.path.join(temp_dir, archive_name, 'abdatasetdump', table)) as f:
+                with open(os.path.join(temp_dir, archive_name, 'abdump', table)) as f:
                     logging.info(" - Importing data into %s table..." % table)
                     cursor.copy_from(f, table, columns=_DATASET_TABLES[table])
         connection.commit()

--- a/db/dump.py
+++ b/db/dump.py
@@ -28,6 +28,7 @@ ROWS_PER_FILE = 500000
 DUMP_LICENSE_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                       "licenses", "COPYING-PublicDomain")
 
+
 # Importing of old dumps will fail if you change
 # definition of columns below.
 _TABLES = {
@@ -359,7 +360,10 @@ def _copy_tables(location, tar, archive_name, start_time=None, end_time=None):
     finally:
         connection.close()
 
-def is_partitioned_table_dump_file(file_name):
+def _is_partitioned_table_dump_file(file_name):
+    """ Checks if the specified file contains data for some table which has been
+    dumped into multiple files.
+    """
     for table in PARTITIONED_TABLES:
         if table in file_name:
             return True
@@ -441,7 +445,7 @@ def import_db_dump(archive_path, tables):
                         logging.info("Schema version verified.")
 
                 else:
-                    if is_partitioned_table_dump_file(file_name):
+                    if _is_partitioned_table_dump_file(file_name):
                         table_name = member.name.split("/")[2]
                         logging.info(" - Importing data from file %s into %s table..." % (file_name, table_name))
                         cursor.copy_from(tar.extractfile(member), '"%s"' % table_name,

--- a/db/dump.py
+++ b/db/dump.py
@@ -88,6 +88,28 @@ _TABLES = {
     ),
 }
 
+_DATASET_TABLES = {
+    "dataset": (
+        "id",
+        "name",
+        "description",
+        "author",
+        "public",
+        "created",
+        "last_edited",
+    ),
+    "dataset_class": (
+        "id",
+        "name",
+        "description",
+        "dataset",
+    ),
+    "dataset_class_member": (
+        "class",
+        "mbid",
+    ),
+}
+
 
 def dump_db(location, threads=None, incremental=False, dump_id=None):
     """Create database dump in a specified location.
@@ -612,3 +634,98 @@ def _get_incremental_dump_timestamp(dump_id=None):
 
 class NoNewData(Exception):
     pass
+
+
+def dump_dataset_tables(location, threads=None):
+    """Create full dump of dataset tables in a specified location.
+
+    Args:
+        location: Directory where archive will be created.
+    Returns:
+        Path to created dump.
+    """
+    utils.path.create_path(location)
+    time_now = datetime.today()
+    archive_name = "acousticbrainz-dataset-dump-%s" % time_now.strftime("%Y%m%d-%H%M%S")
+
+    archive_path = os.path.join(location, archive_name + ".tar.xz")
+    with open(archive_path, "w") as archive:
+
+        pxz_command = ["pxz", "--compress"]
+        if threads is not None:
+            pxz_command.append("-T %s" % threads)
+        pxz = subprocess.Popen(pxz_command, stdin=subprocess.PIPE, stdout=archive)
+
+        # Creating the archive
+        with tarfile.open(fileobj=pxz.stdin, mode="w|") as tar:
+            temp_dir = tempfile.mkdtemp()
+
+            # Adding SCHEMA_SEQUENCE and TIMESTAMP
+            schema_seq_path = os.path.join(temp_dir, "SCHEMA_SEQUENCE")
+            with open(schema_seq_path, "w") as f:
+                f.write(str(db.SCHEMA_VERSION))
+            tar.add(schema_seq_path,
+                    arcname=os.path.join(archive_name, "SCHEMA_SEQUENCE"))
+            timestamp_path = os.path.join(temp_dir, "TIMESTAMP")
+            with open(timestamp_path, "w") as f:
+                f.write(time_now.isoformat(" "))
+            tar.add(timestamp_path,
+                    arcname=os.path.join(archive_name, "TIMESTAMP"))
+
+            dataset_tables_dir = os.path.join(temp_dir, "datasets", "datasets")
+            utils.path.create_path(dataset_tables_dir)
+            _copy_dataset_tables(dataset_tables_dir)
+            tar.add(dataset_tables_dir, arcname=os.path.join(archive_name, "abdatasetdump"))
+
+            shutil.rmtree(temp_dir)  # Cleanup
+
+        pxz.stdin.close()
+    return archive_path
+
+
+def _copy_dataset_tables(location):
+    """Copies all dataset tables into separate files within a specified location."""
+    connection = db.engine.raw_connection()
+    try:
+        cursor = connection.cursor()
+
+        with open(os.path.join(location, "dataset"), "w") as f:
+            logging.info(" - Copying table dataset...")
+            cursor.copy_to(f, 'dataset', columns=_DATASET_TABLES['dataset'])
+
+        with open(os.path.join(location, "dataset_class"), "w") as f:
+            logging.info(" - Copying table dataset_class...")
+            cursor.copy_to(f, 'dataset_class', columns=_DATASET_TABLES['dataset_class'])
+
+        with open(os.path.join(location, "dataset_class_member"), "w") as f:
+            logging.info(" - Copying table dataset_class_member...")
+            cursor.copy_to(f, 'dataset_class_member', columns=_DATASET_TABLES['dataset_class_member'])
+
+    finally:
+        connection.close()
+
+
+def import_datasets_dump(archive_path):
+    """Import datasets from .tar.xz archive into the database."""
+    archive_name = os.path.basename(archive_path).split('.')[0]
+    pxz_command = ["pxz", "--decompress", "--stdout", archive_path]
+    pxz = subprocess.Popen(pxz_command, stdout=subprocess.PIPE)
+
+    table_names = ['dataset', 'dataset_class', 'dataset_class_member']
+    connection = db.engine.raw_connection()
+    try:
+        cursor = connection.cursor()
+        with tarfile.open(fileobj=pxz.stdout, mode="r|") as tar:
+            temp_dir = tempfile.mkdtemp()
+            tar.extractall(temp_dir)
+
+            for table in table_names:
+                with open(os.path.join(temp_dir, archive_name, 'abdatasetdump', table)) as f:
+                    logging.info(" - Importing data into %s table..." % table)
+                    cursor.copy_from(f, table, columns=_DATASET_TABLES[table])
+        connection.commit()
+    finally:
+        connection.close()
+
+    shutil.rmtree(temp_dir)
+    pxz.stdout.close()

--- a/db/dump.py
+++ b/db/dump.py
@@ -724,6 +724,7 @@ def _dump_tables(archive_path, threads, dataset_dump, time_now, start_t=None, en
             shutil.rmtree(temp_dir)
 
         pxz.stdin.close()
+        pxz.wait()
 
 
 def dump_dataset_tables(location, threads=None):

--- a/db/dump.py
+++ b/db/dump.py
@@ -453,7 +453,7 @@ def import_db_dump(archive_path, tables):
                         logging.info("Schema version verified.")
 
                 else:
-                    if _is_partitioned_table_dump_file(file_name):
+                    if member.isfile() and _is_partitioned_table_dump_file(file_name):
                         table_name = member.name.split("/")[2]
                         logging.info(" - Importing data from file %s into %s table..." % (file_name, table_name))
                         cursor.copy_from(tar.extractfile(member), '"%s"' % table_name,

--- a/db/dump.py
+++ b/db/dump.py
@@ -754,7 +754,7 @@ def import_datasets_dump(archive_path):
     pxz_command = ["pxz", "--decompress", "--stdout", archive_path]
     pxz = subprocess.Popen(pxz_command, stdout=subprocess.PIPE)
 
-    table_names = ['dataset', 'dataset_class', 'dataset_class_member']
+    table_names = _DATASET_TABLES.keys()
     connection = db.engine.raw_connection()
     try:
         cursor = connection.cursor()

--- a/db/dump.py
+++ b/db/dump.py
@@ -108,6 +108,45 @@ _DATASET_TABLES = {
         "class",
         "mbid",
     ),
+    "dataset_snapshot": (
+        "id",
+        "dataset_id",
+        "data",
+        "created",
+    ),
+    "dataset_eval_jobs": (
+        "id",
+        "snapshot_id",
+        "status",
+        "status_msg",
+        "options"
+        "training_snapshot",
+        "testing_snapshot",
+        "created",
+        "updated",
+        "result",
+        "eval_location",
+    ),
+    "dataset_eval_sets": (
+        "id",
+        "data",
+    ),
+    "challenge": (
+        "id",
+        "name",
+        "validation_snapshot",
+        "creator",
+        "created",
+        "start_time",
+        "end_time",
+        "classes",
+        "concluded",
+    ),
+    "dataset_eval_challenge":(
+        "dataset_eval_job",
+        "challenge_id",
+        "result",
+    ),
 }
 
 
@@ -199,6 +238,26 @@ def _copy_tables(location, dataset_dump, start_time=None, end_time=None):
             # dataset_class_member
             _copy_table(cursor, location, "dataset_class_member", "(SELECT %s FROM dataset_class_member)" %
                         (", ".join(_DATASET_TABLES["dataset_class_member"])))
+
+            # dataset_snapshot
+            _copy_table(cursor, location, "dataset_snapshot", "(SELECT %s FROM dataset_snapshot)" %
+                        (", ".join(_DATASET_TABLES["dataset_snapshot"])))
+
+            # dataset_eval_jobs
+            _copy_table(cursor, location, "dataset_eval_jobs", "(SELECT %s FROM dataset_eval_jobs)" %
+                        (", ".join(_DATASET_TABLES["dataset_eval_jobs"])))
+
+            # dataset_eval_sets
+            _copy_table(cursor, location, "dataset_eval_sets", "(SELECT %s FROM dataset_eval_sets)" %
+                        (", ".join(_DATASET_TABLES["dataset_eval_sets"])))
+
+            # challenge
+            _copy_table(cursor, location, "challenge", "(SELECT %s FROM challenge)" %
+                        (", ".join(_DATASET_TABLES["challenge"])))
+
+            # dataset_eval_challenge
+            _copy_table(cursor, location, "dataset_eval_challenge", "(SELECT %s FROM dataset_eval_challenge)" %
+                        (", ".join(_DATASET_TABLES["dataset_eval_challenge"])))
 
         else:
             # version

--- a/db/dump.py
+++ b/db/dump.py
@@ -251,7 +251,6 @@ def _copy_table(cursor, location, table_name, query):
     """
     with open(os.path.join(location, table_name), "w") as f:
         logging.info(" - Copying table {table_name}...".format(table_name=table_name))
-        print(" - Copying table {table_name}...".format(table_name=table_name))
         copy_query = 'COPY ({query}) TO STDOUT'.format(query=query)
         cursor.copy_expert(copy_query, f)
 

--- a/db/dump.py
+++ b/db/dump.py
@@ -24,8 +24,8 @@ from sqlalchemy import text
 
 
 DUMP_CHUNK_SIZE = 1000
-COPY_ROW_LIMIT = 2
-DUMP_FILE_SIZE_LIMIT = 1024
+COPY_ROW_LIMIT = 500000
+DUMP_FILE_SIZE_LIMIT = 1024 * 1024 * 1024 * 10 # 10 GB
 DUMP_LICENSE_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                       "licenses", "COPYING-PublicDomain")
 

--- a/db/dump.py
+++ b/db/dump.py
@@ -22,8 +22,13 @@ import os
 from sqlalchemy import text
 
 
+# the number of rows to dump for json dumps in one batch
 DUMP_CHUNK_SIZE = 1000
+
+# Create multiple files of no more than this many rows for the
+# big tables (lowlevel_json, highlevel_model) for the database dump
 ROWS_PER_FILE = 500000
+
 DUMP_LICENSE_FILE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                       "licenses", "COPYING-PublicDomain")
 

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -182,7 +182,7 @@ def remove_old_archives(location, pattern, is_dir=False, sort_key=None):
               help="Directory where dumps need to be created")
 @click.option("--threads", "-t", type=int)
 def full_dataset_dump(location, threads):
-    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    create_app()
     print("Creating full datasets dump...")
     path = dump.dump_dataset_tables(location, threads)
     print("Done! Created:", path)

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -175,3 +175,14 @@ def remove_old_archives(location, pattern, is_dir=False, sort_key=None):
             shutil.rmtree(entry)
         else:
             os.remove(entry)
+
+
+@cli.command()
+@click.option("--location", "-l", default=os.path.join(os.getcwd(), 'export'), show_default=True,
+              help="Directory where dumps need to be created")
+@click.option("--threads", "-t", type=int)
+def full_dataset_dump(location, threads):
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    print("Creating full datasets dump...")
+    path = dump.dump_dataset_tables(location, threads)
+    print("Done! Created:", path)

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -182,7 +182,6 @@ def remove_old_archives(location, pattern, is_dir=False, sort_key=None):
               help="Directory where dumps need to be created")
 @click.option("--threads", "-t", type=int)
 def full_dataset_dump(location, threads):
-    create_app()
     print("Creating full datasets dump...")
     path = dump.dump_dataset_tables(location, threads)
     print("Done! Created:", path)

--- a/db/test/test_dump.py
+++ b/db/test/test_dump.py
@@ -1,5 +1,6 @@
 from db.testing import DatabaseTestCase
 from db import dump
+from db.dump import _TABLES
 import os.path
 import tempfile
 import shutil
@@ -24,7 +25,7 @@ class DatabaseDumpTestCase(DatabaseTestCase):
         id1 = dump._create_new_inc_dump_record()[0]
         path = dump.dump_db(self.temp_dir)
         self.reset_db()
-        dump.import_db_dump(path)
+        dump.import_db_dump(path, _TABLES)
         self.assertEqual(dump.list_incremental_dumps()[0][0], id1)
         id2 = dump._create_new_inc_dump_record()[0]
         self.assertGreater(id2, id1)

--- a/manage.py
+++ b/manage.py
@@ -79,7 +79,7 @@ def init_db(archive, force, skip_create_db=False):
 
     if archive:
         print('Importing data...')
-        db.dump.import_db_dump(archive)
+        db.dump.import_dump(archive)
     else:
         print('Skipping data importing.')
         print('Loading fixtures...')

--- a/manage.py
+++ b/manage.py
@@ -98,11 +98,16 @@ def init_db(archive, force, skip_create_db=False):
 
 @cli.command()
 @click.argument("archive", type=click.Path(exists=True))
-def import_data(archive):
+@click.option("--is-dataset-dump", "-d", is_flag=True, help="Import dataset dumps.")
+def import_data(archive, is_dataset_dump=False):
     """Imports data dump into the database."""
 
     print('Importing data...')
-    db.dump.import_db_dump(archive)
+    if is_dataset_dump:
+        db.dump.import_datasets_dump(archive)
+    else:
+        db.dump.import_db_dump(archive)
+    print('Done!')
 
 
 @cli.command()

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import logging
 import os
 import sys
 
@@ -23,6 +24,7 @@ ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'admin
 cli = FlaskGroup(add_default_commands=False, create_app=webserver.create_app_flaskgroup)
 cli.add_command(shell_command)
 
+logging.basicConfig(level=logging.INFO)
 
 @cli.command()
 @click.option("--host", "-h", default="0.0.0.0", show_default=True)

--- a/manage.py
+++ b/manage.py
@@ -98,15 +98,21 @@ def init_db(archive, force, skip_create_db=False):
 
 @cli.command()
 @click.argument("archive", type=click.Path(exists=True))
-@click.option("--is-dataset-dump", "-d", is_flag=True, help="Import dataset dumps.")
-def import_data(archive, is_dataset_dump=False):
+def import_data(archive):
     """Imports data dump into the database."""
 
     print('Importing data...')
-    if is_dataset_dump:
-        db.dump.import_datasets_dump(archive)
-    else:
-        db.dump.import_db_dump(archive)
+    db.dump.import_db_dump(archive)
+    print('Done!')
+
+
+@cli.command()
+@click.argument("archive", type=click.Path(exists=True))
+def import_dataset_data(archive):
+    """Imports dataset dump into the database."""
+    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+    print('Importing dataset data...')
+    db.dump.import_datasets_dump(archive)
     print('Done!')
 
 

--- a/manage.py
+++ b/manage.py
@@ -110,7 +110,7 @@ def import_data(archive):
 @click.argument("archive", type=click.Path(exists=True))
 def import_dataset_data(archive):
     """Imports dataset dump into the database."""
-    db.init_db_engine(config.SQLALCHEMY_DATABASE_URI)
+
     print('Importing dataset data...')
     db.dump.import_datasets_dump(archive)
     print('Done!')


### PR DESCRIPTION
Instead of dumping the entire lowlevel_json and highlevel_model tables into a single file, I've split it into multiple files. 

This is very similar to how we do it in LB. We keep dumping more rows into a file until the size of the file becomes more than 10 GB.  

We then add these files to the archive and remove them from temporary storage.