### PR TITLE
Set the maximum bulk query number to 25 and add documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,6 @@ Datasets
 Constants
 ^^^^^^^^^
 
-Constants that are releavant to using the API:
+Constants that are relevant to using the API:
 
 .. autodata:: webserver.views.api.v1.core.MAX_ITEMS_PER_BULK_REQUEST

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -23,3 +23,10 @@ Datasets
    :blueprints: api_v1_datasets
    :include-empty-docstring:
    :undoc-static:
+
+Constants
+^^^^^^^^^
+
+Constants that are releavant to using the API:
+
+.. autodata:: webserver.views.api.v1.core.MAX_ITEMS_PER_BULK_REQUEST

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -196,11 +196,11 @@ class CoreViewsTestCase(ServerTestCase):
 
     def test_get_bulk_ll_more_than_200(self):
         # Create many random uuids, because of parameter deduplication
-        manyids = [str(uuid.uuid4()) for i in range(205)]
+        manyids = [str(uuid.uuid4()) for i in range(26)]
         limit_exceed_url = ";".join(manyids)
         resp = self.client.get('api/v1/low-level?recording_ids=' + limit_exceed_url)
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual('More than 200 recordings not allowed per request', resp.json['message'])
+        self.assertEqual('More than 25 recordings not allowed per request', resp.json['message'])
 
     @mock.patch('db.data.load_high_level')
     def test_get_bulk_hl_no_param(self, load_high_level):
@@ -276,11 +276,11 @@ class CoreViewsTestCase(ServerTestCase):
 
     def test_get_bulk_hl_more_than_200(self):
         # Create many random uuids, because of parameter deduplication
-        manyids = [str(uuid.uuid4()) for i in range(205)]
+        manyids = [str(uuid.uuid4()) for i in range(26)]
         limit_exceed_url = ";".join(manyids)
         resp = self.client.get('api/v1/high-level?recording_ids=' + limit_exceed_url)
         self.assert400(resp)
-        self.assertEqual('More than 200 recordings not allowed per request', resp.json['message'])
+        self.assertEqual('More than 25 recordings not allowed per request', resp.json['message'])
 
     def submit_fake_data(self):
         mbids = ["c5f4909e-1d7b-4f15-a6f6-1af376bc01c9",
@@ -323,11 +323,11 @@ class CoreViewsTestCase(ServerTestCase):
 
     def test_get_bulk_count_more_than_200(self):
         # Create many random uuids, because of parameter deduplication
-        manyids = [str(uuid.uuid4()) for i in range(205)]
+        manyids = [str(uuid.uuid4()) for i in range(26)]
         limit_exceed_url = ";".join(manyids)
         resp = self.client.get('api/v1/count?recording_ids=' + limit_exceed_url)
         self.assertEqual(resp.status_code, 400)
-        self.assertEqual('More than 200 recordings not allowed per request',
+        self.assertEqual('More than 25 recordings not allowed per request',
                          resp.json['message'])
 
 


### PR DESCRIPTION
This number tries to seek a balance between a good number of items and the time taken to respond to the query. Tests show that 1 item takes about .3s while 25 take .8s and 50 takes over 1.5s

Also document this number in the API docs.