### PR TITLE
AB-432: Allow badly-formatted MBIDs, but normalise them before use

### DIFF
--- a/webserver/views/api/legacy.py
+++ b/webserver/views/api/legacy.py
@@ -16,6 +16,7 @@ api_legacy_bp = Blueprint('api', __name__)
 @crossdomain()
 @ratelimit()
 def count(mbid):
+    mbid, offset = _validate_data_arguments(str(mbid), None)
     return jsonify({
         'mbid': mbid,
         'count': count_lowlevel(mbid),
@@ -75,7 +76,7 @@ def _validate_data_arguments(mbid, offset):
     If the offset is None, return 0, otherwise interpret it as a number. If it is
     not a number, raise 400."""
     try:
-        uuid.UUID(mbid)
+        mbid = str(uuid.UUID(mbid))
     except ValueError:
         # an invalid uuid is 404
         raise exceptions.APINotFound("Not found")

--- a/webserver/views/api/test/test_legacy.py
+++ b/webserver/views/api/test/test_legacy.py
@@ -35,8 +35,12 @@ class LegacyViewsTestCase(ServerTestCase):
         resp = self.client.get(url_for('api.get_low_level', mbid=mbid))
         self.assertEqual(resp.status_code, 200)
 
-        # works regardless of the case of the uuid
-        resp = self.client.get(url_for('api.get_low_level', mbid=mbid.upper()))
+        # works regardless of the case or format of the uuid
+        mbid = '0DAD432B-16CC-4BF0-8961-FD31D124B01B'
+        resp = self.client.get(url_for('api.get_low_level', mbid=mbid))
+        self.assertEqual(resp.status_code, 200)
+        mbid = '0DAD432B16CC4BF08961FD31D124B01B'
+        resp = self.client.get(url_for('api.get_low_level', mbid=mbid))
         self.assertEqual(resp.status_code, 200)
 
     @mock.patch('db.data.load_high_level')
@@ -53,7 +57,12 @@ class LegacyViewsTestCase(ServerTestCase):
         self.assertEqual(resp.status_code, 200)
         load_high_level.assert_called_with(mbid, 0)
 
-        resp = self.client.get(url_for('api.get_high_level', mbid=mbid.upper()))
+        # works regardless of the case or format of the uuid
+        mbid = '0DAD432B-16CC-4BF0-8961-FD31D124B01B'
+        resp = self.client.get(url_for('api.get_high_level', mbid=mbid))
+        self.assertEqual(resp.status_code, 200)
+        mbid = '0DAD432B16CC4BF08961FD31D124B01B'
+        resp = self.client.get(url_for('api.get_high_level', mbid=mbid))
         self.assertEqual(resp.status_code, 200)
 
     def test_count(self):
@@ -69,11 +78,15 @@ class LegacyViewsTestCase(ServerTestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertItemsEqual(resp.json, expected)
 
-        # upper-case
+        # upper-case and format
+        mbid = '0DAD432B-16CC-4BF0-8961-FD31D124B01B'
         resp = self.client.get(url_for('api.count', mbid=mbid.upper()))
         self.assertEqual(resp.status_code, 200)
         # mbid stays lower-case in the response
         self.assertItemsEqual(resp.json, expected)
+        mbid = '0DAD432B16CC4BF08961FD31D124B01B'
+        resp = self.client.get(url_for('api.count', mbid=mbid.upper()))
+        self.assertEqual(resp.status_code, 200)
 
     def test_cors_headers(self):
         mbid = '0dad432b-16cc-4bf0-8961-fd31d124b01b'

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -213,7 +213,7 @@ def _parse_bulk_params(params):
         elif len(parts) == 2:
             offset = parts[1]
         else:
-            raise webserver.views.api.exceptions.APIBadRequest("More than 1 : in '%s'" % recording)
+            raise webserver.views.api.exceptions.APIBadRequest("More than 1 colon (:) in '%s'" % recording)
 
         args = _validate_arguments(mbid, offset)
         ret.append(args)
@@ -262,7 +262,7 @@ def get_many_lowlevel():
 
        {"mbid1": {"offset1": {document},
                   "offset2": {document}},
-        "mbid2": {"offset1": {document}}
+        "mbid2": {"offset1": {document}},
         "mbid_mapping": {"MBID1": "mbid1"}
        }
 
@@ -271,9 +271,9 @@ def get_many_lowlevel():
     the offset will be 0.
 
     MBID keys are always returned in a normalised form (all lower-case, separated in groups of 8-4-4-4-12 characters),
-    even if the provided recording MBIDs are not given in this form. In the case that a MBID is not given in this
-    normalised form, the value `mbid_mapping` in the response will be a dictionary mapping user-provided MBIDs to
-    this form.
+    even if the provided recording MBIDs are not given in this form. In the case that a requested MBID is not given
+    in this normalised form, the value `mbid_mapping` in the response will be a dictionary mapping user-provided MBIDs
+    to this form.
 
     If the list of MBIDs in the query string has a recording which is not
     present in the database, then it is silently ignored and will not appear
@@ -321,9 +321,9 @@ def get_many_highlevel():
     the offset will be 0.
 
     MBID keys are always returned in a normalised form (all lower-case, separated in groups of 8-4-4-4-12 characters),
-    even if the provided recording MBIDs are not given in this form. In the case that a MBID is not given in this
-    normalised form, the value `mbid_mapping` in the response will be a dictionary mapping user-provided MBIDs to
-    this form.
+    even if the provided recording MBIDs are not given in this form. In the case that a requested MBID is not given
+    in this normalised form, the value `mbid_mapping` in the response will be a dictionary mapping user-provided MBIDs
+    to this form.
 
     If the list of MBIDs in the query string has a recording which is not
     present in the database, then it is silently ignored and will not appear
@@ -365,14 +365,14 @@ def get_many_count():
     .. sourcecode:: json
 
        {"mbid1": {"count": 3},
-        "mbid2": {"count": 1}
+        "mbid2": {"count": 1},
         "mbid_mapping": {"MBID1": "mbid1"}
        }
 
     MBID keys are always returned in a normalised form (all lower-case, separated in groups of 8-4-4-4-12 characters),
-    even if the provided recording MBIDs are not given in this form. In the case that a MBID is not given in this
-    normalised form, the value `mbid_mapping` in the response will be a dictionary mapping user-provided MBIDs to
-    this form.
+    even if the provided recording MBIDs are not given in this form. In the case that a requested MBID is not given
+    in this normalised form, the value `mbid_mapping` in the response will be a dictionary mapping user-provided MBIDs
+    to this form.
 
     :query recording_ids: *Required.* A list of recording MBIDs to retrieve
 

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -68,9 +68,10 @@ def get_low_level(mbid):
 
     :resheader Content-Type: *application/json*
     """
-    offset = _validate_offset(request.args.get("n"))
+    offset = request.args.get("n")
+    _, mbid, offset = _validate_arguments(str(mbid), offset)
     try:
-        return jsonify(db.data.load_low_level(str(mbid), offset))
+        return jsonify(db.data.load_low_level(mbid, offset))
     except NoDataFoundException:
         raise webserver.views.api.exceptions.APINotFound("Not found")
 
@@ -91,13 +92,15 @@ def get_high_level(mbid):
 
     :query n: *Optional.* Integer specifying an offset for a document.
     :query map_classes: *Optional.* If set to 'true', map class names to human-readable values
+    TODO: provide a link to what these mappings are
 
     :resheader Content-Type: *application/json*
     """
-    offset = _validate_offset(request.args.get("n"))
+    offset = request.args.get("n")
+    _, mbid, offset = _validate_arguments(str(mbid), offset)
     map_classes = _validate_map_classes(request.args.get("map_classes"))
     try:
-        return jsonify(db.data.load_high_level(str(mbid), offset, map_classes))
+        return jsonify(db.data.load_high_level(mbid, offset, map_classes))
     except NoDataFoundException:
         raise webserver.views.api.exceptions.APINotFound("Not found")
 
@@ -111,6 +114,8 @@ def submit_low_level(mbid):
 
     :resheader Content-Type: *application/json*
     """
+    # The uuid argument matcher in this method is set to strict mode, which means
+    # that we only accept uuids in lower-case
     raw_data = request.get_data()
     try:
         data = json.loads(raw_data.decode("utf-8"))
@@ -136,20 +141,47 @@ def _validate_map_classes(map_classes):
     return map_classes is not None and map_classes.lower() == 'true'
 
 
-def _validate_offset(offset):
-    """Validate the offset.
+def _generate_normalised_mbid_mapping(query_arguments):
+    """
+    :param query_arguments: a list of tuples (mbid, parsed_mbid, offset) as returned by _validate_arguments
+    :return: a dictionary mapping {mbid: parsed_mbid} only if
+    """
+    mapping = {}
+    for mbid, parsed_mbid, _ in query_arguments:
+        if mbid != parsed_mbid:
+            mapping[mbid] = parsed_mbid
+    return mapping
+
+
+def _validate_arguments(mbid, offset):
+    """Validate the mbid and offset.
 
     If the offset is None, return 0, otherwise interpret it as a number. If it is
-    not a number, raise 400.
+    not a number, return 0. Don't allow negative numbers.
+
+    If the mbid is an invalid UUID, raise an APIBadRequest
+    If the mbid isn't normalised (all lower-case, with hyphens), normalise it.
+
+    Returns:
+        a tuple (original_mbid, normalised_mbid, offset)
     """
+    try:
+        normalised_mbid = str(uuid.UUID(mbid))
+    except ValueError:
+        # an invalid uuid is 404
+        raise webserver.views.api.exceptions.APIBadRequest("'%s' is not a valid UUID" % mbid)
+
     if offset:
         try:
             offset = int(offset)
+            # Don't allow negative offsets
+            offset = max(offset, 0)
         except ValueError:
-            raise webserver.views.api.exceptions.APIBadRequest("Offset must be an integer value")
+            offset = 0
     else:
         offset = 0
-    return offset
+
+    return mbid, normalised_mbid, offset
 
 
 def _parse_bulk_params(params):
@@ -160,46 +192,41 @@ def _parse_bulk_params(params):
     Where offset is a number >=0. Offsets are optional.
     mbid must be a UUID.
 
-    If an offset is not specified or is invalid, 0 is used as a default.
+    If an offset is not specified non-numeric, or negativeit is replaced with 0.
     If an mbid is not valid, an APIBadRequest Exception is
     raised listing the bad MBID and no further processing is done.
 
-    Returns a list of tuples (mbid, offset). MBIDs are converted to lower-case
+    The mbid is normalised to all lower-case, with hyphens between sections.
+
+    Returns a list of tuples (mbid, parsed_mbid, offset).
+    mbid is the mbid as passed by the client. parsed_mbid is a normalised version of this mbid
+    (all lower-case with ).
     """
 
     ret = []
 
     for recording in params.split(";"):
         parts = str(recording).split(":")
-        recording_id = parts[0]
-        try:
-            uuid.UUID(recording_id)
-        except ValueError:
-            raise webserver.views.api.exceptions.APIBadRequest("'%s' is not a valid UUID" % recording_id)
-        if len(parts) > 2:
-            raise webserver.views.api.exceptions.APIBadRequest("More than 1 : in '%s'" % recording)
+        mbid = parts[0]
+        if len(parts) == 1:
+            offset = None
         elif len(parts) == 2:
-            try:
-                offset = int(parts[1])
-                # Don't allow negative offsets
-                offset = max(offset, 0)
-            except ValueError:
-                offset = 0
+            offset = parts[1]
         else:
-            offset = 0
+            raise webserver.views.api.exceptions.APIBadRequest("More than 1 : in '%s'" % recording)
 
-        ret.append((recording_id.lower(), offset))
+        args = _validate_arguments(mbid, offset)
+        ret.append(args)
 
     # Remove duplicates, preserving order
     seen = set()
     return [x for x in ret if not (x in seen or seen.add(x))]
 
 
-def check_bad_request_for_multiple_recordings():
+def _get_recording_ids_from_request():
     """
-    Check if a request for multiple recording ids is valid. The ?recording_ids parameter
-    to the current flask request is checked to see if it is present and if it follows
-    the format
+    Read the ?recording_ids query parameter from the flask request and validate it.
+    The parameter should be in the format
         mbid:n;mbid:n
     where mbid is a recording MBID and n is an optional integer offset. If the offset is
     missing or non-integer, it is replaced with 0
@@ -236,12 +263,17 @@ def get_many_lowlevel():
        {"mbid1": {"offset1": {document},
                   "offset2": {document}},
         "mbid2": {"offset1": {document}}
+        "mbid_mapping": {"MBID1": "mbid1"}
        }
 
     MBIDs and offset keys are returned as strings (as per JSON encoding rules).
     If an offset is not specified in the request for an MBID or is not a valid integer >=0,
     the offset will be 0.
-    MBID keys are always lower-case, even if the provided recording MBIDs are upper-case or mixed case.
+
+    MBID keys are always returned in a normalised form (all lower-case, separated in groups of 8-4-4-4-12 characters),
+    even if the provided recording MBIDs are not given in this form. In the case that a MBID is not given in this
+    normalised form, the value `mbid_mapping` in the response will be a dictionary mapping user-provided MBIDs to
+    this form.
 
     If the list of MBIDs in the query string has a recording which is not
     present in the database, then it is silently ignored and will not appear
@@ -256,8 +288,14 @@ def get_many_lowlevel():
 
     :resheader Content-Type: *application/json*
     """
-    recordings = check_bad_request_for_multiple_recordings()
+    recordings = _get_recording_ids_from_request()
+    mbid_mapping = _generate_normalised_mbid_mapping(recordings)
+    # The result from check_bad_request is (mbid, good_mbid, offset)
+    recordings = [(mbid, offset) for _, mbid, offset in recordings]
     recording_details = db.data.load_many_low_level(recordings)
+    recording_details['mbid_mapping'] = {}
+    if mbid_mapping:
+        recording_details['mbid_mapping'] = mbid_mapping
 
     return jsonify(recording_details)
 
@@ -274,13 +312,18 @@ def get_many_highlevel():
 
        {"mbid1": {"offset1": {document},
                   "offset2": {document}},
-        "mbid2": {"offset1": {document}}
+        "mbid2": {"offset1": {document}},
+        "mbid_mapping": {"MBID1": "mbid1"}
        }
 
     MBIDs and offset keys are returned as strings (as per JSON encoding rules).
     If an offset is not specified in the request for an mbid or is not a valid integer >=0,
     the offset will be 0.
-    MBID keys are always lower-case, even if the provided recording MBIDs are upper-case or mixed case.
+
+    MBID keys are always returned in a normalised form (all lower-case, separated in groups of 8-4-4-4-12 characters),
+    even if the provided recording MBIDs are not given in this form. In the case that a MBID is not given in this
+    normalised form, the value `mbid_mapping` in the response will be a dictionary mapping user-provided MBIDs to
+    this form.
 
     If the list of MBIDs in the query string has a recording which is not
     present in the database, then it is silently ignored and will not appear
@@ -298,8 +341,14 @@ def get_many_highlevel():
     :resheader Content-Type: *application/json*
     """
     map_classes = _validate_map_classes(request.args.get("map_classes"))
-    recordings = check_bad_request_for_multiple_recordings()
+    recordings = _get_recording_ids_from_request()
+    mbid_mapping = _generate_normalised_mbid_mapping(recordings)
+    # The result from check_bad_request is (mbid, good_mbid, offset)
+    recordings = [(mbid, offset) for _, mbid, offset in recordings]
     recording_details = db.data.load_many_high_level(recordings, map_classes)
+    recording_details['mbid_mapping'] = {}
+    if mbid_mapping:
+        recording_details['mbid_mapping'] = mbid_mapping
 
     return jsonify(recording_details)
 
@@ -317,9 +366,13 @@ def get_many_count():
 
        {"mbid1": {"count": 3},
         "mbid2": {"count": 1}
+        "mbid_mapping": {"MBID1": "mbid1"}
        }
 
-    MBID keys are always lower-case, even if the provided recording MBIDs are upper-case or mixed case.
+    MBID keys are always returned in a normalised form (all lower-case, separated in groups of 8-4-4-4-12 characters),
+    even if the provided recording MBIDs are not given in this form. In the case that a MBID is not given in this
+    normalised form, the value `mbid_mapping` in the response will be a dictionary mapping user-provided MBIDs to
+    this form.
 
     :query recording_ids: *Required.* A list of recording MBIDs to retrieve
 
@@ -329,7 +382,13 @@ def get_many_count():
 
     :resheader Content-Type: *application/json*
     """
-    recordings = check_bad_request_for_multiple_recordings()
+    recordings = _get_recording_ids_from_request()
+    mbid_mapping = _generate_normalised_mbid_mapping(recordings)
+    # The result from check_bad_request is (mbid, good_mbid, offset)
+    mbids = [mbid for (_, mbid, offset) in recordings]
+    recording_counts = db.data.count_many_lowlevel(mbids)
+    recording_counts['mbid_mapping'] = {}
+    if mbid_mapping:
+        recording_counts['mbid_mapping'] = mbid_mapping
 
-    mbids = [mbid for (mbid, offset) in recordings]
-    return jsonify(db.data.count_many_lowlevel(mbids))
+    return jsonify(recording_counts)


### PR DESCRIPTION
Postgres requires that uuids are all lower-case, and formatted with hyphens in the correct locations, but uuid.UUID accepts values missing hyphens or with them in non-standard locations. Use str(uuid.UUID(val)) to always normalise these values before passing to postgres.