### PR TITLE
Revert some unneeded changes introduced in 4f3589e881

### DIFF
--- a/docker/jenkins-test.sh
+++ b/docker/jenkins-test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 # Modify these two as needed:
 COMPOSE_FILE_LOC="docker/docker-compose.jenkins.yml"
 TEST_SERVICE_NAME="acousticbrainz"
@@ -13,14 +15,14 @@ TEST_CONTAINER_REF="${COMPOSE_PROJECT_NAME}_${TEST_SERVICE_NAME}_run_1"
 
 # Record installed version of Docker and Compose with each build
 echo "Docker environment:"
-docker --version
+docker version
 docker-compose --version
 
 function cleanup {
     # Shutting down all containers associated with this project
     docker-compose -f $COMPOSE_FILE_LOC \
                    -p $COMPOSE_PROJECT_NAME \
-                   down --remove-
+                   down --remove-orphans
     docker ps -a --no-trunc  | grep $COMPOSE_PROJECT_NAME \
         | awk '{print $1}' | xargs --no-run-if-empty docker stop
     docker ps -a --no-trunc  | grep $COMPOSE_PROJECT_NAME \
@@ -28,8 +30,6 @@ function cleanup {
 }
 
 function run_tests {
-
-    ls -lR
 
     # Create containers
     docker-compose -f $COMPOSE_FILE_LOC \


### PR DESCRIPTION
We introduced an error in this commit (the --remove-orphans flag).

We added 2 `ls -lR` in this commit, which results in a huge page output when listing node modules. I've removed one and left just the one in the container. I'm not sure if this is still necessary, but it could be useful.

Also use set -x to show commands before they're run.

Use `docker version` instead of `docker --version`, to show the client and server versions of docker, for debugging.