### PR TITLE
AB-148, now dataset evaluation returns job_id and set of ignored MBIDs

### DIFF
--- a/utils/dataset_validator.py
+++ b/utils/dataset_validator.py
@@ -132,6 +132,7 @@ def validate_class(cls, idx=None, recordings_required=True):
             ("name", True),
             ("description", False),
             ("recordings", recordings_required),
+            ("skipped_recordings", False),
         ],
         "class%s" % class_number_text,
     )

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -171,7 +171,7 @@ class CoreViewsTestCase(ServerTestCase):
         # from the database are ignored.
 
         params = "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9;7f27d7a9-27f0-4663-9d20-2c9c40200e6d:3;405a5ff4-7ee2-436b-95c1-90ce8a83b359:2"
-        
+
         rec_c5 = {"recording": "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9"}
         rec_40_2 = {"recording": "405a5ff4-7ee2-436b-95c1-90ce8a83b359:2"}
 

--- a/webserver/views/api/v1/test/test_datasets.py
+++ b/webserver/views/api/v1/test/test_datasets.py
@@ -620,4 +620,3 @@ class APIDatasetViewsTestCase(ServerTestCase):
         self.assertEqual(resp.status_code, 400)
         expected = {"message": "No such class exists."}
         self.assertEqual(resp.json, expected)
-

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -228,13 +228,18 @@ def evaluate(dataset_id):
         try:
             if form.filter_type.data == forms.DATASET_EVAL_NO_FILTER:
                 form.filter_type.data = None
-            db.dataset_eval.evaluate_dataset(
+            job_id, dataset = db.dataset_eval.evaluate_dataset(
                 dataset_id=ds["id"],
                 normalize=form.normalize.data,
                 eval_location=form.evaluation_location.data,
                 filter_type=form.filter_type.data,
             )
             flash.info("Dataset %s has been added into evaluation queue." % ds["id"])
+            for cls in dataset["classes"]:
+                flash_message = ''
+                if len(cls["skipped_recordings"]) > 0:
+                    flash_message += '\n' + cls["name"] + ': ' + len(cls["skipped_recordings"])
+                flash.warn("The number of recording ignored per class: %s" % flash_message)
         except db.dataset_eval.IncompleteDatasetException as e:
             flash.error("Cannot add this dataset because of a validation error: %s" % e)
         except db.dataset_eval.JobExistsException:

--- a/webserver/views/test/test_datasets.py
+++ b/webserver/views/test/test_datasets.py
@@ -72,7 +72,7 @@ class DatasetsViewsTestCase(ServerTestCase):
         resp = self.client.delete(url_for("datasets.eval_job", dataset_id=dataset_id, job_id=self.test_uuid))
         self.assert404(resp)
 
-        job_id = dataset_eval.evaluate_dataset(dataset_id, False, dataset_eval.EVAL_LOCAL)
+        job_id, _ = dataset_eval.evaluate_dataset(dataset_id, False, dataset_eval.EVAL_LOCAL)
 
         resp = self.client.delete(url_for("datasets.eval_job", dataset_id=dataset_id, job_id=job_id))
         self.assert401(resp)


### PR DESCRIPTION
Modified the dataset validator to not raise an exception during validation, now the set of ignored recordings are returned. 
When dataset is submitted for evaluation the message with ignored recordings appear if there are any.

![image](https://user-images.githubusercontent.com/4303438/55998867-d2b80280-5cc8-11e9-954f-ce134a10dbb5.png)
