### PR TITLE
AB-419: Encode unicode text when exporting dataset csv

### DIFF
--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -119,23 +119,28 @@ def _convert_dataset_to_csv_stringio(dataset):
 
     Returns:
         A rewound StringIO containing a CSV representation of the dataset"""
+
+    # We need to encode all text fields, because they may have non-ascii characters
+    #   - dataset description, class names, class descriptions
+    # TODO: On upgrade to python 3, check that stringio accepts the correct data
+    #       (may have to change to bytesio if we encode this data)
     fp = StringIO.StringIO()
     writer = csv.writer(fp)
 
     # write dataset description only if it is set
     if dataset["description"]:
         description = dataset["description"]
-        writer.writerow(["description", description])
+        writer.writerow(["description", description.encode("utf-8")])
 
     for ds_class in dataset["classes"]:
         # write class description only if it is set
         if ds_class["description"]:
             ds_class_description = ds_class["description"]
-            ds_class_desc_head = "description:" + ds_class["name"]
-            writer.writerow([ds_class_desc_head, ds_class_description])
+            ds_class_desc_head = "description:" + ds_class["name"].encode("utf-8")
+            writer.writerow([ds_class_desc_head, ds_class_description.encode("utf-8")])
 
     for ds_class in dataset["classes"]:
-        class_name = ds_class["name"]
+        class_name = ds_class["name"].encode("utf-8")
         for rec in ds_class["recordings"]:
             writer.writerow([rec, class_name])
 

--- a/webserver/views/test/test_datasets.py
+++ b/webserver/views/test/test_datasets.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import
 
 import csv
@@ -339,6 +340,22 @@ class DatasetsViewsTestCase(ServerTestCase):
         expected_list = ["description,A dataset description"] + expected_list
         expected = terminator.join(expected_list) + terminator
         self.assertEqual(dataset_csv, expected)
+
+        # Non-ascii text
+        self.test_data["classes"][0]["name"] = u"class dieciséis"
+        self.test_data["classes"][0]["description"] = u"descripción"
+        self.test_data["description"] = u"¿Qué pasa?"
+        expected_list = [u"description,¿Qué pasa?",
+                         u"description:class dieciséis,descripción",
+                         u"e8afe383-1478-497e-90b1-7885c7f37f6e,class dieciséis",
+                         u"0dad432b-16cc-4bf0-8961-fd31d124b01b,class dieciséis",
+                         u"e8afe383-1478-497e-90b1-7885c7f37f6e,Class #2",
+                         u"0dad432b-16cc-4bf0-8961-fd31d124b01b,Class #2"]
+        fp = ws_datasets._convert_dataset_to_csv_stringio(self.test_data)
+        dataset_csv = fp.getvalue()
+        expected = terminator.join(expected_list) + terminator
+        # The result of the conversion is a bytes, so convert it back to unicode
+        self.assertEqual(dataset_csv.decode("utf-8"), expected)
 
     @mock.patch("db.dataset.create_from_dict")
     def test_import_csv_invalid_form(self, mock_create_from_dict):


### PR DESCRIPTION
https://tickets.metabrainz.org/projects/AB/issues/AB-419

The csv module in python 2 requires that all values to it are ascii.
Explicitly convert dataset description, class names, class descriptions before adding them to the csv.
Don't convert uuids because they're valid ascii

I tested csv import with unicode text in the csv file and it worked fine