### PR TITLE
Upgrade to Postgres 10 in docker-compose

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,13 +1,15 @@
 # Docker Compose file for development
 version: "2"
+
+volumes:
+  postgres:
+
 services:
 
   db:
-    image: postgres:9.5.4
+    image: postgres:10.5
     volumes:
-      - ../data/pgdata:/var/lib/postgresql/data/pgdata
-    environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
+      - postgres:/var/lib/postgresql/data
     ports:
       - "15432:5432"
 

--- a/docker/docker-compose.jenkins.yml
+++ b/docker/docker-compose.jenkins.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
 
   db:
-    image: postgres:9.5.4
+    image: postgres:10.5
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
     ports:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -26,17 +26,3 @@ services:
 
   redis:
     image: redis:4.0-alpine
-
-  hl_extractor:
-    build:
-      context: ..
-      dockerfile: ./docker/Dockerfile.dev
-    depends_on:
-      - db
-
-  dataset_evaluator:
-    build:
-      context: ..
-      dockerfile: ./docker/Dockerfile.dev
-    depends_on:
-      - db

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,11 +1,15 @@
 # Docker Compose file for test
 version: "2"
+
+volumes:
+  postgres:
+
 services:
 
   db:
-    image: postgres:9.5.4
-    environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
+    image: postgres:10.5
+    volumes:
+      - postgres:/var/lib/postgresql/data
     ports:
       - "15431:5432"
     command: postgres -F


### PR DESCRIPTION
To bring us in line with what's in production.

Also use a named volume to store postgres data.
Also remove hlextractor and dataset eval from test docker-compose, which we don't need to run. Their image is shared with webserver, so if we have specific tests we can run in the webserver container too.