### PR TITLE
AB-417: Correctly delete datasets

### DIFF
--- a/webserver/views/api/v1/datasets.py
+++ b/webserver/views/api/v1/datasets.py
@@ -87,9 +87,7 @@ def create_dataset():
 @auth_required
 def delete_dataset(dataset_id):
     """Delete a dataset."""
-    ds = get_dataset(dataset_id)
-    if ds["author"] != current_user.id:
-        raise api_exceptions.APIUnauthorized("You can't delete this dataset.")
+    ds = get_check_dataset(dataset_id, write=True)
     db.dataset.delete(ds["id"])
     return jsonify(
         success=True,


### PR DESCRIPTION
https://tickets.metabrainz.org/projects/AB/issues/AB-417

We had no tests for dataset delete, and so didn't know that the delete endpoint used the incorrect method to get the dataset before deleting it.