### PR TITLE
Specify status code to 301 for http requests redirect

### DIFF
--- a/webserver/__init__.py
+++ b/webserver/__init__.py
@@ -136,7 +136,7 @@ def create_app(debug=None):
                 and app.config['TESTING'] == False \
                 and request.blueprint not in ('api', 'api_v1_core', 'api_v1_datasets', 'api_v1_dataset_eval'):
             url = request.url[7:] # remove http:// from url
-            return redirect('https://{}'.format(url))
+            return redirect('https://{}'.format(url), 301)
 
 
     @app.before_request


### PR DESCRIPTION
The redirects are permanent, so the correct code should be 301 while flask defaults to 302.