### PR TITLE
Fix Config loading code

### DIFF
--- a/docker/consul-template.conf
+++ b/docker/consul-template.conf
@@ -1,6 +1,6 @@
 template {
     source = "/code/acousticbrainz/consul_config.py.ctmpl"
-    destination = "/code/acousticbrainz/consul_config.py"
+    destination = "/code/acousticbrainz/config.py"
     command = "sv hup uwsgi"
 }
 template {

--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -29,8 +29,8 @@ def load_config(app):
             if not os.path.exists(config_file):
                 time.sleep(1)
 
-    if not os.path.exists(config_file):
-        print("No config file generated. Retried %d times, exiting." % CONSUL_CONFIG_FILE_RETRY_COUNT)
+        if not os.path.exists(config_file):
+            print("No config file generated. Retried %d times, exiting." % CONSUL_CONFIG_FILE_RETRY_COUNT)
 
     app.config.from_pyfile(config_file)
 

--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -6,7 +6,6 @@ from flask_login import current_user
 from pprint import pprint
 
 import os
-import sys
 import time
 
 API_PREFIX = '/api/'
@@ -25,13 +24,13 @@ def create_app_flaskgroup(script_info):
 def load_config(app):
     """Load configuration file for specified Flask app"""
     config_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "config.py")
-    for _ in range(CONSUL_CONFIG_FILE_RETRY_COUNT):
-        if not os.path.exists(config_file):
-            time.sleep(1)
+    if deploy_env:
+        for _ in range(CONSUL_CONFIG_FILE_RETRY_COUNT):
+            if not os.path.exists(config_file):
+                time.sleep(1)
 
     if not os.path.exists(config_file):
         print("No config file generated. Retried %d times, exiting." % CONSUL_CONFIG_FILE_RETRY_COUNT)
-        sys.exit(-1)
 
     app.config.from_pyfile(config_file)
 
@@ -40,7 +39,7 @@ def load_config(app):
         pprint(dict(app.config))
 
 
-def create_app(debug=None, config_path=None):
+def create_app(debug=None):
     app = CustomFlask(
         import_name=__name__,
         use_flask_uuid=True,

--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -33,7 +33,6 @@ def load_config(app):
         print("No config file generated. Retried %d times, exiting." % CONSUL_CONFIG_FILE_RETRY_COUNT)
         sys.exit(-1)
 
-    print('Loading config.py...')
     app.config.from_pyfile(config_file)
 
     if deploy_env:


### PR DESCRIPTION
Action points:
 - [x] remove `config_path` argument
 - [x] Remove `create_app_with_configuration` method, which is no longer used independently
 - [x] standardaise on consul_config.py _or_ config.py in both apps
 - [x] only use `print` in production
 - [x] correctly pretty-print config in production