### PR TITLE
AB-436: Fix issues. datasets' class descriptions accept empty strings

### DIFF
--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -89,7 +89,7 @@ CREATE TABLE dataset (
 CREATE TABLE dataset_class (
   id          SERIAL,
   name        VARCHAR NOT NULL,
-  description TEXT,
+  description TEXT    NOT NULL, -- NULL values are not accepted
   dataset     UUID    NOT NULL -- FK to dataset
 );
 

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -79,7 +79,7 @@ ALTER TABLE "user" ADD CONSTRAINT user_musicbrainz_id_key UNIQUE (musicbrainz_id
 CREATE TABLE dataset (
   id          UUID,
   name        VARCHAR NOT NULL,
-  description TEXT,
+  description TEXT NOT NULL,
   author      INT NOT NULL, -- FK to user
   public      BOOLEAN NOT NULL,
   created     TIMESTAMP WITH TIME ZONE DEFAULT NOW(),

--- a/admin/sql/create_tables.sql
+++ b/admin/sql/create_tables.sql
@@ -89,7 +89,7 @@ CREATE TABLE dataset (
 CREATE TABLE dataset_class (
   id          SERIAL,
   name        VARCHAR NOT NULL,
-  description TEXT    NOT NULL, -- NULL values are not accepted
+  description TEXT    NOT NULL,
   dataset     UUID    NOT NULL -- FK to dataset
 );
 

--- a/admin/updates/20200428-alter-dataset_class-schema-description-not-null.sql
+++ b/admin/updates/20200428-alter-dataset_class-schema-description-not-null.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+-- Update the NULL values of the description column of the dataset_class to and empty string
+UPDATE dataset_class SET description = '' WHERE description IS NULL;
+-- Alter the table schema by adding the NOT NULL contraint to the description column of the dataset_class table
+ALTER TABLE dataset_class ALTER COLUMN description SET NOT NULL;
+
+COMMIT;

--- a/admin/updates/20200428-alter-dataset_class-schema-description-not-null.sql
+++ b/admin/updates/20200428-alter-dataset_class-schema-description-not-null.sql
@@ -4,5 +4,9 @@ BEGIN;
 UPDATE dataset_class SET description = '' WHERE description IS NULL;
 -- Alter the table schema by adding the NOT NULL contraint to the description column of the dataset_class table
 ALTER TABLE dataset_class ALTER COLUMN description SET NOT NULL;
+-- Update the NULL values of the description column of the dataset to and empty string
+UPDATE dataset SET description = '' WHERE description IS NULL;
+-- Alter the table schema by adding the NOT NULL contraint to the description column of the dataset table
+ALTER TABLE dataset ALTER COLUMN description SET NOT NULL;
 
 COMMIT;

--- a/db/dataset.py
+++ b/db/dataset.py
@@ -44,7 +44,9 @@ def create_from_dict(dictionary, author_id):
 
         for cls in dictionary["classes"]:
             if "description" not in cls:
-                cls["description"] = None
+                # cls["description"] = None
+                cls["description"] = ''
+                
             result = connection.execute("""INSERT INTO dataset_class (name, description, dataset)
                               VALUES (%s, %s, %s) RETURNING id""",
                                         (cls["name"], cls["description"], dataset_id))
@@ -124,7 +126,9 @@ def update(dataset_id, dictionary, author_id):
 
         for cls in dictionary["classes"]:
             if "description" not in cls:
-                cls["description"] = None
+                # cls["description"] = None
+                cls["description"] = ''
+
             result = connection.execute("""INSERT INTO dataset_class (name, description, dataset)
                               VALUES (%s, %s, %s) RETURNING id""",
                                         (cls["name"], cls["description"], dataset_id))
@@ -525,7 +529,7 @@ def check_recording_in_dataset(dataset_id, mbid):
             SELECT dataset_class.id
               FROM dataset_class
               JOIN dataset_class_member
-                ON dataset_class_member.class = dataset_class.id 
+                ON dataset_class_member.class = dataset_class.id
              WHERE dataset_class.dataset = :dataset_id
                AND dataset_class_member.mbid = :mbid
         """), {"dataset_id": dataset_id, "mbid": mbid})

--- a/db/dataset.py
+++ b/db/dataset.py
@@ -36,6 +36,8 @@ def create_from_dict(dictionary, author_id):
     with db.engine.begin() as connection:
         if "description" not in dictionary:
             dictionary["description"] = ""
+        if dictionary["description"] is None:
+            dictionary["description"] = ""
 
         result = connection.execute("""INSERT INTO dataset (id, name, description, public, author)
                           VALUES (uuid_generate_v4(), %s, %s, %s, %s) RETURNING id""",
@@ -44,6 +46,8 @@ def create_from_dict(dictionary, author_id):
 
         for cls in dictionary["classes"]:
             if "description" not in cls:
+                cls["description"] = ""
+            if cls["description"] is None:
                 cls["description"] = ""
             result = connection.execute("""INSERT INTO dataset_class (name, description, dataset)
                               VALUES (%s, %s, %s) RETURNING id""",
@@ -113,6 +117,8 @@ def update(dataset_id, dictionary, author_id):
     with db.engine.begin() as connection:
         if "description" not in dictionary:
             dictionary["description"] = ""
+        if dictionary["description"] is None:
+            dictionary["description"] = ""
 
         connection.execute("""UPDATE dataset
                           SET (name, description, public, author, last_edited) = (%s, %s, %s, %s, now())
@@ -124,6 +130,8 @@ def update(dataset_id, dictionary, author_id):
 
         for cls in dictionary["classes"]:
             if "description" not in cls:
+                cls["description"] = ""
+            if cls["description"] is None:
                 cls["description"] = ""
             result = connection.execute("""INSERT INTO dataset_class (name, description, dataset)
                               VALUES (%s, %s, %s) RETURNING id""",

--- a/db/dataset.py
+++ b/db/dataset.py
@@ -35,7 +35,7 @@ def create_from_dict(dictionary, author_id):
 
     with db.engine.begin() as connection:
         if "description" not in dictionary:
-            dictionary["description"] = None
+            dictionary["description"] = ""
 
         result = connection.execute("""INSERT INTO dataset (id, name, description, public, author)
                           VALUES (uuid_generate_v4(), %s, %s, %s, %s) RETURNING id""",
@@ -44,9 +44,7 @@ def create_from_dict(dictionary, author_id):
 
         for cls in dictionary["classes"]:
             if "description" not in cls:
-                # cls["description"] = None
-                cls["description"] = ''
-                
+                cls["description"] = ""
             result = connection.execute("""INSERT INTO dataset_class (name, description, dataset)
                               VALUES (%s, %s, %s) RETURNING id""",
                                         (cls["name"], cls["description"], dataset_id))
@@ -114,7 +112,7 @@ def update(dataset_id, dictionary, author_id):
 
     with db.engine.begin() as connection:
         if "description" not in dictionary:
-            dictionary["description"] = None
+            dictionary["description"] = ""
 
         connection.execute("""UPDATE dataset
                           SET (name, description, public, author, last_edited) = (%s, %s, %s, %s, now())
@@ -126,9 +124,7 @@ def update(dataset_id, dictionary, author_id):
 
         for cls in dictionary["classes"]:
             if "description" not in cls:
-                # cls["description"] = None
-                cls["description"] = ''
-
+                cls["description"] = ""
             result = connection.execute("""INSERT INTO dataset_class (name, description, dataset)
                               VALUES (%s, %s, %s) RETURNING id""",
                                         (cls["name"], cls["description"], dataset_id))
@@ -444,7 +440,7 @@ def add_class(dataset_id, class_data):
 
     with db.engine.begin() as connection:
         if "description" not in class_data:
-            class_data["description"] = None
+            class_data["description"] = ""
         connection.execute(sqlalchemy.text("""
             INSERT INTO dataset_class (name, description, dataset)
                  SELECT :name, :description, :datasetid

--- a/db/test/test_dataset.py
+++ b/db/test/test_dataset.py
@@ -396,7 +396,7 @@ class GetPublicDatasetsTestCase(DatabaseTestCase):
             res = connection.execute(query, {"name": name})
             return res.fetchone()[0]
 
-    def _create_dataset(self, author_id, name, desc=None, public=True):
+    def _create_dataset(self, author_id, name, desc="", public=True):
         """Creates a dataset for an author with a name and returns its id"""
 
         dataset_id = str(uuid.uuid4())

--- a/db/test/test_dataset.py
+++ b/db/test/test_dataset.py
@@ -50,6 +50,24 @@ class DatasetTestCase(DatabaseTestCase):
         self.assertEqual(len(ds["classes"][0]["recordings"]), 2)
         self.assertEqual(len(ds["classes"][1]["recordings"]), 3)
 
+    def test_create_from_dict_none_description(self):
+        bad_dict = copy.deepcopy(self.test_data)
+        bad_dict["description"] = None
+        bad_dict["classes"][1]["description"] = None
+        id = dataset.create_from_dict(bad_dict, author_id=self.test_user_id)
+        ds = dataset.get(id)
+        self.assertIsNotNone(ds["classes"][1]["description"])
+        self.assertIsNotNone(ds["description"])
+
+    def test_create_from_dict_absence_description(self):
+        bad_dict = copy.deepcopy(self.test_data)
+        bad_dict.pop("description")
+        bad_dict["classes"][1].pop("description")
+        id = dataset.create_from_dict(bad_dict, author_id=self.test_user_id)
+        ds = dataset.get(id)
+        self.assertIn("description", ds["classes"][1].keys())
+        self.assertIn("description", ds.keys())
+
     def test_create_from_dict_duplicates(self):
         bad_dict = copy.deepcopy(self.test_data)
         bad_dict["classes"][0]["recordings"] = [

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -335,7 +335,7 @@ def _parse_dataset_csv(file):
              {"name": class name, "description": class description, "recordings": []}
              a class is only returned if there are recordings for it. A class
         """
-    classes_dict = defaultdict(lambda: {"description": '', "recordings": []})
+    classes_dict = defaultdict(lambda: {"description": "", "recordings": []})
     dataset_description = None
     for class_row in csv.reader(file):
         if len(class_row) != 2:

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -310,7 +310,7 @@ def import_csv():
             "classes": classes,
             "public": form.public.data,
         }
-        
+
         try:
             dataset_id = db.dataset.create_from_dict(dataset_dict, current_user.id)
         except dataset_validator.ValidationException as e:
@@ -335,7 +335,7 @@ def _parse_dataset_csv(file):
              {"name": class name, "description": class description, "recordings": []}
              a class is only returned if there are recordings for it. A class
         """
-    classes_dict = defaultdict(lambda: {"description": None, "recordings": []})
+    classes_dict = defaultdict(lambda: {"description": '', "recordings": []})
     dataset_description = None
     for class_row in csv.reader(file):
         if len(class_row) != 2:
@@ -351,9 +351,9 @@ def _parse_dataset_csv(file):
         else:
             # row is a recording
             classes_dict[class_row[1]]["recordings"].append(class_row[0])
-    
+
     classes = []
-    
+
     for name, class_data in six.iteritems(classes_dict):
         if class_data["recordings"]:
             classes.append({
@@ -361,7 +361,7 @@ def _parse_dataset_csv(file):
                 "name": name,
                 "description": class_data["description"] if "description" in class_data else None,
             })
-    
+
     return dataset_description, classes
 
 

--- a/webserver/views/test/test_datasets.py
+++ b/webserver/views/test/test_datasets.py
@@ -309,7 +309,7 @@ class DatasetsViewsTestCase(ServerTestCase):
                                             "55339a88-f02b-4c03-9f94-f5ef3b29e1ab"]},
 
                             {"name": "Class #2",
-                             "description": None,
+                             "description": "",
                              "recordings": ["6fff3ebf-4c7f-4aed-b807-112fa4994cca",
                                             "2af64e20-38f9-4dc9-8db6-9d6026257dc2"]}
                             ]


### PR DESCRIPTION
Based on the [AB-436](https://tickets.metabrainz.org/browse/AB-436?jql=project%20%3D%20AB%20AND%20status%20%3D%20Open%20AND%20labels%20%3D%20good-first-bug) jira, the following issues are now fixed:

- When uploading a dataset via a CSV file, if the class name description is empty during the submission, the corresponding value that is stored into the DB is not anymore a null value but an empty string `''`.

- The `defaultdict(lambda: {"description": None, "recordings": []})` had to change to `defaultdict(lambda: {"description": '', "recordings": []})` class dictionary declaration inside the _"webserver/views/datasets.py", line 338, `_parse_dataset_csv()`_ function, in order to change the `key/value` class description of the class dictionary declaration.

- The same submission logic is fixed and followed for both the CSV importer and the dataset editor. This logic has been fixed too in case of updating the dataset.

- Additionally, inside the _"db/dataset.py"_ the `create_from_dict()` and `update()` functions are changed in the lines where a for loop was searching inside the class dictionary for the description key, and if it was missing the class description was set to `None` (i.e. `null`). Now, these values are set to `''`.

- The dataset_class table schema is also changed so that the "description" column can't anymore accept null values. The relevant constraint is now updated inside the _"admin/sql/create_tables.sql"_ file for that table. Finally, a new file _"admin/updates/20200428-alter-dataset_class-schema-description-not-null.sql"_ is created that automatically updates the existing stored null values with the _''_ and alters the dataset_class table schema to the new constraint.

- In _"admin/sql/create_tables.sql"_, a constraint `NOT NULL` is set on the table `dataset` for the `description` column.

-  In _"admin/updates/20200428-alter-dataset_class-schema-description-not-null.sql"_, two extra queries have been created that set the null values to an empty string of the `dataset`'s table `description` column and the `dataset` table schema is altered to not accept NULL values. 

- In _"db/test/test_dataset.py"_, in `_create_dataset()`, the  argument declaration is set from `desc=None` to `desc=""`.

Someone can test the CSV importer or the dataset editor if it works successfully by uploading or updating a dataset and submitting an empty description in the class description field (CSV or editor) or uploading a CSV dataset with only the _"<MBID>,<class>"_ fields in each row (i.e. without a _"description:<class>,<description text>"_ row inside the CSV file). Afterward, the submission of null values can be checked by opening a psql prompt and running, for example, the following query:

`SELECT name, description FROM dataset_class WHERE description IS NULL;`

0 rows should be returned back after running the query which means that no null values are now stored into the database in case of an empty class description.

p.s. As I 'm new to the group, I may not follow the PR guidelines explicitly but please, do not hesitate to ask me for further information if you have any questions.