### PR TITLE
AB-412: Compute recording similarity metrics on database

### DIFF
--- a/admin/sql/create_extensions.sql
+++ b/admin/sql/create_extensions.sql
@@ -1,1 +1,2 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+-- CREATE EXTENSION IF NOT EXISTS "cube"; -- Only required for postgres similarity

--- a/admin/sql/create_foreign_keys.sql
+++ b/admin/sql/create_foreign_keys.sql
@@ -115,4 +115,14 @@ ALTER TABLE feedback
   FOREIGN KEY (user_id)
   REFERENCES "user" (id);
 
+ALTER TABLE similarity
+  ADD CONSTRAINT similarity_fk_lowlevel
+  FOREIGN KEY (id)
+  REFERENCES lowlevel (id);
+
+ALTER TABLE similarity_stats
+  ADD CONSTRAINT similarity_stats_fk_metric
+  FOREIGN KEY (metric)
+  REFERENCES similarity_metrics (metric);
+
 COMMIT;

--- a/admin/sql/create_primary_keys.sql
+++ b/admin/sql/create_primary_keys.sql
@@ -20,5 +20,8 @@ ALTER TABLE challenge ADD CONSTRAINT challenge_pkey PRIMARY KEY (id);
 ALTER TABLE dataset_eval_challenge ADD CONSTRAINT dataset_eval_challenge_pkey PRIMARY KEY (dataset_eval_job, challenge_id);
 ALTER TABLE api_key ADD CONSTRAINT api_key_pkey PRIMARY KEY (value);
 ALTER TABLE feedback ADD CONSTRAINT feedback_pkey PRIMARY KEY (user_id, highlevel_model_id);
+ALTER TABLE similarity ADD CONSTRAINT similarity_pkey PRIMARY KEY (id);
+ALTER TABLE similarity_metrics ADD CONSTRAINT similarity_metrics_pkey PRIMARY KEY (metric);
+ALTER TABLE similarity_stats ADD CONSTRAINT similarity_stats_pkey PRIMARY KEY (metric);
 
 COMMIT;

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -156,4 +156,22 @@ CREATE TABLE feedback (
   suggestion         TEXT
 );
 
+CREATE TABLE similarity (
+  id INTEGER -- PK, FK to lowlevel
+);
+
+CREATE TABLE similarity_metrics (
+  metric    TEXT, -- PK
+  is_hybrid   BOOLEAN,
+  description TEXT,
+  category    TEXT,
+  visible     BOOLEAN
+);
+
+CREATE TABLE similarity_stats (
+  metric  TEXT,  -- FK to metric
+  means   DOUBLE PRECISION[],
+  stddevs DOUBLE PRECISION[]
+);
+
 COMMIT;

--- a/admin/updates/20190527-similarity.sql
+++ b/admin/updates/20190527-similarity.sql
@@ -1,0 +1,42 @@
+BEGIN;
+
+-- CREATE EXTENSION IF NOT EXISTS "cube"; -- Only required for postgres similarity
+
+
+CREATE TABLE similarity (
+  id INTEGER -- PK, FK to lowlevel
+);
+
+ALTER TABLE similarity ADD CONSTRAINT similarity_pkey PRIMARY KEY (id);
+
+ALTER TABLE similarity
+  ADD CONSTRAINT similarity_fk_lowlevel
+  FOREIGN KEY (id)
+  REFERENCES lowlevel (id);
+
+
+CREATE TABLE similarity_metrics (
+  metric 	  TEXT, -- PK
+  is_hybrid   BOOLEAN,
+  description TEXT,
+  category    TEXT,
+  visible     BOOLEAN
+);
+
+ALTER TABLE similarity_metrics ADD CONSTRAINT similarity_metrics_pkey PRIMARY KEY (metric);
+
+
+CREATE TABLE similarity_stats (
+  metric  TEXT,  -- FK to metric
+  means   DOUBLE PRECISION[],
+  stddevs DOUBLE PRECISION[]
+);
+
+ALTER TABLE similarity_stats ADD CONSTRAINT similarity_stats_pkey PRIMARY KEY (metric);
+
+ALTER TABLE similarity_stats
+  ADD CONSTRAINT similarity_stats_fk_metric
+  FOREIGN KEY (metric)
+  REFERENCES similarity_metrics (metric);
+
+COMMIT; 

--- a/manage.py
+++ b/manage.py
@@ -18,6 +18,7 @@ import db.exceptions
 import db.stats
 import db.user
 import webserver
+import similarity.manage
 
 ADMIN_SQL_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'admin', 'sql')
 
@@ -241,6 +242,7 @@ def toggle_site_status():
 
 # Please keep additional sets of commands down there
 cli.add_command(db.dump_manage.cli, name="dump")
+cli.add_command(similarity.manage.cli, name="similarity")
 
 if __name__ == '__main__':
     cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Jinja2 == 2.10
 mock == 2.0.0
 musicbrainzngs == 0.6
 ndg-httpsclient==0.5.1
+numpy == 1.16.3
 psycopg2 == 2.7.7
 pytz==2018.9
 pyyaml == 3.13

--- a/similarity/manage.py
+++ b/similarity/manage.py
@@ -1,0 +1,148 @@
+from __future__ import print_function
+from flask.cli import FlaskGroup
+import click
+
+import webserver
+import metrics
+from operations import HybridMetric
+import db
+
+from sqlalchemy import text
+
+
+PROCESS_BATCH_SIZE = 50000
+
+cli = FlaskGroup(add_default_commands=False, create_app=webserver.create_app_flaskgroup)
+
+
+@cli.command(name='init')
+def init_similarity():
+    click.echo('Copying data')
+    with db.engine.begin() as connection:
+        query = text("""
+        INSERT INTO similarity(id)
+             SELECT id
+               FROM lowlevel
+        """)
+        connection.execute(query)
+
+
+def _get_recordings_without_similarity(connection, name, batch_size):
+    query = text("""
+        SELECT id
+          FROM similarity
+         WHERE %(metric)s IS NULL
+         LIMIT %(limit)s
+    """ % {'metric': name, 'limit': batch_size})
+    result = connection.execute(query)
+    rows = result.fetchall()
+    if not rows:
+        return []
+    ids = zip(*rows)[0]
+    return ids
+
+
+def _update_similarity(connection, name, row_id, vector, isnan=False):
+    value = '[' + ', '.join(["'NaN'::double precision"] * len(vector)) + ']' if isnan else str(list(vector))
+    query = text("""
+        UPDATE similarity
+           SET %(metric)s = %(value)s
+         WHERE id = %(id)s
+    """ % {'metric': name, 'value': 'ARRAY' + value, 'id': row_id})
+    connection.execute(query)
+
+
+@cli.command(name='add-metric')
+@click.argument("name")
+@click.option("--force", "-f", is_flag=True, help="Recompute existing metrics.")
+@click.option("--to-process", "-t", type=int, help="Only process limited number of rows")
+@click.option("--batch-size", "-b", type=int, help="Override processing batch size")
+def add_metric(name, force=False, to_process=None, batch_size=None):
+    try:
+        metric_cls = metrics.BASE_METRICS[name]
+    except KeyError:
+        click.echo("No such metric is implemented: {}".format(name))
+        return
+
+    with db.engine.connect() as connection:
+        metric = metric_cls(connection)
+        metric.create(clear=force)
+
+        query = text("""
+            SELECT count(*), count(%s)
+              FROM similarity
+        """ % name)
+        result = connection.execute(query)
+        total, past = result.fetchone()
+        current = past
+        to_process = to_process or total - past
+
+        try:
+            metric.calculate_stats()
+        except AttributeError:
+            pass
+
+        batch_size = batch_size or PROCESS_BATCH_SIZE
+
+        click.echo('Started processing, {} / {} ({:.3f}%) already processed'.format(
+            current, total, float(current) / total * 100))
+        ids = _get_recordings_without_similarity(connection, name, batch_size)
+
+        while len(ids) > 0 and (current - past < to_process):
+            with connection.begin():
+                for row_id, data in metric.get_data_batch(ids):
+                    try:
+                        vector = metric.transform(data)
+                        isnan = False
+                    except ValueError:
+                        vector = [None] * metric.length()
+                        isnan = True
+                    _update_similarity(connection, name, row_id, vector, isnan=isnan)
+
+            current += len(ids)
+
+            click.echo('Processing {} / {} ({:.3f}%)'.format(current, total, float(current) / total * 100))
+            ids = _get_recordings_without_similarity(connection, name, batch_size)
+
+    return current
+
+
+@cli.command(name='delete-metric')
+@click.argument("name")
+@click.option("--soft", "-s", is_flag=True, help="Don't delete data")
+@click.option("--leave-stats", "-l", is_flag=True, help="Don't delete computed statistics")
+def delete_metric(name, soft=False, leave_stats=False):
+    try:
+        metric_cls = metrics.BASE_METRICS[name]
+    except KeyError:
+        click.echo('No such metric is implemented: {}'.format(name))
+        return
+
+    with db.engine.begin() as connection:
+        metric = metric_cls(connection)
+        metric.delete(soft=soft)
+
+        if not leave_stats:
+            try:
+                metric.delete_stats()
+            except AttributeError:
+                pass
+
+
+@cli.command()
+@click.argument("name")
+@click.argument("category")
+@click.option("--description", "-d", type=str, help="Description of metric")
+def add_hybrid(name, category, description=None):
+    description = description or name
+    with db.engine.begin() as connection:
+        metric = HybridMetric(connection, name, category, description)
+        metric.create()
+
+
+@cli.command()
+@click.argument("name")
+def delete_hybrid(name):
+    with db.engine.begin() as connection:
+        metric = HybridMetric(connection, name)
+        metric.delete()

--- a/similarity/metrics.py
+++ b/similarity/metrics.py
@@ -1,0 +1,304 @@
+import numpy as np
+from operations import BaseMetric
+
+from sqlalchemy import text
+
+NORMALIZATION_SAMPLE_SIZE = 10000
+
+
+class LowLevelMetric(BaseMetric):
+    path = ''
+    indices = None
+
+    def get_data_batch(self, ids):
+        query = text("""
+            SELECT id, %(path)s
+              FROM lowlevel_json
+             WHERE id IN :ids
+        """ % {"path": self.path})
+        result = self.connection.execute(query, {'ids': ids})
+        return result.fetchall()
+
+    def length(self):
+        return len(self.indices) if self.indices else 1
+
+
+class NormalizedLowLevelMetric(LowLevelMetric):
+    means = None
+    stddevs = None
+
+    def _calculate_stats_for(self, path):
+        query = text("""
+            SELECT avg(x), stddev_pop(x)
+              FROM (
+            SELECT (%(path)s)::double precision AS x
+              FROM lowlevel_json
+             LIMIT :limit)
+                AS res
+        """ % {"path": path})
+        result = self.connection.execute(query, {'limit': NORMALIZATION_SAMPLE_SIZE})
+        return result.fetchone()
+
+    def calculate_stats(self):
+        # TODO: use same stats for weighted and normal metrics (e.g. mfccs and mfccsw)
+        query = text("""
+            SELECT means, stddevs
+              FROM similarity_stats
+             WHERE metric = :metric
+        """)
+        result = self.connection.execute(query, {"metric": self.name})
+        row = result.fetchone()
+
+        if row:
+            print('Global stats already calculated')
+            self.means, self.stddevs = row
+            return
+
+        print('Calculating global stats for {}'.format(self.name))
+        self.means = []
+        self.stddevs = []
+
+        if self.indices is None:
+            self.means[0], self.stddevs[0] = self._calculate_stats_for(self.path)
+        else:
+            for i in self.indices:
+                print('Index {} (out of {})'.format(i, len(self.indices)))
+                mean, stddev = self._calculate_stats_for('{}->>{}'.format(self.path, i))
+                self.means.append(mean)
+                self.stddevs.append(stddev)
+
+        query = text("""
+            INSERT INTO similarity_stats (metric, means, stddevs)
+                 VALUES (%(metric)s, %(means)s, %(stddevs)s)
+        """ % {'metric': "'{}'".format(self.name),
+               'means': 'ARRAY' + str(self.means),
+               'stddevs': 'ARRAY' + str(self.stddevs)})
+        self.connection.execute(query)
+
+    def delete_stats(self):
+        print('Deleting global stats')
+        query = text("""
+            DELETE FROM similarity_stats
+                  WHERE metric = :metric
+        """)
+        self.connection.execute(query, {"metric": self.name})
+
+    def transform(self, data):
+        if not data:
+            raise ValueError('Invalid data value: {}'.format(data))
+        # normalize
+        data = np.array(data)[self.indices]
+        return (data - np.array(self.means)) / np.array(self.stddevs)
+
+
+class WeightedNormalizedLowLevelMetric(NormalizedLowLevelMetric):
+    weight = 0.95
+
+    def __init__(self, connection):
+        super(WeightedNormalizedLowLevelMetric, self).__init__(connection)
+        indices = np.array(self.indices)
+        indices -= np.min(indices)
+        self.weight_vector = np.array([self.weight ** i for i in indices])
+
+    def transform(self, data):  # add weights
+        data = super(WeightedNormalizedLowLevelMetric, self).transform(data)
+        return data * self.weight_vector
+
+
+class MfccsMetric(NormalizedLowLevelMetric):
+    name = 'mfccs'
+    description = 'MFCCs'
+    category = 'timbre'
+    path = "data->'lowlevel'->'mfcc'->'mean'"
+    indices = range(1, 13)
+
+
+class WeightedMfccsMetric(WeightedNormalizedLowLevelMetric, MfccsMetric):
+    name = 'mfccsw'
+    description = 'MFCCs (weighted)'
+
+
+class GfccsMetric(NormalizedLowLevelMetric):
+    name = 'gfccs'
+    description = 'GFCCs'
+    category = 'timbre'
+    path = "data->'lowlevel'->'gfcc'->'mean'"
+    indices = range(1, 13)
+
+
+class WeightedGfccsMetric(WeightedNormalizedLowLevelMetric, GfccsMetric):
+    name = 'gfccsw'
+    description = 'GFCCs (weighted)'
+
+
+class CircularMetric(LowLevelMetric):
+    def length(self):
+        return 2
+
+    def transform(self, data):
+        """Wrap the value that around circle with overlaps on integers"""
+        value = data * 2 * np.pi
+        return np.array([np.cos(value), np.sin(value)])
+
+
+KEYS_CIRCLE = ['C', 'G', 'D', 'A', 'E', 'B', 'F#', 'C#', 'G#', 'D#', 'A#', 'F']
+KEYS_MAP = {KEYS_CIRCLE[i]: float(i) / 12 for i in range(12)}
+SCALES_MAP = {'major': 0.0, 'minor': -3.0 / 12}
+
+
+class KeyMetric(CircularMetric):
+    name = 'key'
+    path = "data->'tonal'"
+    category = 'rhythm'
+    description = 'Key/Scale'
+
+    def transform(self, data):
+        try:
+            key_value = KEYS_MAP[data['key_key']]
+            key_value += SCALES_MAP[data['key_scale']]
+            return super(KeyMetric, self).transform(key_value)
+        except KeyError:
+            raise ValueError('Invalid key/scale values: \
+                            {}, {}'.format(data['key_key'], data['key_scale']))
+
+
+class LogCircularMetric(CircularMetric):
+    def transform(self, data):
+        if not data:
+            raise ValueError('Invalid data value: {}'.format(data))
+        return super(LogCircularMetric, self).transform(np.log2(data))
+
+
+class BpmMetric(LogCircularMetric):
+    name = 'bpm'
+    description = 'BPM'
+    category = 'rhythm'
+    path = "data->'rhythm'->'bpm'"
+
+
+class OnsetRateMetric(LogCircularMetric):
+    name = 'onsetrate'
+    description = 'OnsetRate'
+    category = 'rhythm'
+    path = "data->'rhythm'->'onset_rate'"
+
+
+class HighLevelMetric(BaseMetric):
+    category = 'high-level'
+
+    def get_data_batch(self, ids):
+        query = text("""
+            SELECT highlevel, jsonb_object_agg(model, data)
+              FROM highlevel_model
+             WHERE highlevel IN :ids
+          GROUP BY highlevel
+        """)
+        result = self.connection.execute(query, {"ids": ids})
+        rows = result.fetchall()
+
+        if len(rows) < len(ids):
+            existing_ids = [row[0] for row in rows]
+            for row_id in set(ids) - set(existing_ids):
+                rows.append((row_id, None))
+        return rows
+
+
+class BinaryCollectiveMetric(HighLevelMetric):
+    models = None
+
+    def transform(self, data):
+        if not data:
+            raise ValueError('Invalid data value: {}'.format(data))
+
+        vector = []
+        try:
+            for model_id in self.models:
+                model_data = data[str(model_id)]['all']
+                assert len(model_data) == 2
+                for key, value in model_data.items():
+                    if not key.startswith('not'):
+                        vector.append(value)
+                        break
+            return vector
+        except KeyError:
+            raise ValueError('Invalid data value: {}'.format(data))
+
+    def length(self):
+        return len(self.models)
+
+
+class MoodsMetric(BinaryCollectiveMetric):
+    name = 'moods'
+    description = 'Moods'
+    models = [
+        11,  # mood_happy
+        14,  # mood_sad
+        9,   # mood_aggressive
+        13,  # mood_relaxed
+        12   # mood_party
+    ]
+
+
+class InstrumentsMetric(BinaryCollectiveMetric):
+    name = 'instruments'
+    description = 'Instruments'
+    models = [
+        8,   # mood_acoustic
+        10,  # mood_electronic
+        18   # voice_instrumental
+    ]
+
+
+class SingleClassifierMetric(HighLevelMetric):
+    model = None
+    size = None
+
+    def transform(self, data):
+        if not data:
+            raise ValueError('Invalid data value: {}'.format(data))
+
+        return data[str(self.model)]['all'].values()
+
+    def length(self):
+        return self.size
+
+
+class DortmundGenreMetric(SingleClassifierMetric):
+    name = 'dortmund'
+    description = 'Genre (dortmund model)'
+    model = 3
+    size = 9
+
+
+class RosamericaGenreMetric(SingleClassifierMetric):
+    name = 'rosamerica'
+    description = 'Genre (rosamerica model)'
+    model = 5
+    size = 8
+
+
+class TzanetakisGenreMetric(SingleClassifierMetric):
+    name = 'tzanetakis'
+    description = 'Genre (tzanetakis model)'
+    model = 6
+    size = 10
+
+
+_BASE_METRICS_LIST = [
+    # Low-level
+    MfccsMetric,
+    WeightedMfccsMetric,
+    GfccsMetric,
+    WeightedGfccsMetric,
+    KeyMetric,
+    BpmMetric,
+    OnsetRateMetric,
+    # High-level
+    MoodsMetric,
+    InstrumentsMetric,
+    DortmundGenreMetric,
+    RosamericaGenreMetric,
+    TzanetakisGenreMetric
+]
+
+BASE_METRICS = {cls.name: cls for cls in _BASE_METRICS_LIST}

--- a/similarity/operations.py
+++ b/similarity/operations.py
@@ -1,0 +1,101 @@
+from sqlalchemy import text
+
+class Metric(object):
+    name = ''
+    description = ''
+    category = ''
+
+    def __init__(self, connection):
+        self.connection = connection
+
+    def _create(self, hybrid, column):
+        hybrid = str(hybrid).upper()
+        metrics_query = text("""
+            INSERT INTO similarity_metrics (metric, is_hybrid, description, category, visible)
+                 VALUES (:metric, :hybrid, :description, :category, TRUE)
+            ON CONFLICT (metric)
+          DO UPDATE SET visible=TRUE
+        """)
+        self.connection.execute(metrics_query, {'metric': self.name, 
+                                                'hybrid': hybrid, 
+                                                'description': self.description,
+                                                'category': self.category})
+
+        # This can be removed if not using postgres similarity solution
+        # index_query = text("""
+        #     CREATE INDEX IF NOT EXISTS %(metric)s_ndx_similarity ON similarity
+        #      USING gist(cube(%(column)s))
+        # """ % {'metric': self.name, 'column': column})
+        # self.connection.execute(index_query)
+
+    def delete(self):
+        metrics_query = text("""
+            DELETE FROM similarity_metrics
+                  WHERE metric = %s
+        """  % self.name)
+        self.connection.execute(metrics_query)
+
+        # # This can be removed if not using postgres similarity solution
+        # index_query = text("""
+        #     DROP INDEX IF EXISTS %s_ndx_similarity
+        # """ % self.name)
+        # self.connection.execute(index_query)
+
+
+class BaseMetric(Metric):
+    def create(self, clear=False):
+        query = text("""
+            ALTER TABLE similarity 
+             ADD COLUMN 
+          IF NOT EXISTS %s DOUBLE PRECISION[]
+        """ % self.name)
+        self.connection.execute(query)
+        self._create(hybrid=False, column=self.name)
+        if clear:
+            query = text("""
+                UPDATE similarity
+                   SET %(metric)s = NULL
+            """ % {"metric": self.name})
+            self.connection.execute(query)
+
+    def delete(self, soft=False):
+        if soft:
+            query = text("""
+                UPDATE similarity_metrics
+                   SET visible = FALSE
+                 WHERE metric = %s
+            """ % self.name)
+            self.connection.execute(query)
+        else:
+            super(BaseMetric, self).delete()
+            query = text("""
+                ALTER TABLE similarity
+                DROP COLUMN
+                  IF EXISTS %s
+            """ % self.name)
+            self.connection.execute(query)
+
+
+class HybridMetric(Metric):
+    def __init__(self, connection, name, category=None, description=None):
+        super(HybridMetric, self).__init__(connection)
+        self.name = name
+        self.category = category
+        self.description = description
+        self.index_name = 'hybrid_%s_ndx_similarity' % name
+        self.pseudo_column = self.get_pseudo_column(name)
+
+        # TODO: automatic inferring of category and description
+
+    def create(self):
+        if not self.category or not self.description:
+            raise ValueError('Category and description are required for creating new hybrid metric')
+        column = self.get_pseudo_column(self.name)
+        self._create(hybrid=True, column=column)
+
+    @staticmethod
+    def get_pseudo_column(metric):
+        metrics = metric.split('_')
+        if len(metrics) > 1:
+            return ' || '.join(metrics)
+        return metric 

--- a/similarity/operations.py
+++ b/similarity/operations.py
@@ -1,5 +1,6 @@
 from sqlalchemy import text
 
+
 class Metric(object):
     name = ''
     description = ''
@@ -16,8 +17,8 @@ class Metric(object):
             ON CONFLICT (metric)
           DO UPDATE SET visible=TRUE
         """)
-        self.connection.execute(metrics_query, {'metric': self.name, 
-                                                'hybrid': hybrid, 
+        self.connection.execute(metrics_query, {'metric': self.name,
+                                                'hybrid': hybrid,
                                                 'description': self.description,
                                                 'category': self.category})
 
@@ -32,7 +33,7 @@ class Metric(object):
         metrics_query = text("""
             DELETE FROM similarity_metrics
                   WHERE metric = %s
-        """  % self.name)
+        """ % self.name)
         self.connection.execute(metrics_query)
 
         # # This can be removed if not using postgres similarity solution
@@ -45,8 +46,8 @@ class Metric(object):
 class BaseMetric(Metric):
     def create(self, clear=False):
         query = text("""
-            ALTER TABLE similarity 
-             ADD COLUMN 
+            ALTER TABLE similarity
+             ADD COLUMN
           IF NOT EXISTS %s DOUBLE PRECISION[]
         """ % self.name)
         self.connection.execute(query)
@@ -89,7 +90,8 @@ class HybridMetric(Metric):
 
     def create(self):
         if not self.category or not self.description:
-            raise ValueError('Category and description are required for creating new hybrid metric')
+            raise ValueError('Category and description are \
+                required for creating new hybrid metric')
         column = self.get_pseudo_column(self.name)
         self._create(hybrid=True, column=column)
 
@@ -98,4 +100,4 @@ class HybridMetric(Metric):
         metrics = metric.split('_')
         if len(metrics) > 1:
             return ' || '.join(metrics)
-        return metric 
+        return metric


### PR DESCRIPTION
# AB-412: Compute recording similarity metrics on database

The first step in adding similarity to AB is to compute metrics for measuring similarity between recordings, since these measurements can later be indexed. This PR will add classes for the metrics and scripts to compute them for the entire database of recordings.

### Database Migrations
##### 'similarity' Table
- Holds computed vectors for each metric, for each recording in the database.
- These vectors will be added to the indices for querying.

##### 'similarity_metrics' Table
- Holds metadata about each metric that has been computed for the database

##### 'similarity_stats' Table
- Hold statistical information, mean and standard deviation of each computed metric.
- These statistics may be useful for representations at a later stage in the project.

### Metrics Classes
- Adds classes with information about each metric and methods for it to be created, deleted, and 
  computed for a recording.
- Includes formation of hybrid metrics, useful at a later stage in the project.

### Incremental Computation of Metrics
- After the similarity table has all recordings added to it using the cli command 
  `./develop.sh run --rm webserver python2 manage.py similarity init`, then a metric
   can be computed on the entire database incrementally using the following command:
  `./develop.sh run --rm webserver python2 manage.py similarity add-metric <metric_name>`
- For now, the metric must exist within the list of base metrics - later, hybrid metrics will allow for this 
  functionality to change.
- Also includes cli commands for adding and deleting hybrid metrics, useful at a later stage in the 
  project.
