### PR TITLE
AB-411: Fix exceptions when uuids have upper-case characters

### DIFF
--- a/db/data.py
+++ b/db/data.py
@@ -377,7 +377,7 @@ def load_low_level(mbid, offset=0):
         NoDataFoundException: if this mbid doesn't exist or the offset is too high"""
 
     # in case it's a uuid
-    mbid = str(mbid)
+    mbid = str(mbid).lower()
     result = load_many_low_level([(mbid, offset)])
     if not result:
         raise db.exceptions.NoDataFoundException
@@ -387,10 +387,10 @@ def load_low_level(mbid, offset=0):
 
 def load_many_low_level(recordings):
     """Collect low-level JSON data for multiple recordings.
-    
+
     Args:
         recordings: A list of tuples (mbid, offset).
-    
+
     Returns:
         A dictionary of mbids containing a dictionary of offsets. If an (mbid, offset) doesn't exist
         in the database, it is ommitted from the returned data.
@@ -436,7 +436,7 @@ def load_high_level(mbid, offset=0):
     """
 
     # in case it's a uuid
-    mbid = str(mbid)
+    mbid = str(mbid).lower()
     result = load_many_high_level([(mbid, offset)])
     if not result:
         raise db.exceptions.NoDataFoundException

--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -81,10 +81,6 @@ def create_app(debug=None):
     else:
         raise Exception('One or more redis cache configuration options are missing from config.py')
 
-    # Extensions
-    from flask_uuid import FlaskUUID
-    FlaskUUID(app)
-
     # MusicBrainz
     import musicbrainzngs
     from db import SCHEMA_VERSION
@@ -145,7 +141,7 @@ def create_app_sphinx():
     that we use, so we have to ignore these initialization steps. Only
     blueprints/views are needed to build documentation.
     """
-    app = CustomFlask(import_name=__name__)
+    app = CustomFlask(import_name=__name__, use_flask_uuid=True)
     _register_blueprints(app)
     return app
 

--- a/webserver/views/api/legacy.py
+++ b/webserver/views/api/legacy.py
@@ -11,7 +11,7 @@ import uuid
 api_legacy_bp = Blueprint('api', __name__)
 
 
-@api_legacy_bp.route("/<uuid:mbid>/count", methods=["GET"])
+@api_legacy_bp.route("/<uuid(strict=False):mbid>/count", methods=["GET"])
 @crossdomain()
 def count(mbid):
     return jsonify({

--- a/webserver/views/api/test/test_legacy.py
+++ b/webserver/views/api/test/test_legacy.py
@@ -1,4 +1,8 @@
 from __future__ import absolute_import
+
+import mock
+
+import db.exceptions
 from webserver.testing import ServerTestCase
 from db.testing import TEST_DATA_PATH
 from flask import url_for
@@ -30,6 +34,46 @@ class LegacyViewsTestCase(ServerTestCase):
 
         resp = self.client.get(url_for('api.get_low_level', mbid=mbid))
         self.assertEqual(resp.status_code, 200)
+
+        # works regardless of the case of the uuid
+        resp = self.client.get(url_for('api.get_low_level', mbid=mbid.upper()))
+        self.assertEqual(resp.status_code, 200)
+
+    @mock.patch('db.data.load_high_level')
+    def test_get_high_level(self, load_high_level):
+        mbid = '0dad432b-16cc-4bf0-8961-fd31d124b01b'
+        load_high_level.side_effect = db.exceptions.NoDataFoundException
+        resp = self.client.get(url_for('api.get_high_level', mbid=mbid))
+        self.assertEqual(resp.status_code, 404)
+
+        load_high_level.side_effect = None
+        load_high_level.return_value = '{}'
+
+        resp = self.client.get(url_for('api.get_high_level', mbid=mbid))
+        self.assertEqual(resp.status_code, 200)
+        load_high_level.assert_called_with(mbid, 0)
+
+        resp = self.client.get(url_for('api.get_high_level', mbid=mbid.upper()))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_count(self):
+        mbid = '0dad432b-16cc-4bf0-8961-fd31d124b01b'
+        resp = self.client.get(url_for('api.count', mbid=mbid))
+        expected = {'mbid': mbid, 'count': 0}
+        self.assertEqual(resp.status_code, 200)
+        self.assertItemsEqual(resp.json, expected)
+
+        self.load_low_level_data(mbid)
+        expected = {'mbid': mbid, 'count': 1}
+        resp = self.client.get(url_for('api.count', mbid=mbid))
+        self.assertEqual(resp.status_code, 200)
+        self.assertItemsEqual(resp.json, expected)
+
+        # upper-case
+        resp = self.client.get(url_for('api.count', mbid=mbid.upper()))
+        self.assertEqual(resp.status_code, 200)
+        # mbid stays lower-case in the response
+        self.assertItemsEqual(resp.json, expected)
 
     def test_cors_headers(self):
         mbid = '0dad432b-16cc-4bf0-8961-fd31d124b01b'


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/AB-411

With the changes in AB-406 we introduced a bug where GET for a single item failed because postgresql returned mbids in lower-case and we tried to use the upper/mixed case value that was passed as a parameter.

Additionally, the Flask-uuid extension only accepts lower-case uuids by default, meaning that some of our API endpoints returned HTTP404 when presented with upper-case MBIDs, even if they existed in the database.

Convert all uuids to lower-case when returning them, and document this. Accept API queries using upper-case uuids.

I made no changes to the internal datasets api because we always use uuids returned from the api/postgres here, which are always lower-case.