### PR TITLE
Include dataset and class descriptions in CSV for import/export - AB-387

### DIFF
--- a/db/testing.py
+++ b/db/testing.py
@@ -18,7 +18,9 @@ class DatabaseTestCase(TestCase):
 
     @staticmethod
     def create_app():
-        return create_app()
+        app = create_app()
+        app.config['WTF_CSRF_ENABLED'] = False
+        return app
 
     def setUp(self):
         self.reset_db()

--- a/webserver/forms.py
+++ b/webserver/forms.py
@@ -14,12 +14,13 @@ DATASET_RUNNING = "running"
 DATASET_DONE = "done"
 DATASET_ALL = "all"
 
+
 class DatasetCSVImportForm(FlaskForm):
-    name = StringField("Name", validators=[DataRequired("Dataset name is required!")])
+    name = StringField("Name", validators=[DataRequired("Dataset name is required")])
     description = TextAreaField("Description")
     file = FileField("CSV file", validators=[
         FileRequired(),
-        FileAllowed(["csv"], "Dataset needs to be in CSV format!"),
+        FileAllowed(["csv"], "Dataset needs to be in CSV format"),
     ])
 
 

--- a/webserver/templates/datasets/import.html
+++ b/webserver/templates/datasets/import.html
@@ -24,7 +24,7 @@
             <pre>description,A dataset of genres<br>description:rock,Songs that fall into the rock genre<br>description:pop,The subset of rock containing 'popular' music</pre>
         </figure>
         Description lines can go anywhere in the file, but we recommend that you add them at the top.
-        Any class with a description but will no recordings will not be imported.
+        Any class with a description but with no recordings will not be imported.
         A description in the CSV file will override the description field in the form.
     </div>
 

--- a/webserver/templates/datasets/import.html
+++ b/webserver/templates/datasets/import.html
@@ -14,8 +14,18 @@
     <div class="alert alert-info" role="alert">
       <strong>You can import datasets in <a href="https://en.wikipedia.org/wiki/Comma-separated_values">CSV</a> format.</strong>
       Each row in the file must contain information about a single recording.
-      First column is a MusicBrainz ID of recording, second is a name of the
-      class this recording needs to be associated with.
+      The first column is a MusicBrainz ID of recording, second is a name of the
+      class that this recording is a part of:
+        <figure class="highlight">
+            <pre>3e48bced-3faa-441a-beaa-1bf24a9201b2,pop<br>3b9b8b69-775a-488f-b9ab-28a6aa5853a7,rock</pre>
+        </figure>
+        You can optionally add a dataset description and class descriptions by using a <code>description</code> key:
+        <figure class="highlight">
+            <pre>description,A dataset of genres<br>description:rock,Songs that fall into the rock genre<br>description:pop,The subset of rock containing 'popular' music</pre>
+        </figure>
+        Description lines can go anywhere in the file, but we recommend that you add them at the top.
+        Any class with a description but will no recordings will not be imported.
+        A description in the CSV file will override the description field in the form.
     </div>
 
     {% for field in form.errors %}

--- a/webserver/testing.py
+++ b/webserver/testing.py
@@ -1,5 +1,7 @@
 from db.testing import DatabaseTestCase
+import os
 
+TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'views', 'test_data')
 
 class ServerTestCase(DatabaseTestCase):
 

--- a/webserver/testing.py
+++ b/webserver/testing.py
@@ -3,6 +3,7 @@ import os
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'views', 'test_data')
 
+
 class ServerTestCase(DatabaseTestCase):
 
     def temporary_login(self, user_id):

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -122,18 +122,17 @@ def _convert_dataset_to_csv_stringio(dataset):
     fp = StringIO.StringIO()
     writer = csv.writer(fp)
 
-    if dataset["description"] is not None:
-        #check if description is empty string
-        if dataset["description"] != "":
-            description = dataset["description"]
-            writer.writerow(["description", description])
+    #check if description is empty string or None
+    if dataset["description"]:
+        description = dataset["description"]
+        writer.writerow(["description", description])
 
     for ds_class in dataset["classes"]:
-        if ds_class["description"] is not None:
-            if ds_class["description"] != "":
-                ds_class_description = ds_class["description"]
-                ds_class_desc_head = "description:" + ds_class["name"]
-                writer.writerow([ds_class_desc_head, ds_class_description])
+        #check if description is empty string or None
+        if ds_class["description"]:
+            ds_class_description = ds_class["description"]
+            ds_class_desc_head = "description:" + ds_class["name"]
+            writer.writerow([ds_class_desc_head, ds_class_description])
 
     for ds_class in dataset["classes"]:
         class_name = ds_class["name"]
@@ -302,7 +301,7 @@ def import_csv():
         [description, classes] = _parse_dataset_csv(request.files[form.file.name])
         dataset_dict = {
             "name": form.name.data,
-            "description": description if not None else form.description.data,
+            "description": description if description else form.description.data,
             "classes": classes,
             "public": True,
         }

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -310,7 +310,7 @@ def import_csv():
         except dataset_validator.ValidationException as e:
             raise BadRequest(str(e))
         flash.info("Dataset has been imported successfully.")
-        return redirect(url_for(".view", id=dataset_id))
+        return redirect(url_for(".view", dataset_id=dataset_id))
 
     else:
         return render_template("datasets/import.html", form=form)

--- a/webserver/views/test_data/test_dataset.csv
+++ b/webserver/views/test_data/test_dataset.csv
@@ -5,3 +5,4 @@ description:Class #1,This is a description for Class #1
 6fff3ebf-4c7f-4aed-b807-112fa4994cca,Class #2
 2af64e20-38f9-4dc9-8db6-9d6026257dc2,Class #2
 55339a88-f02b-4c03-9f94-f5ef3b29e1ab,Class #1
+description:Class #3,This is a description for Class #3

--- a/webserver/views/test_data/test_db.csv
+++ b/webserver/views/test_data/test_db.csv
@@ -1,0 +1,7 @@
+description,This is a test dataset.
+00f08e7e-7c7f-4f9f-b8f2-5986ba53476d,Class #1
+c5e1c8bc-64c9-4690-a9e0-6c025721ff86,Class #1
+description:Class #1,This is a description for Class #1
+6fff3ebf-4c7f-4aed-b807-112fa4994cca,Class #2
+2af64e20-38f9-4dc9-8db6-9d6026257dc2,Class #2
+55339a88-f02b-4c03-9f94-f5ef3b29e1ab,Class #1


### PR DESCRIPTION
### Import/Export csv w/ description support

This pull request addresses the issues noted in ticket AB-387
https://tickets.metabrainz.org/projects/AB/issues/AB-387?filter=allopenissues

##### Import:
- alter `_parse_dataset_csv(file)` in `webserver/views/datasets.py` to
  handle dataset and class descriptions on any line of csv file
- csv line format for dataset description: 
    `description,description of dataset dataset`
- csv line format for class description: 
    `description:class1,description of class 1`
- `_parse_dataset_csv(file)` returns `[dataset_description, classes]`
  where dataset_description is description of entire dataset and classes
  is a list of all class dictionaries with structure:
```    
    {'recordings': [mbid1,...,mbidn], 
    'description': 'class description', 
    'name': 'class_name'}
```
- small change to `db/dataset.py` function
  `create_from_dict(dictionary,author_id)` to support class and dataset
  dictionaries containing a description

##### Export:
- in `webserver/views/datasets.py` function
  `_convert_dataset_to_csv_stringio(dataset)` adds dataset description and 
  class descriptions to top of csv if they exist
- format:
```
    description,dataset description
    description:class1,description of class one 
    description:class2,description of class two 
    ... 
    mbid,classname
    ... 
```

Create unit test `test_parse_dataset_csv` in `webserver/views/test:
- add directory `webserver/views/test_data` with file `test_db.csv`
- add `test_data` path to `webserver/testing.py`

Altered unit test for `test_dataset_to_csv`:
- add support for class and dataset descriptions