### PR TITLE
AB-418: Format track lengths greater than an hour

### DIFF
--- a/webserver/views/data.py
+++ b/webserver/views/data.py
@@ -142,6 +142,21 @@ def _get_youtube_query(metadata):
         )
 
 
+def _format_length(length_ms):
+    try:
+        length = float(length_ms) / 1000
+    except ValueError:
+        return "?:??"
+    mins, secs = divmod(length, 60)
+    hours, mins = divmod(mins, 60)
+    if hours >= 1:
+        return "%d:%02d:%02d" % (hours, mins, secs)
+    elif mins >= 1:
+        return "%d:%02d" % (mins, secs)
+    else:
+        return "00:%02d" % secs
+
+
 def _get_recording_info(mbid, metadata):
     info = {
         'mbid': mbid,
@@ -166,7 +181,7 @@ def _get_recording_info(mbid, metadata):
                 '%s / %s' % (release['medium-list'][0]['track-list'][0]['number'],
                              release['medium-list'][0]['track-count'])
         if 'length' in good_metadata:
-            info['length'] = time.strftime("%M:%S", time.gmtime(float(good_metadata['length']) / 1000))
+            info['length'] = _format_length(good_metadata['length'])
         return info
 
     elif metadata:

--- a/webserver/views/test/test_data.py
+++ b/webserver/views/test/test_data.py
@@ -5,6 +5,7 @@ from flask import url_for
 
 from webserver.external import musicbrainz
 from webserver.testing import ServerTestCase
+import webserver.views.data
 
 
 class DataViewsTestCase(ServerTestCase):
@@ -47,6 +48,31 @@ class DataViewsTestCase(ServerTestCase):
         self.assertEqual(resp.status_code, 404)
         self.assertIn("We don't have any information about this recording yet.",
                       resp.data.decode("utf-8"))
+
+    def test_format_length(self):
+        # less than a minute, 00:ss
+        length = "45000"
+        self.assertEqual(webserver.views.data._format_length(length), "00:45")
+
+        # less than 10 minutes, m:ss
+        length = "430000"
+        self.assertEqual(webserver.views.data._format_length(length), "7:10")
+
+        # over 10 minutes, mm:ss
+        length = "1383000"
+        self.assertEqual(webserver.views.data._format_length(length), "23:03")
+
+        # an hour: 1:00:00
+        length = "3600000"
+        self.assertEqual(webserver.views.data._format_length(length), "1:00:00")
+
+        # less than 70 minutes, 1:mm:ss
+        length = "3661000"
+        self.assertEqual(webserver.views.data._format_length(length), "1:01:01")
+
+        # error, non-numeric
+        length = "test"
+        self.assertEqual(webserver.views.data._format_length(length), "?:??")
 
 
 class FakeMusicBrainz(object):


### PR DESCRIPTION
https://tickets.metabrainz.org/projects/AB/issues/AB-418

We were only formatting minutes and seconds of a length, not hours. Add them in 