### PR TITLE
AB-406 Step 1: Offset migration for existing submissions

### DIFF
--- a/add_submission_offsets.py
+++ b/add_submission_offsets.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from flask.cli import FlaskGroup
 import click
 from collections import defaultdict
@@ -9,19 +11,22 @@ from sqlalchemy import text
 
 cli = FlaskGroup(add_default_commands=False, create_app=webserver.create_app_flaskgroup)
 
+
 @cli.command(name='add-offsets')
 @click.option("--limit", "-l", default=10000)
 def add_offsets(limit):
     """Update lowlevel submission offsets with a specified limit."""
     incremental_add_offset(limit)
 
+
 def incremental_add_offset(limit):
     with db.engine.connect() as connection:
 
         # Find number of items in table
         size_query = text("""
-            SELECT MAX(id) AS size
+            SELECT count(*) AS size
               FROM lowlevel
+             WHERE submission_offset IS NULL
         """)
         size_result = connection.execute(size_query)
         table_size = size_result.fetchone()["size"]
@@ -53,13 +58,13 @@ def incremental_add_offset(limit):
         print("Starting batch insertions...")
         print("============================")
         while True:
-            batch_result = connection.execute(batch_query, { "limit": limit })
+            batch_result = connection.execute(batch_query, {"limit": limit})
             if not batch_result.rowcount:
-                print("\nSubmission offset exists for all items. Exiting...")
+                print("Submission offset exists for all items. Exiting...")
                 break
 
             batch_count += 1
-            print("\nUpdating batch {}:".format(batch_count))
+            print("Updating batch {}:".format(batch_count))
             with connection.begin() as transaction:
                 for id, gid in batch_result.fetchall():
                     if gid in max_offsets:
@@ -75,14 +80,10 @@ def incremental_add_offset(limit):
                            SET submission_offset = :offset
                          WHERE id = :id
                     """)
-                    connection.execute(query, { "id": id, "offset": offset })
+                    connection.execute(query, {"id": id, "offset": offset})
                     item_count += 1
-                    print("\r   Inserted {}/{} items...".format(item_count, table_size)),
+            print(" Batch done, inserted {}/{} items...".format(item_count, table_size)),
         print("")
-
 
         print("============================")
         print("Batch insertions finished.")
-
-
-

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -6,7 +6,8 @@ CREATE TABLE lowlevel (
   build_sha1 TEXT      NOT NULL,
   lossless   BOOLEAN                  DEFAULT 'n',
   submitted  TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  gid_type   gid_type  NOT NULL
+  gid_type   gid_type  NOT NULL,
+  submission_offset     INTEGER
 );
 
 CREATE TABLE lowlevel_json (

--- a/admin/updates/20190508-submission-offsets-1.sql
+++ b/admin/updates/20190508-submission-offsets-1.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE lowlevel ADD COLUMN submission_offset INTEGER;
+
+-- Updating the submission offset column based on determination of offset
+UPDATE lowlevel 
+   SET submission_offset = offset_table.submission_offset
+  FROM (
+SELECT id, ROW_NUMBER () 
+	   OVER (PARTITION BY gid ORDER BY submitted) - 1 submission_offset 
+  FROM lowlevel)
+    AS offset_table
+ WHERE lowlevel.id = offset_table.id;
+
+COMMIT;

--- a/admin/updates/20190508-submission-offsets-1.sql
+++ b/admin/updates/20190508-submission-offsets-1.sql
@@ -2,14 +2,4 @@ BEGIN;
 
 ALTER TABLE lowlevel ADD COLUMN submission_offset INTEGER;
 
--- Updating the submission offset column based on determination of offset
-UPDATE lowlevel 
-   SET submission_offset = offset_table.submission_offset
-  FROM (
-SELECT id, ROW_NUMBER () 
-	   OVER (PARTITION BY gid ORDER BY submitted) - 1 submission_offset 
-  FROM lowlevel)
-    AS offset_table
- WHERE lowlevel.id = offset_table.id;
-
 COMMIT;

--- a/manage.py
+++ b/manage.py
@@ -19,6 +19,8 @@ import db.stats
 import db.user
 import webserver
 
+import submission_offsets
+
 ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'admin', 'sql')
 
 cli = FlaskGroup(add_default_commands=False, create_app=webserver.create_app_flaskgroup)
@@ -241,7 +243,7 @@ def toggle_site_status():
 
 # Please keep additional sets of commands down there
 cli.add_command(db.dump_manage.cli, name="dump")
-
+cli.add_command(submission_offsets.cli, name="update-offsets")
 
 if __name__ == '__main__':
     cli()

--- a/manage.py
+++ b/manage.py
@@ -19,7 +19,7 @@ import db.stats
 import db.user
 import webserver
 
-import submission_offsets
+import add_submission_offsets
 
 ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'admin', 'sql')
 
@@ -243,7 +243,7 @@ def toggle_site_status():
 
 # Please keep additional sets of commands down there
 cli.add_command(db.dump_manage.cli, name="dump")
-cli.add_command(submission_offsets.cli, name="update-offsets")
+cli.add_command(add_submission_offsets.cli, name="update-offsets")
 
 if __name__ == '__main__':
     cli()

--- a/submission_offsets.py
+++ b/submission_offsets.py
@@ -50,25 +50,18 @@ def incremental_add_offset(limit):
 			if gid in max_offsets:
 				# Current offset exists
 				max_offsets[gid] += 1
-				offset = max_offsets[gid]
-
-				query = text("""
-					UPDATE lowlevel
-					   SET submission_offset = :offset
-					 WHERE id = :id
-				""")
-				connection.execute(query, { "id": id, "offset": offset })
 			else:
 				# No existing offset
 				max_offsets[gid] = 0
+			offset = max_offsets[gid]
 
-				query = text("""
-					UPDATE lowlevel
-					   SET submission_offset = 0
-					 WHERE id = :id
-				""")
-				connection.execute(query, { "id": id })
-
+			query = text("""
+				UPDATE lowlevel
+				   SET submission_offset = :offset
+				 WHERE id = :id
+			""")
+			connection.execute(query, { "id": id, "offset": offset })
+			
 			count += 1
 
 		print("============================")

--- a/submission_offsets.py
+++ b/submission_offsets.py
@@ -12,57 +12,77 @@ cli = FlaskGroup(add_default_commands=False, create_app=webserver.create_app_fla
 @cli.command(name='add-offsets')
 @click.option("--limit", "-l", default=10000)
 def add_offsets(limit):
-	"""Update lowlevel submission offsets with a specified limit."""
-	incremental_add_offset(limit)
+    """Update lowlevel submission offsets with a specified limit."""
+    incremental_add_offset(limit)
 
 def incremental_add_offset(limit):
-	with db.engine.connect() as connection:
-		# Find the next batch of items to update
-		batch_query = text("""
-			SELECT id, gid
-			  FROM lowlevel
-			 WHERE submission_offset IS NULL
-			 LIMIT :limit
-		""")
-		batch_result = connection.execute(batch_query, { "limit": limit })
+    with db.engine.connect() as connection:
 
-		# Find max existing offsets
-		offset_query = text("""
-			SELECT gid, MAX(submission_offset)
-			  FROM lowlevel
-			 WHERE submission_offset IS NOT NULL
-		      GROUP BY gid
-		""")
-		offset_result = connection.execute(offset_query)
+        # Find number of items in table
+        size_query = text("""
+            SELECT MAX(id) AS size
+              FROM lowlevel
+        """)
+        size_result = connection.execute(size_query)
+        table_size = size_result.fetchone()["size"]
 
-		max_offsets = defaultdict(int)
-		for gid, max_offset in offset_result.fetchall():
-			max_offsets[gid] = max_offset
+        # Find max existing offsets
+        offset_query = text("""
+            SELECT gid, MAX(submission_offset)
+              FROM lowlevel
+             WHERE submission_offset IS NOT NULL
+          GROUP BY gid
+        """)
+        offset_result = connection.execute(offset_query)
 
-		print("Starting batch insertions...")
-		print("============================")
-		count = 0
-		for id, gid in batch_result.fetchall():
-			print("Finished {}/{} items".format(count, limit))
-			print("Current lowlevel.id: {}".format(id)) 
-			print("Inserting...")
-			if gid in max_offsets:
-				# Current offset exists
-				max_offsets[gid] += 1
-			else:
-				# No existing offset
-				max_offsets[gid] = 0
-			offset = max_offsets[gid]
+        max_offsets = defaultdict(int)
+        for gid, max_offset in offset_result.fetchall():
+            max_offsets[gid] = max_offset
 
-			query = text("""
-				UPDATE lowlevel
-				   SET submission_offset = :offset
-				 WHERE id = :id
-			""")
-			connection.execute(query, { "id": id, "offset": offset })
-			count += 1
+        # Find the next batch of items to update
+        batch_query = text("""
+            SELECT id, gid
+              FROM lowlevel
+             WHERE submission_offset IS NULL
+          ORDER BY id
+             LIMIT :limit
+        """)
 
-		print("============================")
-		print("Batch insertions finished.")
+        batch_count = 0
+        item_count = 0
+        print("Starting batch insertions...")
+        print("============================")
+        while True:
+            batch_result = connection.execute(batch_query, { "limit": limit })
+            if not batch_result.rowcount:
+                print("\nSubmission offset exists for all items. Exiting...")
+                break
+
+            batch_count += 1
+            print("\nUpdating batch {}:".format(batch_count))
+            with connection.begin() as transaction:
+                for id, gid in batch_result.fetchall():
+                    if gid in max_offsets:
+                        # Current offset exists
+                        max_offsets[gid] += 1
+                    else:
+                        # No existing offset
+                        max_offsets[gid] = 0
+                    offset = max_offsets[gid]
+
+                    query = text("""
+                        UPDATE lowlevel
+                           SET submission_offset = :offset
+                         WHERE id = :id
+                    """)
+                    connection.execute(query, { "id": id, "offset": offset })
+                    item_count += 1
+                    print("\r   Inserted {}/{} items...".format(item_count, table_size)),
+        print("")
+
+
+        print("============================")
+        print("Batch insertions finished.")
+
 
 

--- a/submission_offsets.py
+++ b/submission_offsets.py
@@ -31,7 +31,7 @@ def incremental_add_offset(limit):
 			SELECT gid, MAX(submission_offset)
 			  FROM lowlevel
 			 WHERE submission_offset IS NOT NULL
-	      GROUP BY gid
+		  GROUP BY gid
 		""")
 		offset_result = connection.execute(offset_query)
 
@@ -46,7 +46,6 @@ def incremental_add_offset(limit):
 			print("Finished {}/{} items".format(count, limit))
 			print("Current lowlevel.id: {}".format(id)) 
 			print("Inserting...")
-
 			if gid in max_offsets:
 				# Current offset exists
 				max_offsets[gid] += 1
@@ -61,7 +60,6 @@ def incremental_add_offset(limit):
 				 WHERE id = :id
 			""")
 			connection.execute(query, { "id": id, "offset": offset })
-			
 			count += 1
 
 		print("============================")

--- a/submission_offsets.py
+++ b/submission_offsets.py
@@ -31,7 +31,7 @@ def incremental_add_offset(limit):
 			SELECT gid, MAX(submission_offset)
 			  FROM lowlevel
 			 WHERE submission_offset IS NOT NULL
-		  GROUP BY gid
+		      GROUP BY gid
 		""")
 		offset_result = connection.execute(offset_query)
 

--- a/submission_offsets.py
+++ b/submission_offsets.py
@@ -1,0 +1,77 @@
+from flask.cli import FlaskGroup
+import click
+from collections import defaultdict
+
+import db
+import webserver
+
+from sqlalchemy import text
+
+cli = FlaskGroup(add_default_commands=False, create_app=webserver.create_app_flaskgroup)
+
+@cli.command(name='add-offsets')
+@click.option("--limit", "-l", default=10000)
+def add_offsets(limit):
+	"""Update lowlevel submission offsets with a specified limit."""
+	incremental_add_offset(limit)
+
+def incremental_add_offset(limit):
+	with db.engine.connect() as connection:
+		# Find the next batch of items to update
+		batch_query = text("""
+			SELECT id, gid
+			  FROM lowlevel
+			 WHERE submission_offset IS NULL
+			 LIMIT :limit
+		""")
+		batch_result = connection.execute(batch_query, { "limit": limit })
+
+		# Find max existing offsets
+		offset_query = text("""
+			SELECT gid, MAX(submission_offset)
+			  FROM lowlevel
+			 WHERE submission_offset IS NOT NULL
+	      GROUP BY gid
+		""")
+		offset_result = connection.execute(offset_query)
+
+		max_offsets = defaultdict(int)
+		for gid, max_offset in offset_result.fetchall():
+			max_offsets[gid] = max_offset
+
+		print("Starting batch insertions...")
+		print("============================")
+		count = 0
+		for id, gid in batch_result.fetchall():
+			print("Finished {}/{} items".format(count, limit))
+			print("Current lowlevel.id: {}".format(id)) 
+			print("Inserting...")
+
+			if gid in max_offsets:
+				# Current offset exists
+				max_offsets[gid] += 1
+				offset = max_offsets[gid]
+
+				query = text("""
+					UPDATE lowlevel
+					   SET submission_offset = :offset
+					 WHERE id = :id
+				""")
+				connection.execute(query, { "id": id, "offset": offset })
+			else:
+				# No existing offset
+				max_offsets[gid] = 0
+
+				query = text("""
+					UPDATE lowlevel
+					   SET submission_offset = 0
+					 WHERE id = :id
+				""")
+				connection.execute(query, { "id": id })
+
+			count += 1
+
+		print("============================")
+		print("Batch insertions finished.")
+
+


### PR DESCRIPTION
## Submission Offsets for Existing Submissions

#### Migration to add nullable submission_offset column
This will allow for us to populate the submission offset but the field 
will be null for recordings that are submitted during the process, 
allowing us to catch and update them in the next step. Note that the
offset column will only exist in the lowlevel table.

#### Migration to add offset for existing submissions
Uses a subquery with a window function to calculate the offsets for all
existing entries, then update the submission_offset column in lowlevel 
with the results.