### PR TITLE
Only render the error message if it exists

### DIFF
--- a/utils/dataset_validator.py
+++ b/utils/dataset_validator.py
@@ -66,7 +66,7 @@ def _validate_dataset_name(name):
     if not isinstance(name, string_types):
         raise ValidationException("Field `name` must be a string.")
     if not (DATASET_NAME_LEN_MIN <= len(name) <= DATASET_NAME_LEN_MAX):
-        raise ValidationException("Class name must be between %s and %s characters" %
+        raise ValidationException("Dataset name must be between %s and %s characters" %
                                   (DATASET_NAME_LEN_MIN, DATASET_NAME_LEN_MAX))
 
 

--- a/utils/test/test_dataset_validator.py
+++ b/utils/test/test_dataset_validator.py
@@ -289,20 +289,24 @@ class DatasetValidatorTestCase(unittest.TestCase):
 
     def test_dataset_item_lengths(self):
         # Incorrect lengths
-        with self.assertRaises(dataset_validator.ValidationException):
+        with self.assertRaises(dataset_validator.ValidationException) as ar:
             dataset_validator.validate({
                 "name": "",  # Smaller than Min Len
                 "classes": [],
                 "public": False,
             })
-        with self.assertRaises(dataset_validator.ValidationException):
+        self.assertEqual(str(ar.exception), "Dataset name must be between 1 and 100 characters")
+
+        with self.assertRaises(dataset_validator.ValidationException) as ar:
             dataset_validator.validate({
                 "name": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv \
                 wxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghj",  # Greater than Max Len
                 "classes": [],
                 "public": False,
             })
-        with self.assertRaises(dataset_validator.ValidationException):
+        self.assertEqual(str(ar.exception), "Dataset name must be between 1 and 100 characters")
+
+        with self.assertRaises(dataset_validator.ValidationException) as ar:
             dataset_validator.validate({
                 "name": "this dataset",
                 "classes": [
@@ -313,7 +317,9 @@ class DatasetValidatorTestCase(unittest.TestCase):
                 ],
                 "public": False,
             })
-        with self.assertRaises(dataset_validator.ValidationException):
+        self.assertEqual(str(ar.exception), "Length of the `name` field in class number 0 doesn't fit the limits. Class name must be between 1 and 100 characters")
+
+        with self.assertRaises(dataset_validator.ValidationException) as ar:
             dataset_validator.validate({
                 "name": "this dataset",
                 "classes": [
@@ -325,6 +331,8 @@ class DatasetValidatorTestCase(unittest.TestCase):
                 ],
                 "public": False,
             })
+        self.assertEqual(str(ar.exception), "Length of the `name` field in class number 0 doesn't fit the limits. Class name must be between 1 and 100 characters")
+
         with self.assertRaises(dataset_validator.ValidationException):
             dataset_validator.validate({
                 "name": "test",

--- a/webserver/static/scripts/datasets/editor.js
+++ b/webserver/static/scripts/datasets/editor.js
@@ -276,13 +276,9 @@ var DatasetControlButtons = React.createClass({
             buttonText = "Update";
         }
         if (this.state.errorMsg) {
-            var errorMessage = "Unknown error";
-            if (typeof this.state.errorMsg.error !== 'undefined') {
-                errorMessage = this.state.errorMsg.error;
-            }
             var error = <p className='text-danger'>
                     <strong>An error occurred while submitting this dataset:</strong>
-                    &nbsp;{ errorMessage }
+                    &nbsp;{ this.state.errorMsg.error ||  "Unknown error" }
                 </p>
         } else {
             var error = ''

--- a/webserver/static/scripts/datasets/editor.js
+++ b/webserver/static/scripts/datasets/editor.js
@@ -275,12 +275,21 @@ var DatasetControlButtons = React.createClass({
         if (this.props.mode == MODE_EDIT) {
             buttonText = "Update";
         }
+        if (this.state.errorMsg) {
+            var errorMessage = "Unknown error";
+            if (typeof this.state.errorMsg.error !== 'undefined') {
+                errorMessage = this.state.errorMsg.error;
+            }
+            var error = <p className='text-danger'>
+                    <strong>An error occurred while submitting this dataset:</strong>
+                    &nbsp;{ errorMessage }
+                </p>
+        } else {
+            var error = ''
+        }
         return (
             <div className="form-group">
-                <p className={this.state.errorMsg ? 'text-danger' : 'hidden'}>
-                    <strong>Error occured while submitting this dataset:</strong>
-                    <br />{ this.state.errorMsg }
-                </p>
+                { error }
                 <button onClick={this.handleSubmit} type="button"
                         disabled={this.state.enabled ? '' : 'disabled'}
                         className="btn btn-default btn-primary">{buttonText}</button>


### PR DESCRIPTION
There was an existing error where we were not rendering the .error property, causing a react exception.