### PR TITLE
 AB-367: Create dump archive in specific order

### DIFF
--- a/db/dump.py
+++ b/db/dump.py
@@ -294,15 +294,15 @@ def _copy_dataset_tables(location, tar, archive_name, start_time=None, end_time=
                     (", ".join(_DATASET_TABLES["dataset_snapshot"])))
         _add_file_to_tar_and_delete(location, archive_name, tar, "dataset_snapshot")
 
-        # dataset_eval_jobs
-        _copy_table(cursor, location, "dataset_eval_jobs", "SELECT %s FROM dataset_eval_jobs" %
-                    (", ".join(_DATASET_TABLES["dataset_eval_jobs"])))
-        _add_file_to_tar_and_delete(location, archive_name, tar, "dataset_eval_jobs")
-
         # dataset_eval_sets
         _copy_table(cursor, location, "dataset_eval_sets", "SELECT %s FROM dataset_eval_sets" %
                     (", ".join(_DATASET_TABLES["dataset_eval_sets"])))
         _add_file_to_tar_and_delete(location, archive_name, tar, "dataset_eval_sets")
+
+        # dataset_eval_jobs
+        _copy_table(cursor, location, "dataset_eval_jobs", "SELECT %s FROM dataset_eval_jobs" %
+                    (", ".join(_DATASET_TABLES["dataset_eval_jobs"])))
+        _add_file_to_tar_and_delete(location, archive_name, tar, "dataset_eval_jobs")
 
         # challenge
         _copy_table(cursor, location, "challenge", "SELECT %s FROM challenge" %

--- a/db/dump.py
+++ b/db/dump.py
@@ -377,7 +377,7 @@ def _copy_tables(location, tar, archive_name, start_time=None, end_time=None):
         _add_file_to_tar_and_delete(location, archive_name, tar, "highlevel_meta")
 
         # highlevel_model
-        query = "SELECT %s FROM highlevel_model WHERE id IN (SELECT id FROM highlevel %s) ORDER BY id LIMIT {limit} OFFSET {offset}" \
+        query = "SELECT %s FROM highlevel_model WHERE highlevel IN (SELECT id FROM highlevel %s) ORDER BY id LIMIT {limit} OFFSET {offset}" \
                 % (", ".join(_TABLES["highlevel_model"]), generate_where("submitted"))
         _copy_table_into_multiple_files(cursor, "highlevel_model", query, tar, archive_name)
 

--- a/manage.py
+++ b/manage.py
@@ -112,11 +112,22 @@ def import_data(archive, drop_constraints=False):
     db.dump.import_db_dump(archive)
     print('Done!')
 
+    if drop_constraints:
+        print('Creating primary key and foreign key constraints...')
+        db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_primary_keys.sql'))
+        db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'create_foreign_keys.sql'))
+
 
 @cli.command()
+@click.option("--drop-constraints", "-d", is_flag=True, help="Drop primary and foreign keys before importing.")
 @click.argument("archive", type=click.Path(exists=True))
-def import_dataset_data(archive):
+def import_dataset_data(archive, drop_constraints=False):
     """Imports dataset dump into the database."""
+
+    if drop_constraints:
+        print('Dropping primary key and foreign key constraints...')
+        db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'drop_foreign_keys.sql'))
+        db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'drop_primary_keys.sql'))
 
     print('Importing dataset data...')
     db.dump.import_datasets_dump(archive)

--- a/manage.py
+++ b/manage.py
@@ -109,7 +109,7 @@ def import_data(archive, drop_constraints=False):
         db.run_sql_script(os.path.join(ADMIN_SQL_DIR, 'drop_primary_keys.sql'))
 
     print('Importing data...')
-    db.dump.import_db_dump(archive)
+    db.dump.import_dump(archive)
     print('Done!')
 
     if drop_constraints:


### PR DESCRIPTION
Dumps were being created by using `TarFile.add`, passing in an entire directory. This didn't give us control of the order in which files were added to the dump. Now, explicitly add each file to the archive as we dump the table in the defined order.
This allows us to import dump files even if fk constraints are present, because all required rows are added in the right order.

Also fix dataset dumps to ensure that they dump in an order that can be imported with fk constraints

Include a small fix to the highlevel_model dump to include all rows

Fix a bad merge introduced by the combination of the dataset dumps and #299