### PR TITLE
AB-376: Add all stats rows in a single transaction

### DIFF
--- a/admin/sql/create_indexes.sql
+++ b/admin/sql/create_indexes.sql
@@ -23,4 +23,7 @@ CREATE INDEX highlevel_ndx_highlevel_model ON highlevel_model (highlevel);
 
 CREATE UNIQUE INDEX lower_musicbrainz_id_ndx_user ON "user" (lower(musicbrainz_id));
 
+CREATE INDEX collected_ndx_statistics ON statistics (collected);
+CREATE INDEX collected_hour_ndx_statistics ON statistics (date_part('hour'::text, timezone('UTC'::text, collected)));
+
 COMMIT;

--- a/admin/updates/20190227-statistics-indexes.sql
+++ b/admin/updates/20190227-statistics-indexes.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+CREATE INDEX collected_ndx_statistics ON statistics (collected);
+CREATE INDEX collected_hour_ndx_statistics ON statistics (date_part('hour'::text, timezone('UTC'::text, collected)));
+
+COMMIT;

--- a/db/stats.py
+++ b/db/stats.py
@@ -100,18 +100,18 @@ def compute_stats(to_date):
 
         while next_date < to_date:
             stats = _count_submissions_to_date(connection, next_date)
-            with connection.begin() as transaction:
-                _write_stats(connection, next_date, stats)
+            _write_stats(connection, next_date, stats)
             next_date = _get_next_hour(next_date)
 
 
 def _write_stats(connection, date, stats):
     """Records a value with a given name and current timestamp."""
-    for name, value in six.iteritems(stats):
-        q = text("""
-            INSERT INTO statistics (collected, name, value)
-                 VALUES (:collected, :name, :value)""")
-        connection.execute(q, {"collected": date, "name": name, "value": value})
+    with connection.begin():
+        for name, value in six.iteritems(stats):
+            q = text("""
+                INSERT INTO statistics (collected, name, value)
+                     VALUES (:collected, :name, :value)""")
+            connection.execute(q, {"collected": date, "name": name, "value": value})
 
 
 def add_stats_to_cache():

--- a/db/stats.py
+++ b/db/stats.py
@@ -196,12 +196,16 @@ def load_statistics_data(limit=None):
     # create an array of {"name": name, "value": value} objects and change
     # it in python
     args = {}
-    # TODO: use sqlalchemy select().limit()?
     qtext = """
             SELECT collected
                  , json_agg(row_to_json(
                     (SELECT r FROM (SELECT name, value) r) )) AS stats
               FROM statistics
+             WHERE date_part('hour', timezone('UTC'::text, collected)) = 0 
+                OR collected = (SELECT collected
+                                  FROM statistics
+                              ORDER BY collected DESC
+                                 LIMIT 1)
           GROUP BY collected
           ORDER BY collected DESC
           """

--- a/db/stats.py
+++ b/db/stats.py
@@ -100,7 +100,8 @@ def compute_stats(to_date):
 
         while next_date < to_date:
             stats = _count_submissions_to_date(connection, next_date)
-            _write_stats(connection, next_date, stats)
+            with connection.begin() as transaction:
+                _write_stats(connection, next_date, stats)
             next_date = _get_next_hour(next_date)
 
 

--- a/db/stats.py
+++ b/db/stats.py
@@ -183,7 +183,7 @@ def format_statistics_for_highcharts(data):
 
         ts = _make_timestamp(collected)
         for k, v in counts.items():
-            counts[k].append([ts, stats[k]])
+            counts[k].append([ts, stats.get(k, 0)])
 
     stats = [{"name": stats_key_map.get(key, key), "data": data} for key, data in counts.items()]
 

--- a/manage.py
+++ b/manage.py
@@ -18,7 +18,6 @@ import db.exceptions
 import db.stats
 import db.user
 import webserver
-from db.testing import DatabaseTestCase
 
 ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'admin', 'sql')
 
@@ -150,6 +149,9 @@ def compute_stats():
     import datetime
     import pytz
     db.stats.compute_stats(datetime.datetime.now(pytz.utc))
+    incomplete = db.stats.has_incomplete_stats_rows()
+    if incomplete:
+        click.echo("Incomplete stats row detected", err=True)
 
 
 @cli.command()


### PR DESCRIPTION
# Issue
We had an issue where a compute_stats run must have skipped writing a single row, as a result, the stats page couldn't find the value for this date.

# Fixes 
Add all rows in a single transaction so that if there is any problem writing any one of them, we're not left in an inconsistent state

Perform an additional sanity check after computing stats to ensure that we're not left in this state any more

If a value is missing when rendering the stats page, ignore it instead of raising an error

Only return a stats value for each day to reduce the size of the returned js file 24x (5MB->200K), and add some indexes to make this process faster.

# deployment steps
This PR adds a new SQL update file which creates some indexes, `admin/updates/20190227-statistics-indexes.sql`, this should be run after deployment.