### PR TITLE
Preserve order of recording ids when removing duplicates

### DIFF
--- a/db/dataset.py
+++ b/db/dataset.py
@@ -50,8 +50,9 @@ def create_from_dict(dictionary, author_id):
                                         (cls["name"], cls["description"], dataset_id))
             cls_id = result.fetchone()[0]
 
-            # Removing duplicate recordings
-            cls["recordings"] = list(set(cls["recordings"]))
+            # Remove duplicate recordings, preserving order
+            seen = set()
+            cls["recordings"] = [r for r in cls["recordings"] if not (r in seen or seen.add(r))]
 
             for recording_mbid in cls["recordings"]:
                 connection.execute("INSERT INTO dataset_class_member (class, mbid) VALUES (%s, %s)",

--- a/db/test/test_dataset_eval.py
+++ b/db/test/test_dataset_eval.py
@@ -76,7 +76,7 @@ class DatasetEvalTestCase(DatabaseTestCase):
                  mock.call("fd528ddb-411c-47bc-a383-1f8a222ed213"),
                  mock.call("96888f9e-c268-4db2-bc13-e29f8b317c20"),
                  mock.call("ed94c67d-bea8-4741-a3a6-593f20a22eb6")]
-        count_lowlevel.assert_has_calls(calls, any_order=True)
+        count_lowlevel.assert_has_calls(calls)
 
         count_lowlevel.return_value = 0
         with self.assertRaises(dataset_eval.IncompleteDatasetException) as e:


### PR DESCRIPTION
This makes it easier to reason about tests, but also makes sense
to ensure that users see items in the same order that they added
them originally to the dataset