### PR TITLE
AB-394 - Bulk get items with a single database query

### DIFF
--- a/db/data.py
+++ b/db/data.py
@@ -6,6 +6,7 @@ import json
 import os
 import db
 import db.exceptions
+from collections import defaultdict
 
 from sqlalchemy import text
 import sqlalchemy.exc
@@ -385,7 +386,7 @@ def load_many_low_level(recordings):
             SELECT id, gid,
         ROW_NUMBER () 
               OVER (PARTITION BY gid 
-          ORDER BY submitted DESC) - 1 submission_offset
+          ORDER BY submitted) - 1 submission_offset
               FROM lowlevel
             )   AS partitions
          LEFT JOIN lowlevel_json 
@@ -395,9 +396,9 @@ def load_many_low_level(recordings):
         
         result = connection.execute(query, { 'recordings': tuple(recordings) })
 
-        recordings_info = {}
+        recordings_info = defaultdict(dict)
         for row in result.fetchall():
-            recordings_info.setdefault(str(row['gid']), {})[str(row['submission_offset'])] = row['data']
+            recordings_info[str(row['gid'])][str(row['submission_offset'])] = row['data']
 
         return recordings_info
 

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -183,17 +183,12 @@ def get_data_for_multiple_recordings(collect_data):
 
     recording_details = {}
 
-    # Loading low level data with single query method
-    if collect_data == db.data.load_many_low_level:
-        recording_details = collect_data(recordings)
-
     # Loading low level data with multiple query method
-    else:
-        for recording_id, offset in recordings:
-            try:
-                recording_details.setdefault(recording_id, {})[offset] = collect_data(recording_id, offset)
-            except NoDataFoundException:
-                pass
+    for recording_id, offset in recordings:
+        try:
+            recording_details.setdefault(recording_id, {})[offset] = collect_data(recording_id, offset)
+        except NoDataFoundException:
+            pass
 
     return jsonify(recording_details)
 
@@ -227,7 +222,7 @@ def get_many_lowlevel():
 
     :query query_method: *Optional.* Determines which query method should be used
 
-      `single` will use the single-query method. No parameter or other value will revert
+      `single` will use the single-query method. No parameter or another value will revert
       to the multiple-query method
 
     :resheader Content-Type: *application/json*
@@ -235,11 +230,12 @@ def get_many_lowlevel():
     # Query option allowed for testing purposes:
     if request.args.get("query_method") == "single":
         # Use single-query method
-        recording_details = get_data_for_multiple_recordings(db.data.load_many_low_level)
+        recordings = check_bad_request_for_multiple_recordings()
+        recording_details = db.data.load_many_low_level(recordings)
+        return jsonify(recording_details)    
     else:
         # Use multiple-query method
         recording_details = get_data_for_multiple_recordings(db.data.load_low_level)
-    
     return recording_details
 
 


### PR DESCRIPTION
## Single database query for low-level data of many recordings

#### Check for database query method in endpoint query string 
API endpoint get_many_lowlevel takes optional parameter to specify
the use of this method: `query_method` if the value of
query_method is `single`, the new single query method will be used.
Else, it will continue using multi query method. This is meant to
simplify the testing process.

#### Single query implemented for low-level data
Single query uses subquery to partition recordings and attach
offset values, outer query is used to filter the results.

#### To Do:
- Test single query against previous method on larger datasets
- Consider changes that may allow the query to be better optimized
- Implement similar method for high level data