### PR TITLE
Add Similarity Documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,6 +24,14 @@ Datasets
    :include-empty-docstring:
    :undoc-static:
 
+Similarity
+^^^^^^^^^^
+
+.. autoflask:: webserver:create_app_sphinx()
+   :blueprints: api_v1_similarity
+   :include-empty-docstring:
+   :undoc-static:
+
 Constants
 ^^^^^^^^^
 

--- a/docs/dev/similarity.rst
+++ b/docs/dev/similarity.rst
@@ -1,0 +1,25 @@
+Developing for Similarity
+=========================
+
+Setting up the environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once your database and server are built, compute the static indices
+for all indices at once using the cli command:
+
+`./develop.sh run --rm webserver python2 manage.py similarity add-indices`
+
+Index parameters
+^^^^^^^^^^^^^^^^
+
+Indices take a number of parameters when being built. We are currently evaluating
+them ourselves and have developed a set of base indices, but you may want to
+experiment with different parameters. 
+
+Queries to an index become more precise when the index is built with a higher 
+number of trees, but they will also take longer to build. Indices can also vary
+in the method used to calculate distance between recordings. Limitations of
+parameter selection can be found in the `Annoy documentation`_ and our codebase_
+
+.. _Annoy documentation: https://github.com/spotify/annoy
+.. _codebase: https://github.com/metabrainz/acousticbrainz-server/master/tree/similarity/index_model.py

--- a/docs/dev/similarity.rst
+++ b/docs/dev/similarity.rst
@@ -4,10 +4,34 @@ Developing for Similarity
 Setting up the environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once your database and server are built, compute the static indices
-for all indices at once using the cli command:
+**NOTE:** If there is no submitted data in the lowlevel table, similarity
+cannot be initialized.
 
-`./develop.sh run --rm webserver python2 manage.py similarity add-indices`
+Once your database and server are built, there are a few steps required to
+initialize the similarity engine. These steps can be run completed altogether
+using the following cli command:
+
+``./develop.sh run --rm webserver python2 manage.py similarity init``
+
+As seen below, they may also be applied separately for more control.
+
+Compute all required statistics over the lowlevel table:
+
+``./develop.sh run --rm webserver python2 manage.py similarity compute-stats``
+
+Compute all metrics for all recordings in the lowlevel table:
+
+``./develop.sh run --rm webserver python2 manage.py similarity add-metrics``
+
+This command can be run again at any time to compute the metrics for a number of
+newly submitted recordings. It will not recompute metrics for recordings that
+already exist in the similarity.similarity table.
+
+Finally, compute all static indices at once:
+
+``./develop.sh run --rm webserver python2 manage.py similarity add-indices``
+
+It is possible to alter the index parameters using additional arguments.
 
 Index parameters
 ^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,8 @@ Contents:
    :maxdepth: 2
 
    api
+   /dev/similarity
+   similarity
 
 Indices and tables
 ==================

--- a/docs/similarity.rst
+++ b/docs/similarity.rst
@@ -53,6 +53,21 @@ Note: Hybrid metrics are combinations of multiple metrics. In the future,
 we hope to integrate more metrics that combine low-level features for a 
 more holistic approach to similarity.
 
+Similarity Statistics
+^^^^^^^^^^^^^^^^^^^^^
+
+Some of our metrics are normalized using the mean and standard deviation
+of their features from the lowlevel table. We must compute the statistics
+for such metrics prior to computing the metrics themselves. To do so, we
+collect a sample of the lowlevel table and use it to approximate the mean
+and standard deviation. Currently, the metrics that require statistics are
+the following:
+
+- MFCCs
+- Weighted MFCCs
+- GFCCs
+- Weighted GFCCs
+
 Indexing
 ^^^^^^^^
 
@@ -66,6 +81,26 @@ on a time interval.
 
 More can be read about indices and contributing to similarity work in the
 `developer reference`_.
+
+Evaluation
+^^^^^^^^^^
+
+The similarity engine is an ongoing project, and its results are still largely
+experimental. While we tune different index parameters (described in the
+`developer reference`_), we'd like to gather feedback from the community.
+
+As such, we've made an evaluation available to the public. When viewing the
+summary data for a recording, you may access similar recordings organized by
+metric. Recordings are organized from most similar to least similar. Alongside
+the list of the most similar recordings, you may provide input:
+
+- Rate whether the recording should be higher or lower on the list of similarity,
+or whether this result seems accurate.
+- Provide additional suggestions related to a specific similar recording, or in
+general.
+
+Feel free to provide as much or as little feedback as you wish when browsing.
+We appreciate your help in improving similarity at AcousticBrainz!
 
 .. _API endpoints: https://acousticbrainz.readthedocs.io/api.html
 .. _Annoy: https://github.com/spotify/annoy

--- a/docs/similarity.rst
+++ b/docs/similarity.rst
@@ -1,0 +1,72 @@
+Recording Similarity
+====================
+
+An emerging feature in AcousticBrainz is recording similarity.
+
+We compute similarity between recordings based on a selection of 
+high and low-level features [metrics]. 
+
+Similarity metrics for each recording should be computed on submission. 
+When the metrics for a recording have been added to static index files, 
+we can query for track-track similarity based on our choice of feature. 
+
+This dataset is made available through a set of `API endpoints`_, and 
+distribution of the static index files for more flexibility.
+
+Similarity Metrics
+^^^^^^^^^^^^^^^^^^
+
+Similarity metrics are methods of applying a vectorized measurement to
+one, or many features of high and low-level data.
+
+Thus far, the following metrics can be used to assess similarity:
+
+==================== ============ ====================
+**Metric**			 **Hybrid**	  **Category**
+==================== ============ ====================
+MFCCs				 False	      Timbre
+==================== ============ ====================
+MFCCs (Weighted)	 False	      Timbre
+==================== ============ ====================
+GFCCs				 False	      Timbre
+==================== ============ ====================
+GFCCs (Weighted)	 False	      Timbre
+==================== ============ ====================
+Key					 False	      Rhythm (Key/Scale)
+==================== ============ ====================
+BPM					 False	      Rhythm
+==================== ============ ====================
+OnsetRate			 False	      Rhythm
+==================== ============ ====================
+Moods				 False	      High-Level
+==================== ============ ====================
+Instruments			 False	      High-Level
+==================== ============ ====================
+Dortmund			 False	      High-Level (Genre)
+==================== ============ ====================
+Rosamerica			 False	      High-Level (Genre)
+==================== ============ ====================
+Tzanetakis			 False	      High-Level (Genre)
+==================== ============ ====================
+
+Note: Hybrid metrics are combinations of multiple metrics. In the future, 
+we hope to integrate more metrics that combine low-level features for a 
+more holistic approach to similarity.
+
+Indexing
+^^^^^^^^
+
+Metric vectors for each recording are added to static indices, created with 
+the Annoy_ library. An individual index exists for each of the metrics
+available. An index uses a nearest neighbours approach for queries.
+
+Note that computing an index takes time, and thus it cannot happen each time
+a recording is submitted. Indices are recomputed, including new submissions,
+on a time interval.
+
+More can be read about indices and contributing to similarity work in the
+`developer reference`_.
+
+.. _API endpoints: https://acousticbrainz.readthedocs.io/api.html
+.. _Annoy: https://github.com/spotify/annoy
+.. _developer reference: https://acousticbrainz.readthedocs.io/dev/similarity.html

--- a/docs/similarity.rst
+++ b/docs/similarity.rst
@@ -22,31 +22,31 @@ one, or many features of high and low-level data.
 Thus far, the following metrics can be used to assess similarity:
 
 ==================== ============ ====================
-**Metric**			 **Hybrid**	  **Category**
+**Metric**           **Hybrid**   **Category**
 ==================== ============ ====================
-MFCCs				 False	      Timbre
+MFCCs                False        Timbre
 ==================== ============ ====================
-MFCCs (Weighted)	 False	      Timbre
+MFCCs (Weighted)     False        Timbre
 ==================== ============ ====================
-GFCCs				 False	      Timbre
+GFCCs                False        Timbre
 ==================== ============ ====================
-GFCCs (Weighted)	 False	      Timbre
+GFCCs (Weighted)     False        Timbre
 ==================== ============ ====================
-Key					 False	      Rhythm (Key/Scale)
+Key                  False        Rhythm (Key/Scale)
 ==================== ============ ====================
-BPM					 False	      Rhythm
+BPM                  False        Rhythm
 ==================== ============ ====================
-OnsetRate			 False	      Rhythm
+OnsetRate            False        Rhythm
 ==================== ============ ====================
-Moods				 False	      High-Level
+Moods                False        High-Level
 ==================== ============ ====================
-Instruments			 False	      High-Level
+Instruments          False        High-Level
 ==================== ============ ====================
-Dortmund			 False	      High-Level (Genre)
+Dortmund             False        High-Level (Genre)
 ==================== ============ ====================
-Rosamerica			 False	      High-Level (Genre)
+Rosamerica           False        High-Level (Genre)
 ==================== ============ ====================
-Tzanetakis			 False	      High-Level (Genre)
+Tzanetakis           False        High-Level (Genre)
 ==================== ============ ====================
 
 Note: Hybrid metrics are combinations of multiple metrics. In the future, 


### PR DESCRIPTION
## Add Similarity Documentation

This PR is meant to introduce documentation about similarity in AB, specifically using Annoy. It outlines the use of metrics and indices for both developers and other users.