### PR TITLE
Store the maximum row ID done in hl_calc and get rows after that row ID

### DIFF
--- a/db/data.py
+++ b/db/data.py
@@ -470,8 +470,14 @@ def get_unprocessed_highlevel_documents_for_model(highlevel_model, within=None):
         docs = result.fetchall()
         return docs
 
-def get_unprocessed_highlevel_documents():
-    """Fetch up to 100 low-level documents which have no associated high level data."""
+def get_unprocessed_highlevel_documents(min_row_id=0):
+    """Fetch up to 100 low-level documents which have no associated high level data.
+
+    Args:
+        min_row_id (int): the minimum lowlevel row ID the function should return. This
+                        is used to restrict the query to only get docs submitted
+                        after a particular time.
+    """
     with db.engine.connect() as connection:
         query = text(
                 """SELECT ll.gid::text
@@ -483,8 +489,10 @@ def get_unprocessed_highlevel_documents():
             LEFT JOIN highlevel AS hl
                    ON ll.id = hl.id
                 WHERE hl.mbid IS NULL
+                  AND ll.id >= :min_row_id
+             ORDER BY ll.id
                 LIMIT 100""")
-        result = connection.execute(query)
+        result = connection.execute(query, {"min_row_id": min_row_id})
         docs = result.fetchall()
         return docs
 

--- a/hl_extractor/hl_calc.py
+++ b/hl_extractor/hl_calc.py
@@ -148,6 +148,7 @@ def main(num_threads):
     create_profile(PROFILE_CONF_TEMPLATE, PROFILE_CONF, build_sha1)
 
     num_processed = 0
+    done_row_id = 0
 
     pool = {}
     docs = []
@@ -155,7 +156,7 @@ def main(num_threads):
         # Check to see if we need more database rows
         if len(docs) == 0:
             # Fetch more rows from the DB
-            docs = db.data.get_unprocessed_highlevel_documents()
+            docs = db.data.get_unprocessed_highlevel_documents(min_row_id=done_row_id)
 
             # We will fetch some rows that are already in progress. Remove those.
             in_progress = pool.keys()
@@ -207,6 +208,7 @@ def main(num_threads):
                     print("done  %s" % mbid)
                     sys.stdout.flush()
                     num_processed += 1
+                    done_row_id = max(done_row_id, ll_id)
 
             if len(pool) == num_threads:
                 # tranquilo!


### PR DESCRIPTION
As discussed on IRC.

The query plan (from my local environment):

```
                                                  QUERY PLAN                                            
       
--------------------------------------------------------------------------------------------------------
-------
 Limit  (cost=45.95..45.96 rows=1 width=68)
   ->  Sort  (cost=45.95..45.96 rows=1 width=68)
         Sort Key: ll.id
         ->  Nested Loop  (cost=23.79..45.94 rows=1 width=68)
               ->  Hash Right Join  (cost=23.65..45.27 rows=2 width=20)
                     Hash Cond: (hl.id = ll.id)
                     Filter: (hl.mbid IS NULL)
                     ->  Seq Scan on highlevel hl  (cost=0.00..19.20 rows=920 width=20)
                     ->  Hash  (cost=20.02..20.02 rows=290 width=20)
                           ->  Bitmap Heap Scan on lowlevel ll  (cost=6.40..20.02 rows=290 width=20)
                                 Recheck Cond: (id > 0)
                                 ->  Bitmap Index Scan on lowlevel_pkey  (cost=0.00..6.33 rows=290 width
=0)
                                       Index Cond: (id > 0)
               ->  Index Scan using lowlevel_json_pkey on lowlevel_json llj  (cost=0.14..0.33 rows=1 wid
th=36)
                     Index Cond: (id = ll.id)

```