### PR TITLE
AB-362: Cull/Filter clearly bad data

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -13,6 +13,7 @@ CREATE TABLE lowlevel_json (
   id          INTEGER, -- FK to lowlevel.id
   data        JSONB    NOT NULL,
   data_sha256 CHAR(64) NOT NULL,
+  label       TEXT, 
   version     INTEGER  NOT NULL-- FK to version.id
 );
 

--- a/admin/updates/20190330-add-mbid-labels.sql
+++ b/admin/updates/20190330-add-mbid-labels.sql
@@ -1,0 +1,6 @@
+
+BEGIN;
+
+ALTER TABLE lowlevel_json ADD COLUMN label TEXT;
+
+COMMIT;

--- a/db/detect_outliers.py
+++ b/db/detect_outliers.py
@@ -1,0 +1,62 @@
+import numpy as np
+import json
+import csv
+import collections
+from scipy import stats
+from scipy.stats import spearmanr
+
+def extract_features(decoded_data):
+
+        arr = []
+        #length
+        arr.append(decoded_data["metadata"]["audio_properties"]["length"])
+        #bpm
+        arr.append(decoded_data["rhythm"]["bpm"])
+        #average_loudness
+        arr.append(decoded_data["lowlevel"]["average_loudness"])
+        #onset_rate
+        arr.append(decoded_data["rhythm"]["onset_rate"])
+        #replay_gain
+        arr.append(decoded_data["metadata"]["audio_properties"]["replay_gain"])
+        #tuning_frequency
+        arr.append(decoded_data["tonal"]["tuning_frequency"])
+
+        return arr
+
+
+def calc_z_scores(data):
+        """used to calculate column vise z-scores for the list of data
+        """
+        data = np.array(data)
+        z = np.zeros(data.shape)
+        for i in range(0, data.shape[1]):
+            arr = data[:, i].astype(np.float)
+            arr = np.abs(stats.zscore(arr))
+            z[:, i] = arr
+
+        return z
+
+
+def identify_anomalies(data):
+        """returns a list of outlier ides and the offest of the best one 
+        threshold is taken to be 1.65 for a 90 % confidence value
+        """
+        arr = []
+        l = len(data)
+        z = calc_z_scores(data)
+        for i in range(0, z.shape[1]):
+            arr = np.concatenate((np.array(arr), np.where(z[:, i] > 1.65)[0]))
+
+        # root mean squate of z values for each offset to detect least varying id
+        z_rms = np.sqrt(np.mean(z**2, axis=1))
+        best_id = np.argmin(z_rms) + 1
+
+        unique, counts = np.unique(arr, return_counts=True)
+        # dict containing {ids,count}
+        ids_dict = dict(zip(unique, counts))
+        #check for ids which have more than or equalto 3 outlying features
+        outliers = [k for k, v in ids_dict.items() if v >= 3]
+
+        correct_offsets = list(x for x in range(1, l+1) if x not in outliers)
+        return outliers, correct_offsets, best_id
+        

--- a/db/test/test_data.py
+++ b/db/test/test_data.py
@@ -72,6 +72,12 @@ class DataDBTestCase(DatabaseTestCase):
             db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data, gid_types.GID_TYPE_MBID)
 
 
+    def test_get_correct_lowlevel(self):
+        """ Calculating correct offset in a set of same mbids """
+        db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data, gid_types.GID_TYPE_MBID)
+        self.assertEqual(self.test_lowlevel_data, db.data.get_correct_lowlevel(self.test_mbid))
+
+
     def test_write_load_low_level(self):
         """Writing and loading a dict returns the same data"""
         one = {"data": "one", "metadata": {"audio_properties": {"lossless": True}, "version": {"essentia_build_sha": "x"}}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,6 @@ pyyaml == 3.13
 rauth == 0.7.3
 setproctitle == 1.1.10
 six == 1.11.0
+numpy == 1.16.1
+scipy == 1.2.1
 -r docs/requirements.txt


### PR DESCRIPTION
**Feature Addition**
## Problem
For a particular MbRecording Id acousticbrainz probably has multiple documents, but there may be some incorrectly matched mbids in that data, so for a handful of documents we can pick out rows which out lie the norms.

## Solution 
I added a new script filter_data.py which filters outlying data by calculating z-scores, it runs in a separate thread, i used a value of 1.65 for a 95% accuracy.
The PR is not yet complete but i wanted to see if i was going in the right direction.