### PR TITLE
AB-437: Make files in /code owned by the acousticbrainz user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM metabrainz/python:2.7 AS acousticbrainz-base
 
-ARG deploy_env
-
 # Dockerize
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
@@ -41,7 +39,6 @@ RUN wget -q -O - https://deb.nodesource.com/setup_12.x | bash - && apt-get updat
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /code
-RUN mkdir /code/hl_extractor
 RUN mkdir /data
 WORKDIR /code
 
@@ -75,36 +72,39 @@ RUN mkdir /tmp/models \
     && mv /tmp/models/v2.1_beta1/svm_models /data/ \
     && cd / && rm -r /tmp/models
 
+RUN groupadd --gid 901 acousticbrainz
+RUN useradd --create-home --shell /bin/bash --uid 901 --gid 901 acousticbrainz
+
+RUN chown acousticbrainz:acousticbrainz /code
+
 # Python dependencies
-RUN mkdir /code/docs/
-COPY docs/requirements.txt /code/docs/requirements.txt
-COPY requirements.txt /code/requirements.txt
+RUN mkdir /code/docs/ && chown acousticbrainz:acousticbrainz /code/docs/
+COPY --chown=acousticbrainz:acousticbrainz docs/requirements.txt /code/docs/requirements.txt
+COPY --chown=acousticbrainz:acousticbrainz requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY package.json /code
+COPY --chown=acousticbrainz:acousticbrainz package.json /code
+
+USER acousticbrainz
 RUN npm install
 
 
 FROM acousticbrainz-base AS acousticbrainz-dev
+USER root
 
-ARG deploy_env
-
-COPY requirements_development.txt /code/requirements_development.txt
+COPY --chown=acousticbrainz:acousticbrainz requirements_development.txt /code/requirements_development.txt
 RUN pip install --no-cache-dir -r requirements_development.txt
 
-COPY . /code
+COPY --chown=acousticbrainz:acousticbrainz . /code
+USER acousticbrainz
 
 
 FROM acousticbrainz-base AS acousticbrainz-prod
-
-ARG deploy_env
+USER root
 
 RUN pip install --no-cache-dir uWSGI==2.0.17.1
-RUN groupadd --gid 901 acousticbrainz
-RUN useradd --create-home --shell /bin/bash --uid 901 --gid 901 acousticbrainz
 
-RUN mkdir /cache_namespaces
-RUN chown -R acousticbrainz:acousticbrainz /cache_namespaces
+RUN mkdir /cache_namespaces && chown -R acousticbrainz:acousticbrainz /cache_namespaces
 
 # Consul template service is already set up, just need to copy the configuration
 COPY ./docker/consul-template.conf /etc/consul-template.conf
@@ -134,5 +134,7 @@ RUN touch /etc/service/cron/down
 
 COPY ./docker/rc.local /etc/rc.local
 
-COPY . /code
+COPY --chown=acousticbrainz:acousticbrainz . /code
+
+USER acousticbrainz
 RUN npm run build:prod

--- a/docker/docker-compose.jenkins.yml
+++ b/docker/docker-compose.jenkins.yml
@@ -6,15 +6,13 @@ services:
     image: postgres:10.5
     environment:
       PGDATA: /var/lib/postgresql/data/pgdata
-    ports:
-      - "15431:5432"
     command: postgres -F
 
   acousticbrainz:
     build:
       context: ..
       dockerfile: Dockerfile
-      target: acousticbrainz-dev
+      target: acousticbrainz-test
     depends_on:
       - db
       - redis

--- a/docker/jenkins-test.sh
+++ b/docker/jenkins-test.sh
@@ -49,7 +49,7 @@ function run_tests {
     docker-compose -f $COMPOSE_FILE_LOC -p $COMPOSE_PROJECT_NAME run --rm $TEST_SERVICE_NAME \
         dockerize \
         -wait tcp://db:5432 -timeout 60s bash -c \
-        "cd /code && cp config.py.example config.py && ls -lR && python manage.py init_db"
+        "cd /code && cp config.py.example config.py && python manage.py init_db"
 
     # run tests
     echo "running tests"

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -19,9 +19,7 @@ TAG=${2:-beta}
 
 echo "Building AcousticBrainz web image with env $ENV tag $TAG..."
 docker build -t metabrainz/acousticbrainz:$TAG \
-        --target acousticbrainz-prod \
-        --build-arg GIT_COMMIT_SHA=$(git rev-parse HEAD) \
-        --build-arg deploy_env=$ENV .
+        --target acousticbrainz-prod .
 echo "Done!"
 echo "Pushing image to docker hub metabrainz/acousticbrainz-web:$TAG..."
 docker push metabrainz/acousticbrainz:$TAG


### PR DESCRIPTION
This was a little bit more involved than I had hoped, because npm installs things in the working directory... Because of this I had to make the `acousticbrainz` user earlier, and then `COPY --chown` everywhere, and use `USER` to switch between users. Now, everything in /code is owned by acousticbrainz.

Some upsides: now, everywhere that you run this, it's running as a non-privileged user!
Some downsides
 * now you can't run `pip install` in a shell if you temporarily want to install something while developing. Should we revert back to running as root for this?
 * Running in dev on a linux host, we've still got the issue where commands are being run as uid 901, and therefore files which are created by it can't be read/deleted by the user on their host without `sudo chown` magic

@paramsingh any feedback on what uid we should be running as in dev?