### PR TITLE
AB-404: Endpoint for users to select specific lowlevel features

### DIFF
--- a/db/data.py
+++ b/db/data.py
@@ -598,15 +598,17 @@ def load_many_select_features(recordings, features, aliases):
     
     Args:
         recordings: A list of tuples (mbid, offset).
-        features: A string of paths to features 
-            "llj.data->'feature1' AS feature1, ..., llj.data->'featureN' AS featureN"
+        features: A list of string of paths to features. 
+            ["llj.data->'feature1', ..., llj.data->'featureN']
+        aliases: A list of aliases for querying the features.
+            ["lowlevel.feature1", ..., "metadata.featureN"]
 
     Returns:
-        {"mbid-1": {"offset-1": {"feature1": feature1, ..., "featureN": featureN},
+        {"mbid-1": {"offset-1": {lowlevel document},
                     ...
-                    "offset-n": {"feature1": feature1, ..., "featureN": featureN}},
+                    "offset-n": {lowlevel document},
          ...
-         "mbid-n": {"offset-1": {"feature1": feature1, ..., "featureN": featureN}}
+         "mbid-n": {"offset-1": {lowlevel document}}
         } 
     """
     # Build string of select features with aliases
@@ -634,7 +636,6 @@ def load_many_select_features(recordings, features, aliases):
             data = defaultdict(dict)
             for alias in aliases:
                 current = temp = {}
-                count = 0
                 alias_keys = alias.split('.')
                 for key in alias_keys[1:-1]:
                     temp[key] = {}

--- a/db/data.py
+++ b/db/data.py
@@ -631,7 +631,25 @@ def load_many_individual_features(recordings, features):
 
 
 def build_feature_string(features):
-    # Build string of individual features with aliases
+    """Build string of individual features with aliases for a PostgreSQL query.
+
+    Args:
+        features: Contains information about the
+        individual features, a list of tuples of the form:
+            [(<feature_path>, <alias>, <default_type>), ...]
+
+            <feature_path> is a string holding the path to a feature:
+            "llj.data->feature_name"
+
+            <alias> is a string alias for a feature:
+            "lowlevel.feature_name"
+
+            <default_type> is the type to which a feature value will default
+            if it is non-existent: None, {}, or [].
+
+    Returns: a string of the form:
+    "data->'lowlevel'->'mfccs' AS mfccs, data->'lowlevel'->'gfccs' AS gfccs"
+    """
     feature_string = ', '.join(' AS '.join([x[0], x[1].join(['"', '"'])]) for x in features)
     return feature_string
 
@@ -702,9 +720,9 @@ def parse_features_row(row, features):
         structure of lowlevel_json.data, as defined by the aliases.
 
             {
-                "lowlevel": {"feature_1": x,
+                "lowlevel": {"feature_name": feature_1,
                             ...
-                             "feature_n"},
+                             "feature_name": feature_n},
             }
 
         *Note*: If a feature in the parameter `features` does not exist
@@ -718,7 +736,7 @@ def parse_features_row(row, features):
         for key in alias_keys[1:-1]:
             temp[key] = {}
             temp = temp[key]
-        if row[alias]:
+        if alias in row.keys() and row[alias]:
             temp[alias_keys[-1]] = row[alias]
         else:
             temp[alias_keys[-1]] = default_type

--- a/db/data.py
+++ b/db/data.py
@@ -593,13 +593,13 @@ def load_many_high_level(recordings, map_classes=False):
         return dict(recordings_info)
 
 
-def load_many_select_features(recordings, features):
-    """Load select lowlevel features for multiple recordings.
+def load_many_individual_features(recordings, features):
+    """Load individual lowlevel features for multiple recordings.
     
     Args:
         recordings: A list of tuples (mbid, offset).
         features: Contains information about the
-        select features, a list of tuples of the form: 
+        individual features, a list of tuples of the form: 
             [(<feature_path>, <alias>, <default_type>), ...]
 
             <feature_path> is a string holding the path to a feature:
@@ -619,7 +619,7 @@ def load_many_select_features(recordings, features):
          "mbid-n": {"offset-1": {lowlevel document}}
         } 
     """
-    # Build string of select features with aliases
+    # Build string of individual features with aliases
     feature_string = features[0][0] + ' AS "' + features[0][1] + '", '
     for path, alias, _ in features[1:len(features)-1]:
         feature_string += path + ' AS "' +  alias + '", '

--- a/db/data.py
+++ b/db/data.py
@@ -594,7 +594,7 @@ def load_many_high_level(recordings, map_classes=False):
 
 
 def load_many_select_features(recordings, features, aliases):
-    """Load select features for multiple recordings.
+    """Load select lowlevel features for multiple recordings.
     
     Args:
         recordings: A list of tuples (mbid, offset).

--- a/db/data.py
+++ b/db/data.py
@@ -650,7 +650,7 @@ def build_feature_string(features):
     Returns: a string of the form:
     "data->'lowlevel'->'mfccs' AS mfccs, data->'lowlevel'->'gfccs' AS gfccs"
     """
-    feature_string = ', '.join(' AS '.join([x[0], x[1].join(['"', '"'])]) for x in features)
+    feature_string = ', '.join(['%s AS "%s"' % (x[0], x[1]) for x in features])
     return feature_string
 
 
@@ -660,7 +660,7 @@ def bulk_get_recording_features(recordings, feature_string):
 
     Args:
         recordings: a list of tuples of the form (MBID, offset)
-        
+
         feature_string: a string of the features that should
         be collected, with their aliases.
             e.g. "data->'lowlevel'->'mfccs' AS mfccs,
@@ -689,7 +689,7 @@ def parse_features_row(row, features):
     Parse a row of the joined lowlevel and lowlevel_json tables
     containing individual features of the lowlevel_json.data for
     a single recording.
- 
+
     Args:
         row: a row resulting from the sqlalchemy query, of the form:
         (<gid>, <offset>, <feature_1>, ..., <feature_n>).
@@ -703,7 +703,7 @@ def parse_features_row(row, features):
 
         features: a list of tuples of the form:
         (<feature_path>, <alias>, <default_type>)
-            
+
             <feature_path> is a string holding the path to a feature:
             "llj.data->feature_name"
 

--- a/db/test/test_data.py
+++ b/db/test/test_data.py
@@ -605,7 +605,7 @@ class DataDBTestCase(DatabaseTestCase):
         second_data = copy.deepcopy(self.test_lowlevel_data)
         second_data["metadata"]["tags"]["album"] = ["Another album"]
 
-        db.data.write_low_level(self.test_mbid, self.test_lowlevel_data, gid_types.GID_TYPE_MBID)        
+        db.data.write_low_level(self.test_mbid, self.test_lowlevel_data, gid_types.GID_TYPE_MBID)
         db.data.write_low_level(self.test_mbid, second_data, gid_types.GID_TYPE_MBID)        
         db.data.write_low_level(self.test_mbid_two, self.test_lowlevel_data_two, gid_types.GID_TYPE_MBID)
 
@@ -627,8 +627,8 @@ class DataDBTestCase(DatabaseTestCase):
         self.assertEqual(expected, db.data.load_many_individual_features(list(recordings), features))
 
     def test_load_many_individual_features_none(self):
-        """If there is no data found for any of the specified recordings, 
-        an empty dictionary is returned. If there is no data for a feature, 
+        """If there is no data found for any of the specified recordings,
+        an empty dictionary is returned. If there is no data for a feature,
         it is returned with the specified default value."""
         # No data written for the recordings specified
         recordings = [(self.test_mbid, 0),
@@ -649,27 +649,18 @@ class DataDBTestCase(DatabaseTestCase):
         altered_data = copy.deepcopy(self.test_lowlevel_data)
         del altered_data["lowlevel"]["average_loudness"]
         del altered_data["metadata"]["tags"]
-        db.data.write_low_level(self.test_mbid, altered_data, gid_types.GID_TYPE_MBID) 
+        db.data.write_low_level(self.test_mbid, altered_data, gid_types.GID_TYPE_MBID)
 
-        recordings = [(self.test_mbid, 0)]       
+        recordings = [(self.test_mbid, 0)]
 
         features = [("llj.data->'lowlevel'->'average_loudness'", "lowlevel.average_loudness", None),
                     ("llj.data->'metadata'->'audio_properties'->'replay_gain'", "metadata.audio_properties.replay_gain", None),
                     ("llj.data->'metadata'->'tags'", "metadata.tags", {})]
 
-        expected = {"0dad432b-16cc-4bf0-8961-fd31d124b01b": 
-                        {"0": {'lowlevel': {
-                                    'average_loudness': None
-                                },
-                                "metadata": {
-                                    "audio_properties": {
-                                        "replay_gain": -9.43081283569
-                                    },
-                                    "tags": {}
-                                }
-                            }
-                        }
-                    }
+        expected = {"0dad432b-16cc-4bf0-8961-fd31d124b01b": {"0": {"lowlevel": {"average_loudness": None},
+                                                                   "metadata": {"audio_properties": {
+                                                                       "replay_gain": -9.43081283569},
+                                                                       "tags": {}}}}}
 
         self.assertEqual(expected, db.data.load_many_individual_features(list(recordings), features))
 
@@ -678,7 +669,7 @@ class DataDBTestCase(DatabaseTestCase):
            "<feature_path_1> AS <alias>, <feature_path_2> AS <alias>"
         """
         # If features is empty, empty string should be returned
-        features =  []
+        features = []
         self.assertEqual("", db.data.build_feature_string(features))
 
         features = [("llj.data->'lowlevel'->'average_loudness'", "lowlevel.average_loudness", None),
@@ -726,7 +717,7 @@ class DataDBTestCase(DatabaseTestCase):
                            "script": ["Latn"],
                            "title": ["Nascence"],
                            "tracknumber": ["1/18"]}
-        )]
+                          )]
         self.assertEqual(expected_rows, db.data.bulk_get_recording_features(recordings, feature_string))
 
     def test_parse_features_row_missing_feature(self):

--- a/db/test/test_data.py
+++ b/db/test/test_data.py
@@ -597,7 +597,8 @@ class DataDBTestCase(DatabaseTestCase):
             self.test_mbid: {'0': hl1_expected},
         }
         self.assertEqual(expected, db.data.load_many_high_level(list(recordings), map_classes=True))
-    def test_load_many_select_features(self):
+
+    def test_load_many_individual_features(self):
         """Lowlevel data returned matches (mbid, offset) pairs. Only returns features that
         are specified, with lowlevel structure maintained.
         """
@@ -623,9 +624,9 @@ class DataDBTestCase(DatabaseTestCase):
                     ("llj.data->'tonal'->'key_key'", "tonal.key_key", None)]
 
         expected = json.loads(open(os.path.join(TEST_DATA_PATH, "lowlevel_select_features_response.json")).read())
-        self.assertEqual(expected, db.data.load_many_select_features(list(recordings), features))
+        self.assertEqual(expected, db.data.load_many_individual_features(list(recordings), features))
 
-    def test_load_many_select_features_none(self):
+    def test_load_many_individual_features_none(self):
         """If there is no data found for any of the specified recordings, 
         an empty dictionary is returned. If there is no data for a feature, 
         it is returned with the specified default value."""
@@ -642,7 +643,7 @@ class DataDBTestCase(DatabaseTestCase):
                     ("llj.data->'tonal'->'key_key'", "tonal.key_key", None)]
 
         expected = {}
-        self.assertEqual(expected, db.data.load_many_select_features(list(recordings), features))
+        self.assertEqual(expected, db.data.load_many_individual_features(list(recordings), features))
 
         # No existing data for a feature
         altered_data = copy.deepcopy(self.test_lowlevel_data)
@@ -670,7 +671,7 @@ class DataDBTestCase(DatabaseTestCase):
                         }
                     }
 
-        self.assertEqual(expected, db.data.load_many_select_features(list(recordings), features))
+        self.assertEqual(expected, db.data.load_many_individual_features(list(recordings), features))
 
     def test_count_lowlevel(self):
         db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data, gid_types.GID_TYPE_MBID)

--- a/db/test/test_data.py
+++ b/db/test/test_data.py
@@ -597,6 +597,80 @@ class DataDBTestCase(DatabaseTestCase):
             self.test_mbid: {'0': hl1_expected},
         }
         self.assertEqual(expected, db.data.load_many_high_level(list(recordings), map_classes=True))
+    def test_load_many_select_features(self):
+        """Lowlevel data returned matches (mbid, offset) pairs. Only returns features that
+        are specified, with lowlevel structure maintained.
+        """
+        second_data = copy.deepcopy(self.test_lowlevel_data)
+        second_data["metadata"]["tags"]["album"] = ["Another album"]
+
+        db.data.write_low_level(self.test_mbid, self.test_lowlevel_data, gid_types.GID_TYPE_MBID)        
+        db.data.write_low_level(self.test_mbid, second_data, gid_types.GID_TYPE_MBID)        
+        db.data.write_low_level(self.test_mbid_two, self.test_lowlevel_data_two, gid_types.GID_TYPE_MBID)
+
+        # If no data exists for an (mbid, offset) pair, it is skipped
+        recordings = [(self.test_mbid, 0),
+                      (self.test_mbid, 1),
+                      (self.test_mbid, 2),
+                      (self.test_mbid_two, 0)]
+
+        features = [("llj.data->'lowlevel'->'average_loudness'", "lowlevel.average_loudness", None),
+                    ("llj.data->'lowlevel'->'dynamic_complexity'", "lowlevel.dynamic_complexity", None),
+                    ("llj.data->'metadata'->'audio_properties'->'replay_gain'", "metadata.audio_properties.replay_gain", None),
+                    ("llj.data->'metadata'->'tags'", "metadata.tags", {}),
+                    ("llj.data->'rhythm'->'beats_loudness'->'mean'", "rhythm.beats_loudness.mean", None),
+                    ("llj.data->'rhythm'->'bpm_histogram_second_peak_bpm'->'mean'", "rhythm.bpm_histogram_second_peak_bpm.mean", None),
+                    ("llj.data->'tonal'->'key_key'", "tonal.key_key", None)]
+
+        expected = json.loads(open(os.path.join(TEST_DATA_PATH, "lowlevel_select_features_response.json")).read())
+        self.assertEqual(expected, db.data.load_many_select_features(list(recordings), features))
+
+    def test_load_many_select_features_none(self):
+        """If there is no data found for any of the specified recordings, 
+        an empty dictionary is returned. If there is no data for a feature, 
+        it is returned with the specified default value."""
+        # No data written for the recordings specified
+        recordings = [(self.test_mbid, 0),
+                      (self.test_mbid_two, 0)]
+
+        features = [("llj.data->'lowlevel'->'average_loudness'", "lowlevel.average_loudness", None),
+                    ("llj.data->'lowlevel'->'dynamic_complexity'", "lowlevel.dynamic_complexity", None),
+                    ("llj.data->'metadata'->'audio_properties'->'replay_gain'", "metadata.audio_properties.replay_gain", None),
+                    ("llj.data->'metadata'->'tags'", "metadata.tags", {}),
+                    ("llj.data->'rhythm'->'beats_loudness'->'mean'", "rhythm.beats_loudness.mean", None),
+                    ("llj.data->'rhythm'->'bpm_histogram_second_peak_bpm'->'mean'", "rhythm.beats_loudness.mean", None),
+                    ("llj.data->'tonal'->'key_key'", "tonal.key_key", None)]
+
+        expected = {}
+        self.assertEqual(expected, db.data.load_many_select_features(list(recordings), features))
+
+        # No existing data for a feature
+        altered_data = copy.deepcopy(self.test_lowlevel_data)
+        del altered_data["lowlevel"]["average_loudness"]
+        del altered_data["metadata"]["tags"]
+        db.data.write_low_level(self.test_mbid, altered_data, gid_types.GID_TYPE_MBID) 
+
+        recordings = [(self.test_mbid, 0)]       
+
+        features = [("llj.data->'lowlevel'->'average_loudness'", "lowlevel.average_loudness", None),
+                    ("llj.data->'metadata'->'audio_properties'->'replay_gain'", "metadata.audio_properties.replay_gain", None),
+                    ("llj.data->'metadata'->'tags'", "metadata.tags", {})]
+
+        expected = {"0dad432b-16cc-4bf0-8961-fd31d124b01b": 
+                        {"0": {'lowlevel': {
+                                    'average_loudness': None
+                                },
+                                "metadata": {
+                                    "audio_properties": {
+                                        "replay_gain": -9.43081283569
+                                    },
+                                    "tags": {}
+                                }
+                            }
+                        }
+                    }
+
+        self.assertEqual(expected, db.data.load_many_select_features(list(recordings), features))
 
     def test_count_lowlevel(self):
         db.data.submit_low_level_data(self.test_mbid, self.test_lowlevel_data, gid_types.GID_TYPE_MBID)

--- a/db/test_data/lowlevel_select_features_response.json
+++ b/db/test_data/lowlevel_select_features_response.json
@@ -1,0 +1,217 @@
+{"0dad432b-16cc-4bf0-8961-fd31d124b01b": 
+    {"0": { "lowlevel": {
+                "average_loudness": 0.048737552017,
+                "dynamic_complexity": 6.21206188202
+            },
+            "metadata": {
+                "audio_properties": {
+                    "replay_gain": -9.43081283569
+                },
+                "tags": {
+                    "acoustid_id": ["25343079-d20f-4827-9e83-840e278a67ff"],
+                    "album": ["Journey"],
+                    "albumartist": ["Austin Wintory"],
+                    "albumartistsort": ["Wintory, Austin"],
+                    "artist": ["Austin Wintory"],
+                    "artistsort": ["Wintory, Austin"],
+                    "artistwebpage": ["http://austinwintory.com/"],
+                    "date": ["2012"],
+                    "discnumber": ["1/1"],
+                    "file_name": "01 Nascence.mp3",
+                    "media": ["Digital Media"],
+                    "musicbrainz album release country": ["XW"],
+                    "musicbrainz album status": ["official"],
+                    "musicbrainz album type": ["album/soundtrack"],
+                    "musicbrainz_albumartistid": ["78f15956-c5e1-46d6-a46b-fa6f46681ec8"],
+                    "musicbrainz_albumid": ["1f3abcda-15a7-4465-92c6-9926cdc4f247"],
+                    "musicbrainz_artistid": ["78f15956-c5e1-46d6-a46b-fa6f46681ec8"],
+                    "musicbrainz_recordingid": ["0dad432b-16cc-4bf0-8961-fd31d124b01b"],
+                    "musicbrainz_releasegroupid": ["d1850227-c7c7-42c8-b469-6e99023412de"],
+                    "originaldate": ["2012"],
+                    "script": ["Latn"],
+                    "title": ["Nascence"],
+                    "tracknumber": ["1/18"]
+                }
+            },
+            "rhythm": {
+                "beats_loudness": {
+                    "mean": 0.0246992316097
+                },
+                "bpm_histogram_second_peak_bpm": {
+                    "mean": 133
+                }
+            },
+            "tonal": {
+                "key_key": "D"
+            }
+        },
+    "1": { "lowlevel": {
+                "average_loudness": 0.048737552017,
+                "dynamic_complexity": 6.21206188202
+            },
+            "metadata": {
+                "audio_properties": {
+                    "replay_gain": -9.43081283569
+                },
+                "tags": {
+                    "acoustid_id": ["25343079-d20f-4827-9e83-840e278a67ff"],
+                    "album": ["Another album"],
+                    "albumartist": ["Austin Wintory"],
+                    "albumartistsort": ["Wintory, Austin"],
+                    "artist": ["Austin Wintory"],
+                    "artistsort": ["Wintory, Austin"],
+                    "artistwebpage": ["http://austinwintory.com/"],
+                    "date": ["2012"],
+                    "discnumber": ["1/1"],
+                    "file_name": "01 Nascence.mp3",
+                    "media": ["Digital Media"],
+                    "musicbrainz album release country": ["XW"],
+                    "musicbrainz album status": ["official"],
+                    "musicbrainz album type": ["album/soundtrack"],
+                    "musicbrainz_albumartistid": ["78f15956-c5e1-46d6-a46b-fa6f46681ec8"],
+                    "musicbrainz_albumid": ["1f3abcda-15a7-4465-92c6-9926cdc4f247"],
+                    "musicbrainz_artistid": ["78f15956-c5e1-46d6-a46b-fa6f46681ec8"],
+                    "musicbrainz_recordingid": ["0dad432b-16cc-4bf0-8961-fd31d124b01b"],
+                    "musicbrainz_releasegroupid": ["d1850227-c7c7-42c8-b469-6e99023412de"],
+                    "originaldate": ["2012"],
+                    "script": ["Latn"],
+                    "title": ["Nascence"],
+                    "tracknumber": ["1/18"]
+                }
+            },
+            "rhythm": {
+                "beats_loudness": {
+                    "mean": 0.0246992316097
+                },
+                "bpm_histogram_second_peak_bpm": {
+                    "mean": 133
+                }
+            },
+            "tonal": {
+                "key_key": "D"
+            }
+        }
+    },
+"e8afe383-1478-497e-90b1-7885c7f37f6e": 
+    {"0": { "lowlevel": {
+                "average_loudness": 0.28302448988,
+                "dynamic_complexity": 5.1763920784
+            },
+            "metadata": {
+                "audio_properties": {
+                    "replay_gain": -9.99079704285
+                },
+                "tags": {
+                    "album": [
+                        "The Rise and Fall of Ziggy Stardust and the Spiders From Mars"
+                    ],
+                    "albumartist": [
+                        "David Bowie"
+                    ],
+                    "albumartistsort": [
+                        "Bowie, David"
+                    ],
+                    "artist": [
+                        "David Bowie"
+                    ],
+                    "artistsort": [
+                        "Bowie, David"
+                    ],
+                    "asin": [
+                        "B0007MUR2W"
+                    ],
+                    "barcode": [
+                        "724352190003"
+                    ],
+                    "catalognumber": [
+                        "RCD 10134"
+                    ],
+                    "composer": [
+                        "David Bowie"
+                    ],
+                    "composersort": [
+                        "Bowie, David"
+                    ],
+                    "date": [
+                        "1990-06-06"
+                    ],
+                    "discnumber": [
+                        "01"
+                    ],
+                    "disctotal": [
+                        "01"
+                    ],
+                    "file_name": "02_soul_love.flac",
+                    "genre": [
+                        "Rock"
+                    ],
+                    "isrc": [
+                        "USJT10200020"
+                    ],
+                    "label": [
+                        "Rykodisc"
+                    ],
+                    "language": [
+                        "English"
+                    ],
+                    "media": [
+                        "CD"
+                    ],
+                    "musicbrainz_albumartistid": [
+                        "5441c29d-3602-4898-b1a1-b77fa23b8e50"
+                    ],
+                    "musicbrainz_albumid": [
+                        "85f61d36-afa0-3977-9b0e-45329574175b"
+                    ],
+                    "musicbrainz_artistid": [
+                        "5441c29d-3602-4898-b1a1-b77fa23b8e50"
+                    ],
+                    "musicbrainz_discid": [
+                        "574CMRWvKzrO9gC1s9VIxQR.FwA-",
+                        "7EPvKqpvNIeQts9y6gkz1XXssN8-",
+                        "CblmKqXfvgbq4Ue2.Agr8IUkRWU-",
+                        "NtVtShORDb3LhPIBV2o7etyYFkU-",
+                        "iBrBc..4sp57lnxGqilWNWbylAc-",
+                        "jA.sQ6_Avuu8C6s3dn6bAA_Yydo-",
+                        "oqhayjQyo98j6qJRLZm8OomIZe0-"
+                    ],
+                    "musicbrainz_recordingid": [
+                        "e8afe383-1478-497e-90b1-7885c7f37f6e"
+                    ],
+                    "musicbrainz_releasegroupid": [
+                        "a176b42b-fb6c-3156-aba1-c1fc1ee75752"
+                    ],
+                    "musicip_puid": [
+                        "b1e7eb4b-6337-1700-6b05-9e343f1ff148"
+                    ],
+                    "releasecountry": [
+                        "United States"
+                    ],
+                    "script": [
+                        "Latin"
+                    ],
+                    "title": [
+                        "Soul Love"
+                    ],
+                    "tracknumber": [
+                        "02"
+                    ],
+                    "tracktotal": [
+                        "16"
+                    ]
+                }
+            },
+            "rhythm": {
+                "beats_loudness": {
+                    "mean": 0.0168792642653
+                },
+                "bpm_histogram_second_peak_bpm": {
+                    "mean": 136
+                }                                        
+            },
+            "tonal": {
+                "key_key": "D"
+            }
+        }
+    }
+}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -62,4 +62,5 @@ Constants
 Constants that are relevant to using the API:
 
 .. autodata:: webserver.views.api.v1.core.MAX_ITEMS_PER_BULK_REQUEST
+.. autodata:: webserver.views.api.v1.core.LOWLEVEL_INDIVIDUAL_FEATURES
 

--- a/utils/container_utils.py
+++ b/utils/container_utils.py
@@ -1,0 +1,3 @@
+def remove_duplicates(arr):
+    seen = set()
+    return [x for x in arr if not (x in seen or seen.add(x))]

--- a/utils/remove_duplicates.py
+++ b/utils/remove_duplicates.py
@@ -1,0 +1,3 @@
+def remove_duplicates(arr):
+    seen = set()
+    return [x for x in arr if not (x in seen or seen.add(x))]

--- a/utils/remove_duplicates.py
+++ b/utils/remove_duplicates.py
@@ -1,3 +1,0 @@
-def remove_duplicates(arr):
-    seen = set()
-    return [x for x in arr if not (x in seen or seen.add(x))]

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -23,6 +23,25 @@ bp_core = Blueprint('api_v1_core', __name__)
 
 #: The maximum number of items that you can pass as a recording_ids parameter to bulk lookup endpoints
 MAX_ITEMS_PER_BULK_REQUEST = 25
+# Individual features selectable in get_many_select_features.
+# Note: metadata.version and metadata.audio_properties will be included in all responses.
+SELECTABLE_FEATURES = ['lowlevel.average_loudness', 
+                        'lowlevel.dynamic_complexity', 
+                        'metadata.audio_properties.replay_gain',
+                        'metadata.tags', 
+                        'rhythm.beats_count', 
+                        'rhythm.beats_loudness.mean', 
+                        'rhythm.bpm', 
+                        'rhythm.bpm_histogram_first_peak_bpm.mean', 
+                        'rhythm.bpm_histogram_second_peak_bpm.mean', 
+                        'rhythm.danceability', 
+                        'rhythm.onset_rate', 
+                        'tonal.chords_key', 
+                        'tonal.chords_scale', 
+                        'tonal.key_key', 
+                        'tonal.key_scale', 
+                        'tonal.tuning_frequency', 
+                        'tonal.tuning_equal_tempered_deviation']
 
 
 @bp_core.route("/<uuid(strict=False):mbid>/count", methods=["GET"])
@@ -320,27 +339,10 @@ def parse_select_features():
     if not features_param:
         raise webserver.views.api.exceptions.APIBadRequest("Missing `features` parameter")
 
-    selectable_features = ['lowlevel.average_loudness', 
-                            'lowlevel.dynamic_complexity', 
-                            'metadata.audio_properties.replay_gain', 
-                            'rhythm.beats_count', 
-                            'rhythm.beats_loudness.mean', 
-                            'rhythm.bpm', 
-                            'rhythm.bpm_histogram_first_peak_bpm.mean', 
-                            'rhythm.bpm_histogram_second_peak_bpm.mean', 
-                            'rhythm.danceability', 
-                            'rhythm.onset_rate', 
-                            'tonal.chords_key', 
-                            'tonal.chords_scale', 
-                            'tonal.key_key', 
-                            'tonal.key_scale', 
-                            'tonal.tuning_frequency', 
-                            'tonal.tuning_equal_tempered_deviation']
-
     parsed_features = []
     raw_paths = []
     for feature in features_param.split(';'):
-        if feature in selectable_features:
+        if feature in SELECTABLE_FEATURES:
             raw_paths.append(feature)
             # Build feature path
             feature_path = 'llj.data'

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -345,8 +345,9 @@ def parse_individual_features():
             <alias> is a string alias for a feature:
             "lowlevel.feature_name"
 
-            <default_type> is the type to which a feature value will default,
-            if it is non-existent, depending on the alias from AVAILABLE_FEATURES.
+            <default_type> is the type to which a feature value will default
+            if it is non-existent, depending on the alias from
+            :py:const:`~webserver.views.api.v1.core.AVAILABLE_FEATURES`
     """
     features_param = request.args.get("features")
     if not features_param:
@@ -373,7 +374,7 @@ def parse_individual_features():
     return [x for x in parsed_features if not (x in ret or ret.append(x))]
 
 
-@bp_core.route("/low-level/select", methods=["GET"])
+@bp_core.route("/low-level/individual", methods=["GET"])
 @crossdomain()
 def get_many_individual_features():
     """Get a specified subset of low-level data for many recordings at once.

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -306,42 +306,58 @@ def get_many_highlevel():
 
 def parse_select_features():
     """Check whether the features are found or not.
-    Parse the query string of features to create a list of features,
-    excluding those that are not offered.
+    Parse the query string of features to create a list of 
+    the json paths to features, excluding those that are 
+    not offered.
+
     If features are missing, an APIBadRequest Exception is
     raised stating the missing features message.
-    Returns a list of features ['feature1',...,'featureN']
+    
+    Returns a string of feature paths with alias:
+        "llj.data->'feature1' AS feature1, ..., llj.data->'featureN' AS featureN"
     """
-    features = request.args.get("features")
-
-    if not features:
+    features_param = request.args.get("features")
+    if not features_param:
         raise webserver.views.api.exceptions.APIBadRequest("Missing `features` parameter")
 
-    ret = []
     selectable_features = ['lowlevel.average_loudness', 
-        'lowlevel.dynamic_complexity', 
-        'metadata.audio_properties.replay_gain', 
-        'rhythm.beats_count', 
-        'rhythm.beats_loudness.mean', 
-        'rhythm.bpm', 
-        'rhythm.bpm_histogram_first_peak_bpm.mean', 
-        'rhythm.bpm_histogram_second_peak_bpm.mean', 
-        'bpm.danceability', 
-        'bpm.onset_rate', 
-        'tonal.chords_key', 
-        'tonal.chords_scale', 
-        'tonal.key_key', 
-        'tonal.key_scale', 
-        'tonal.tuning_frequency', 
-        'tonal.tuning_equal_tempered_deviation']
+                            'lowlevel.dynamic_complexity', 
+                            'metadata.audio_properties.replay_gain', 
+                            'rhythm.beats_count', 
+                            'rhythm.beats_loudness.mean', 
+                            'rhythm.bpm', 
+                            'rhythm.bpm_histogram_first_peak_bpm.mean', 
+                            'rhythm.bpm_histogram_second_peak_bpm.mean', 
+                            'rhythm.danceability', 
+                            'rhythm.onset_rate', 
+                            'tonal.chords_key', 
+                            'tonal.chords_scale', 
+                            'tonal.key_key', 
+                            'tonal.key_scale', 
+                            'tonal.tuning_frequency', 
+                            'tonal.tuning_equal_tempered_deviation']
 
-    for feature in features.split(';'):
+    parsed_features = []
+    raw_paths = []
+    for feature in features_param.split(';'):
         if feature in selectable_features:
-            ret.append(feature)
+            raw_paths.append(feature)
+            # Build feature path
+            feature_path = 'llj.data'
+            for element in feature.split('.'):
+                feature_path += '->\'' + element + '\''
+            parsed_features.append(feature_path)
 
     # Remove duplicates, preserving order
     seen = set()
-    return [x for x in ret if not (x in seen or seen.add(x))]
+    parsed_features = [x for x in parsed_features if not (x in seen or seen.add(x))]
+
+    features_string = parsed_features[0] + ' AS "' + raw_paths[0] + '", '
+    for feature, alias in zip(parsed_features[1:len(parsed_features)-1], raw_paths[1:len(raw_paths)-1]):
+        features_string += feature + ' AS "' +  alias + '", '
+    features_string += parsed_features[len(parsed_features)-1] + ' AS "' + raw_paths[len(raw_paths)-1] + '"'
+
+    return features_string
 
 
 @bp_core.route("/low-level/select", methods=["GET"])
@@ -369,8 +385,8 @@ def get_many_select_features():
     :resheader Content-Type: *application/json*
     """
     recordings = check_bad_request_for_multiple_recordings()
-    features = parse_select_features()
-    recording_details = db.data.load_many_select_features(recordings, features)
+    features_string = parse_select_features()
+    recording_details = db.data.load_many_select_features(recordings, features_string)
 
     return jsonify(recording_details)
 

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -25,23 +25,23 @@ bp_core = Blueprint('api_v1_core', __name__)
 MAX_ITEMS_PER_BULK_REQUEST = 25
 # Individual features selectable in get_many_select_features.
 # Note: metadata.version and metadata.audio_properties will be included in all responses.
-SELECTABLE_FEATURES = ['lowlevel.average_loudness', 
-                        'lowlevel.dynamic_complexity', 
-                        'metadata.audio_properties.replay_gain',
-                        'metadata.tags', 
-                        'rhythm.beats_count', 
-                        'rhythm.beats_loudness.mean', 
-                        'rhythm.bpm', 
-                        'rhythm.bpm_histogram_first_peak_bpm.mean', 
-                        'rhythm.bpm_histogram_second_peak_bpm.mean', 
-                        'rhythm.danceability', 
-                        'rhythm.onset_rate', 
-                        'tonal.chords_key', 
-                        'tonal.chords_scale', 
-                        'tonal.key_key', 
-                        'tonal.key_scale', 
-                        'tonal.tuning_frequency', 
-                        'tonal.tuning_equal_tempered_deviation']
+SELECTABLE_FEATURES = {"lowlevel.average_loudness": "llj.data->'lowlevel'->'average_loudness'", 
+                        "lowlevel.dynamic_complexity": "llj.data->'lowlevel'->'dynamic_complexity'", 
+                        "metadata.audio_properties.replay_gain": "llj.data->'metadata'->'audio_properties'->'replay_gain'",
+                        "metadata.tags": "llj.data->'metadata'->'tags'", 
+                        "rhythm.beats_count": "llj.data->'rhythm'->'beats_count'", 
+                        "rhythm.beats_loudness.mean": "llj.data->'rhythm'->'beats_loudness'->'mean'", 
+                        "rhythm.bpm": "llj.data->'rhythm'->'bpm'", 
+                        "rhythm.bpm_histogram_first_peak_bpm.mean": "llj.data->'bpm_histogram_first_peak_bpm'->'mean'", 
+                        "rhythm.bpm_histogram_second_peak_bpm.mean": "llj.data->'bpm_histogram_second_peak_bpm'->'mean'", 
+                        "rhythm.danceability": "llj.data->'rhythm'->'danceability'", 
+                        "rhythm.onset_rate": "llj.data->'rhythm'->'onset_rate'", 
+                        "tonal.chords_key": "llj.data->'tonal'->'chords_key'", 
+                        "tonal.chords_scale": "llj.data->'tonal'->'chords_scale'", 
+                        "tonal.key_key": "llj.data->'tonal'->'key_key'", 
+                        "tonal.key_scale": "llj.data->'tonal'->'key_scale'", 
+                        "tonal.tuning_frequency": "llj.data->'tonal'->'tuning_frequency'", 
+                        "tonal.tuning_equal_tempered_deviation": "llj.data->'tonal'->'tuning_equal_tempered_deviation'"}
 
 
 @bp_core.route("/<uuid(strict=False):mbid>/count", methods=["GET"])
@@ -345,9 +345,7 @@ def parse_select_features():
         if feature in SELECTABLE_FEATURES:
             aliases.append(feature)
             # Build feature path
-            feature_path = 'llj.data'
-            for element in feature.split('.'):
-                feature_path += "->'" + element + "'"
+            feature_path = SELECTABLE_FEATURES[feature]
             parsed_features.append(feature_path)
 
     # Always include metadata.version and metadata.audio_properties

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -25,7 +25,7 @@ bp_core = Blueprint('api_v1_core', __name__)
 #: The maximum number of items that you can pass as a recording_ids parameter to bulk lookup endpoints
 MAX_ITEMS_PER_BULK_REQUEST = 25
 
-# Individual features selectable in get_many_select_features.
+# Individual features selectable in get_many_individual_features.
 # Note: metadata.version and metadata.audio_properties will be included in all responses.
 AVAILABLE_FEATURES = {
     "lowlevel.average_loudness": ["llj.data->'lowlevel'->'average_loudness'", None], 
@@ -326,7 +326,7 @@ def get_many_highlevel():
     return jsonify(recording_details)
 
 
-def parse_select_features():
+def parse_individual_features():
     """Check whether the features are found or not.
     Parse the query string of features to create a list of 
     the json paths to features, excluding those that are 
@@ -375,7 +375,7 @@ def parse_select_features():
 
 @bp_core.route("/low-level/select", methods=["GET"])
 @crossdomain()
-def get_many_select_features():
+def get_many_individual_features():
     """Get a specified subset of low-level data for many recordings at once.
     
     **Example response**:
@@ -411,8 +411,8 @@ def get_many_select_features():
     :resheader Content-Type: *application/json*
     """
     recordings = check_bad_request_for_multiple_recordings()
-    parsed_features = parse_select_features()
-    recording_details = db.data.load_many_select_features(recordings, parsed_features)
+    parsed_features = parse_individual_features()
+    recording_details = db.data.load_many_individual_features(recordings, parsed_features)
 
     return jsonify(recording_details)
 

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -376,15 +376,27 @@ def get_many_select_features():
                   "offset2": {document}},
         "mbid2": {"offset1": {document}}
        }
+
+    MBIDs and offset keys are returned as strings (as per JSON encoding rules).
+    If an offset is not specified in the request for an mbid or is not a valid integer >=0,
+    the offset will be 0.
+
+    If the list of MBIDs in the query string has a recording which is not
+    present in the database, then it is silently ignored and will not appear
+    in the returned data.
     
     :query recording_ids: *Required.* A list of recording MBIDs to retrieve.
         
         Takes the form `mbid[:offset];mbid[:offset]`. Offsets are optional, and should
-        be >= 0
+        be >= 0.
+
+        You can specify up to :py:const:`~webserver.views.api.v1.core.MAX_ITEMS_PER_BULK_REQUEST` MBIDs in a request.
     
     :query features: *Required.* A list of features to be returned for each mbid.
         
         Takes the form `feature1;feature2`.
+
+        The following features can be specified :py:const:`~webserver.views.api.v1.core.SELECTABLE_FEATURES` in a request.
     
     :resheader Content-Type: *application/json*
     """

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -10,8 +10,8 @@ import webserver.views.api.exceptions
 from db.data import submit_low_level_data, count_lowlevel
 from db.exceptions import NoDataFoundException, BadDataException
 from webserver.decorators import crossdomain
+from utils.container_utils import remove_duplicates
 from brainzutils.ratelimit import ratelimit
-from utils.remove_duplicates import remove_duplicates
 
 bp_core = Blueprint('api_v1_core', __name__)
 

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -407,7 +407,7 @@ def get_many_individual_features():
         
         Takes the form `feature1;feature2`.
 
-        The following features can be specified :py:const:`~webserver.views.api.v1.core.SELECTABLE_FEATURES` in a request.
+        The following features can be specified :py:const:`~webserver.views.api.v1.core.AVAILABLE_FEATURES` in a request.
     
     :resheader Content-Type: *application/json*
     """

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -11,6 +11,7 @@ from db.data import submit_low_level_data, count_lowlevel
 from db.exceptions import NoDataFoundException, BadDataException
 from webserver.decorators import crossdomain
 from brainzutils.ratelimit import ratelimit
+from utils.remove_duplicates import remove_duplicates
 
 bp_core = Blueprint('api_v1_core', __name__)
 
@@ -210,8 +211,7 @@ def _parse_bulk_params(params):
         ret.append((recording_id.lower(), offset))
 
     # Remove duplicates, preserving order
-    seen = set()
-    return [x for x in ret if not (x in seen or seen.add(x))]
+    return remove_duplicates(ret)
 
 
 def check_bad_request_for_multiple_recordings():
@@ -360,8 +360,8 @@ def parse_select_features():
     aliases.append(metadata_audio_properties_alias)
 
     # Remove duplicates, preserving order
-    seen = set()
-    return [x for x in parsed_features if not (x in seen or seen.add(x))], aliases
+    parsed_features = remove_duplicates(parsed_features)
+    return parsed_features, aliases
 
 
 @bp_core.route("/low-level/select", methods=["GET"])

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -384,28 +384,12 @@ class CoreViewsTestCase(ServerTestCase):
         self.assertEqual('More than 25 recordings not allowed per request', resp.json['message'])
 
     def test_get_bulk_individual_features_no_params(self):
-        # No parameters in bulk lookup results in an error
-        resp = self.client.get('/api/v1/low-level/individual')
-        self.assertEqual(400, resp.status_code)
-
-        # There are two params, but the recordings parameter is checked first
-        expected_result = {"message": "Missing `recording_ids` parameter"}
-        self.assertEqual(expected_result, resp.json)
-
-        # Only recordings parameter missing
+        # Features parameter without a recording_ids parameter is invalid
         features = "lowlevel.average_loudness;rhythm.onset_rate"
-        resp = self.client.get('/api/v1/low-level/individual?features=%s' % features)
+        resp = self.client.get('/api/v1/low-level?features=%s' % features)
         self.assertEqual(400, resp.status_code)
 
         expected_result = {"message": "Missing `recording_ids` parameter"}
-        self.assertEqual(expected_result, resp.json)
-
-        # Only features parameter missing
-        recordings = self.test_recording1_mbid + ';' + self.test_recording2_mbid
-        resp = self.client.get('/api/v1/low-level/individual?recording_ids=%s' % recordings)
-        self.assertEqual(400, resp.status_code)
-
-        expected_result = {"message": "Missing `features` parameter"}
         self.assertEqual(expected_result, resp.json)
 
     @mock.patch('db.data.load_many_individual_features')
@@ -431,7 +415,7 @@ class CoreViewsTestCase(ServerTestCase):
         }
         load_many_individual_features.return_value = expected_result
 
-        resp = self.client.get('/api/v1/low-level/individual?recording_ids={}&features={}'.format(recordings, features))
+        resp = self.client.get('/api/v1/low-level?recording_ids={}&features={}'.format(recordings, features))
         self.assertEqual(200, resp.status_code)
         self.assertEqual(expected_result, resp.json)
 
@@ -451,7 +435,7 @@ class CoreViewsTestCase(ServerTestCase):
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5}
         }
         load_many_individual_features.return_value = expected_result
-        resp = self.client.get('/api/v1/low-level/individual?recording_ids={}&features={}'.format(recordings, features))
+        resp = self.client.get('/api/v1/low-level?recording_ids={}&features={}'.format(recordings, features))
         self.assertEqual(resp.status_code, 200)
 
         # We expect that we get returned whatever we set the mock to, but the argument
@@ -470,7 +454,7 @@ class CoreViewsTestCase(ServerTestCase):
         # ignored.
         recordings = "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9;7f27d7a9-27f0-4663-9d20-2c9c40200e6d:3;405a5ff4-7ee2-436b-95c1-90ce8a83b359:2"
         features = "lowlevel.avg_loudness;rhythm.onset_rate;rhythm.bpm_histogram_first_peak_bpm"
-        
+
         rec_c5 = {"recording": "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9"}
         rec_40_2 = {"recording": "405a5ff4-7ee2-436b-95c1-90ce8a83b359:2"}
 
@@ -480,13 +464,13 @@ class CoreViewsTestCase(ServerTestCase):
         }
         load_many_individual_features.return_value = expected_result
 
-        resp = self.client.get('/api/v1/low-level/individual?recording_ids={}&features={}'.format(recordings, features))
+        resp = self.client.get('/api/v1/low-level?recording_ids={}&features={}'.format(recordings, features))
         self.assertEqual(200, resp.status_code)
         self.assertEqual(expected_result, resp.json)
 
         recordings = [("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
                       ("7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 3),
-                      ("405a5ff4-7ee2-436b-95c1-90ce8a83b359", 2)]   
+                      ("405a5ff4-7ee2-436b-95c1-90ce8a83b359", 2)]
         features = [("llj.data->'rhythm'->'onset_rate'", "rhythm.onset_rate", None),
                     ("llj.data->'metadata'->'version'", "metadata.version", {}),
                     ("llj.data->'metadata'->'audio_properties'", "metadata.audio_properties", {})]
@@ -497,7 +481,7 @@ class CoreViewsTestCase(ServerTestCase):
         manyids = [str(uuid.uuid4()) for i in range(26)]
         limit_exceed_url = ";".join(manyids)
         features = "lowlevel.average_loudness"
-        resp = self.client.get('/api/v1/low-level/individual?recording_ids={}&features={}'.format(limit_exceed_url, features))
+        resp = self.client.get('/api/v1/low-level?recording_ids={}&features={}'.format(limit_exceed_url, features))
         self.assertEqual(400, resp.status_code)
         self.assertEqual('More than 25 recordings not allowed per request', resp.json['message'])
 

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -356,7 +356,7 @@ class CoreViewsTestCase(ServerTestCase):
         self.assert400(resp)
         self.assertEqual('More than 25 recordings not allowed per request', resp.json['message'])
 
-    def test_get_bulk_select_features_no_params(self):
+    def test_get_bulk_individual_features_no_params(self):
         # No parameters in bulk lookup results in an error
         resp = self.client.get('/api/v1/low-level/select')
         self.assertEqual(400, resp.status_code)
@@ -383,8 +383,8 @@ class CoreViewsTestCase(ServerTestCase):
 
     # Once PR #349 adds conversion to lowercase in _parse_bulk_params, this skip should be removed
     @unittest.skip('Conversion to lowercase in _parse_bulk_params not yet added via PR #349.')
-    @mock.patch('db.data.load_many_select_features')
-    def test_get_bulk_select_features(self, load_many_select_features):
+    @mock.patch('db.data.load_many_individual_features')
+    def test_get_bulk_individual_features(self, load_many_individual_features):
         """Check that many items are returned, including two offsets of the
         same MBID.
 
@@ -404,7 +404,7 @@ class CoreViewsTestCase(ServerTestCase):
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
             "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2, "3": rec_40_3}
         }
-        load_many_select_features.return_value = expected_result
+        load_many_individual_features.return_value = expected_result
 
         resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(recordings, features))
         self.assertEqual(200, resp.status_code)
@@ -417,7 +417,7 @@ class CoreViewsTestCase(ServerTestCase):
                     ("llj.data->'rhythm'->'onset_rate'", "rhythm.onset_rate", None),
                     ("llj.data->'metadata'->'version'", "metadata.version", {}),
                     ("llj.data->'metadata'->'audio_properties'", "metadata.audio_properties", {})]
-        load_many_select_features.assert_called_with(recordings, features)
+        load_many_individual_features.assert_called_with(recordings, features)
 
         # upper-case MBID
         recordings = "c5f4909e-1d7b-4f15-a6f6-1AF376BC01C9"
@@ -425,7 +425,7 @@ class CoreViewsTestCase(ServerTestCase):
         expected_result = {
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5}
         }
-        load_many_select_features.return_value = expected_result
+        load_many_individual_features.return_value = expected_result
         resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(recordings, features))
         self.assertEqual(resp.status_code, 200)
 
@@ -436,10 +436,10 @@ class CoreViewsTestCase(ServerTestCase):
         features = [("llj.data->'lowlevel'->'average_loudness'", "lowlevel.average_loudness", None),
                     ("llj.data->'metadata'->'version'", "metadata.version", {}),
                     ("llj.data->'metadata'->'audio_properties'", "metadata.audio_properties", {})]
-        load_many_select_features.assert_called_with(recordings, features)
+        load_many_individual_features.assert_called_with(recordings, features)
 
-    @mock.patch('db.data.load_many_select_features')
-    def test_get_bulk_select_features_absent(self, load_many_select_features):
+    @mock.patch('db.data.load_many_individual_features')
+    def test_get_bulk_individual_features_absent(self, load_many_individual_features):
         # Within MBID parameter, ones absent from the database are ignored.
         # Features that aren't in the list of available features are
         # ignored.
@@ -453,7 +453,7 @@ class CoreViewsTestCase(ServerTestCase):
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
             "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2}
         }
-        load_many_select_features.return_value = expected_result
+        load_many_individual_features.return_value = expected_result
 
         resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(recordings, features))
         self.assertEqual(200, resp.status_code)
@@ -465,9 +465,9 @@ class CoreViewsTestCase(ServerTestCase):
         features = [("llj.data->'rhythm'->'onset_rate'", "rhythm.onset_rate", None),
                     ("llj.data->'metadata'->'version'", "metadata.version", {}),
                     ("llj.data->'metadata'->'audio_properties'", "metadata.audio_properties", {})]
-        load_many_select_features.assert_called_with(recordings, features)
+        load_many_individual_features.assert_called_with(recordings, features)
 
-    def test_get_bulk_select_features_more_than_25(self):
+    def test_get_bulk_individual_features_more_than_25(self):
         # Create many random uuids, because of parameter deduplication
         manyids = [str(uuid.uuid4()) for i in range(26)]
         limit_exceed_url = ";".join(manyids)

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -381,8 +381,6 @@ class CoreViewsTestCase(ServerTestCase):
         expected_result = {"message": "Missing `features` parameter"}
         self.assertEqual(expected_result, resp.json)
 
-    # Once PR #349 adds conversion to lowercase in _parse_bulk_params, this skip should be removed
-    @unittest.skip('Conversion to lowercase in _parse_bulk_params not yet added via PR #349.')
     @mock.patch('db.data.load_many_individual_features')
     def test_get_bulk_individual_features(self, load_many_individual_features):
         """Check that many items are returned, including two offsets of the

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -358,7 +358,7 @@ class CoreViewsTestCase(ServerTestCase):
 
     def test_get_bulk_individual_features_no_params(self):
         # No parameters in bulk lookup results in an error
-        resp = self.client.get('/api/v1/low-level/select')
+        resp = self.client.get('/api/v1/low-level/individual')
         self.assertEqual(400, resp.status_code)
 
         # There are two params, but the recordings parameter is checked first
@@ -367,7 +367,7 @@ class CoreViewsTestCase(ServerTestCase):
 
         # Only recordings parameter missing
         features = "lowlevel.average_loudness;rhythm.onset_rate"
-        resp = self.client.get('/api/v1/low-level/select?features=%s' % features)
+        resp = self.client.get('/api/v1/low-level/individual?features=%s' % features)
         self.assertEqual(400, resp.status_code)
 
         expected_result = {"message": "Missing `recording_ids` parameter"}
@@ -375,7 +375,7 @@ class CoreViewsTestCase(ServerTestCase):
 
         # Only features parameter missing
         recordings = self.test_recording1_mbid + ';' + self.test_recording2_mbid
-        resp = self.client.get('/api/v1/low-level/select?recording_ids=%s' % recordings)
+        resp = self.client.get('/api/v1/low-level/individual?recording_ids=%s' % recordings)
         self.assertEqual(400, resp.status_code)
 
         expected_result = {"message": "Missing `features` parameter"}
@@ -406,7 +406,7 @@ class CoreViewsTestCase(ServerTestCase):
         }
         load_many_individual_features.return_value = expected_result
 
-        resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(recordings, features))
+        resp = self.client.get('/api/v1/low-level/individual?recording_ids={}&features={}'.format(recordings, features))
         self.assertEqual(200, resp.status_code)
         self.assertEqual(expected_result, resp.json)
 
@@ -426,7 +426,7 @@ class CoreViewsTestCase(ServerTestCase):
             "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5}
         }
         load_many_individual_features.return_value = expected_result
-        resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(recordings, features))
+        resp = self.client.get('/api/v1/low-level/individual?recording_ids={}&features={}'.format(recordings, features))
         self.assertEqual(resp.status_code, 200)
 
         # We expect that we get returned whatever we set the mock to, but the argument
@@ -455,7 +455,7 @@ class CoreViewsTestCase(ServerTestCase):
         }
         load_many_individual_features.return_value = expected_result
 
-        resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(recordings, features))
+        resp = self.client.get('/api/v1/low-level/individual?recording_ids={}&features={}'.format(recordings, features))
         self.assertEqual(200, resp.status_code)
         self.assertEqual(expected_result, resp.json)
 
@@ -472,7 +472,7 @@ class CoreViewsTestCase(ServerTestCase):
         manyids = [str(uuid.uuid4()) for i in range(26)]
         limit_exceed_url = ";".join(manyids)
         features = "lowlevel.average_loudness"
-        resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(limit_exceed_url, features))
+        resp = self.client.get('/api/v1/low-level/individual?recording_ids={}&features={}'.format(limit_exceed_url, features))
         self.assertEqual(400, resp.status_code)
         self.assertEqual('More than 25 recordings not allowed per request', resp.json['message'])
 

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -381,15 +381,17 @@ class CoreViewsTestCase(ServerTestCase):
         expected_result = {"message": "Missing `features` parameter"}
         self.assertEqual(expected_result, resp.json)
 
+    # Once PR #349 adds conversion to lowercase in _parse_bulk_params, this skip should be removed
+    @unittest.skip('Conversion to lowercase in _parse_bulk_params not yet added via PR #349.')
     @mock.patch('db.data.load_many_select_features')
     def test_get_bulk_select_features(self, load_many_select_features):
         """Check that many items are returned, including two offsets of the
-        same MBID. 
+        same MBID.
 
-        If metadata.audio_properties and metadata.version are not requested, 
-        they are still included. 
-        
-        Duplicate features and (MBID, offset) combinations are removed.""" 
+        If metadata.audio_properties and metadata.version are not requested,
+        they are still included.
+
+        Duplicate features and (MBID, offset) combinations are removed."""
 
         recordings = "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9;c5f4909e-1d7b-4f15-a6f6-1af376bc01c9:0;405a5ff4-7ee2-436b-95c1-90ce8a83b359:2;405a5ff4-7ee2-436b-95c1-90ce8a83b359:3"
         features = "lowlevel.average_loudness;rhythm.onset_rate;lowlevel.average_loudness"

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -229,7 +229,7 @@ class CoreViewsTestCase(ServerTestCase):
                       ("405a5ff4-7ee2-436b-95c1-90ce8a83b359", 2)]
         load_many_low_level.assert_called_with(recordings)
 
-    def test_get_bulk_ll_more_than_200(self):
+    def test_get_bulk_ll_more_than_25(self):
         # Create many random uuids, because of parameter deduplication
         manyids = [str(uuid.uuid4()) for i in range(26)]
         limit_exceed_url = ";".join(manyids)
@@ -354,6 +354,124 @@ class CoreViewsTestCase(ServerTestCase):
         limit_exceed_url = ";".join(manyids)
         resp = self.client.get('api/v1/high-level?recording_ids=' + limit_exceed_url)
         self.assert400(resp)
+        self.assertEqual('More than 25 recordings not allowed per request', resp.json['message'])
+
+    def test_get_bulk_select_features_no_params(self):
+        # No parameters in bulk lookup results in an error
+        resp = self.client.get('/api/v1/low-level/select')
+        self.assertEqual(400, resp.status_code)
+
+        # There are two params, but the recordings parameter is checked first
+        expected_result = {"message": "Missing `recording_ids` parameter"}
+        self.assertEqual(expected_result, resp.json)
+
+        # Only recordings parameter missing
+        features = "lowlevel.average_loudness;rhythm.onset_rate"
+        resp = self.client.get('/api/v1/low-level/select?features=%s' % features)
+        self.assertEqual(400, resp.status_code)
+
+        expected_result = {"message": "Missing `recording_ids` parameter"}
+        self.assertEqual(expected_result, resp.json)
+
+        # Only features parameter missing
+        recordings = self.test_recording1_mbid + ';' + self.test_recording2_mbid
+        resp = self.client.get('/api/v1/low-level/select?recording_ids=%s' % recordings)
+        self.assertEqual(400, resp.status_code)
+
+        expected_result = {"message": "Missing `features` parameter"}
+        self.assertEqual(expected_result, resp.json)
+
+    @mock.patch('db.data.load_many_select_features')
+    def test_get_bulk_select_features(self, load_many_select_features):
+        """Check that many items are returned, including two offsets of the
+        same MBID. 
+
+        If metadata.audio_properties and metadata.version are not requested, 
+        they are still included. 
+        
+        Duplicate features and (MBID, offset) combinations are removed.""" 
+
+        recordings = "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9;c5f4909e-1d7b-4f15-a6f6-1af376bc01c9:0;405a5ff4-7ee2-436b-95c1-90ce8a83b359:2;405a5ff4-7ee2-436b-95c1-90ce8a83b359:3"
+        features = "lowlevel.average_loudness;rhythm.onset_rate;lowlevel.average_loudness"
+
+        rec_c5 = {"recording": "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9"}
+        rec_40_2 = {"recording": "405a5ff4-7ee2-436b-95c1-90ce8a83b359:2"}
+        rec_40_3 = {"recording": "405a5ff4-7ee2-436b-95c1-90ce8a83b359:3"}
+
+        expected_result = {
+            "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
+            "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2, "3": rec_40_3}
+        }
+        load_many_select_features.return_value = expected_result
+
+        resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(recordings, features))
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(expected_result, resp.json)
+
+        recordings = [("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
+                      ("405a5ff4-7ee2-436b-95c1-90ce8a83b359", 2),
+                      ("405a5ff4-7ee2-436b-95c1-90ce8a83b359", 3)]
+        features = [("llj.data->'lowlevel'->'average_loudness'", "lowlevel.average_loudness", None),
+                    ("llj.data->'rhythm'->'onset_rate'", "rhythm.onset_rate", None),
+                    ("llj.data->'metadata'->'version'", "metadata.version", {}),
+                    ("llj.data->'metadata'->'audio_properties'", "metadata.audio_properties", {})]
+        load_many_select_features.assert_called_with(recordings, features)
+
+        # upper-case MBID
+        recordings = "c5f4909e-1d7b-4f15-a6f6-1AF376BC01C9"
+        features = "lowlevel.average_loudness"
+        expected_result = {
+            "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5}
+        }
+        load_many_select_features.return_value = expected_result
+        resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(recordings, features))
+        self.assertEqual(resp.status_code, 200)
+
+        # We expect that we get returned whatever we set the mock to, but the argument
+        # to load_many_high_level is always lower-case regardless of what we pass in
+        self.assertEqual(resp.json, expected_result)
+        recordings = [("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0)]
+        features = [("llj.data->'lowlevel'->'average_loudness'", "lowlevel.average_loudness", None),
+                    ("llj.data->'metadata'->'version'", "metadata.version", {}),
+                    ("llj.data->'metadata'->'audio_properties'", "metadata.audio_properties", {})]
+        load_many_select_features.assert_called_with(recordings, features)
+
+    @mock.patch('db.data.load_many_select_features')
+    def test_get_bulk_select_features_absent(self, load_many_select_features):
+        # Within MBID parameter, ones absent from the database are ignored.
+        # Features that aren't in the list of available features are
+        # ignored.
+        recordings = "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9;7f27d7a9-27f0-4663-9d20-2c9c40200e6d:3;405a5ff4-7ee2-436b-95c1-90ce8a83b359:2"
+        features = "lowlevel.avg_loudness;rhythm.onset_rate;rhythm.bpm_histogram_first_peak_bpm"
+        
+        rec_c5 = {"recording": "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9"}
+        rec_40_2 = {"recording": "405a5ff4-7ee2-436b-95c1-90ce8a83b359:2"}
+
+        expected_result = {
+            "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9": {"0": rec_c5},
+            "405a5ff4-7ee2-436b-95c1-90ce8a83b359": {"2": rec_40_2}
+        }
+        load_many_select_features.return_value = expected_result
+
+        resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(recordings, features))
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(expected_result, resp.json)
+
+        recordings = [("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
+                      ("7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 3),
+                      ("405a5ff4-7ee2-436b-95c1-90ce8a83b359", 2)]   
+        features = [("llj.data->'rhythm'->'onset_rate'", "rhythm.onset_rate", None),
+                    ("llj.data->'metadata'->'version'", "metadata.version", {}),
+                    ("llj.data->'metadata'->'audio_properties'", "metadata.audio_properties", {})]
+        load_many_select_features.assert_called_with(recordings, features)
+
+    def test_get_bulk_select_features_more_than_25(self):
+        # Create many random uuids, because of parameter deduplication
+        manyids = [str(uuid.uuid4()) for i in range(26)]
+        limit_exceed_url = ";".join(manyids)
+        features = "lowlevel.average_loudness"
+        resp = self.client.get('/api/v1/low-level/select?recording_ids={}&features={}'.format(limit_exceed_url, features))
+        self.assertEqual(400, resp.status_code)
         self.assertEqual('More than 25 recordings not allowed per request', resp.json['message'])
 
     def submit_fake_data(self):


### PR DESCRIPTION
# AB-404: Endpoint for users to select specific lowlevel features

This feature allows users to select only a subset of the lowlevel data available when they do not require the whole file, and should help to reduce loads as a result. It makes this possible with the following changes:

- Create an endpoint, get_many_select_features which takes the required features as a parameter.
- Parse the features to get a string of paths that access different features of lowlevel.data.
- Query for these features in a similar fashion to other bulk get methods.