### PR TITLE
Docker args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,8 @@ RUN npm install
 
 FROM acousticbrainz-base AS acousticbrainz-dev
 
+ARG deploy_env
+
 COPY requirements_development.txt /code/requirements_development.txt
 RUN pip install --no-cache-dir -r requirements_development.txt
 
@@ -91,6 +93,8 @@ COPY . /code
 
 
 FROM acousticbrainz-base AS acousticbrainz-prod
+
+ARG deploy_env
 
 RUN pip install uWSGI==2.0.17.1
 

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -19,7 +19,7 @@ TAG=${2:-beta}
 
 echo "Building AcousticBrainz web image with env $ENV tag $TAG..."
 docker build -t metabrainz/acousticbrainz:$TAG \
-        --target acousticbrainz-prod
+        --target acousticbrainz-prod \
         --build-arg GIT_COMMIT_SHA=$(git rev-parse HEAD) \
         --build-arg deploy_env=$ENV .
 echo "Done!"


### PR DESCRIPTION
Define the deploy_env ARG in all stages

From the documentation:
https://docs.docker.com/engine/reference/builder/#scope

An ARG instruction goes out of scope at the end of the build stage where
it was defined. To use an arg in multiple stages, each stage must
include the ARG instruction.

Also fix a syntax error in push.sh, missing a continuation line