### PR TITLE
AB-420: allow unicode characters in MBIDs when uploading a dataset

### DIFF
--- a/utils/dataset_validator.py
+++ b/utils/dataset_validator.py
@@ -1,5 +1,5 @@
 from flask_uuid import UUID_RE
-from six import string_types
+from six import string_types, ensure_text
 
 DATASET_NAME_LEN_MIN = 1
 DATASET_NAME_LEN_MAX = 100
@@ -232,7 +232,7 @@ def _validate_recordings(recordings, cls_name, cls_index=None):
         raise ValidationException('Field `recordings` in class "%s"%s is not a list.'
                                   % (cls_name, class_number_text))
     for recording in recordings:
-        if not UUID_RE.match(str(recording)):
+        if not isinstance(recording, string_types) or not UUID_RE.match(ensure_text(recording)):
             raise ValidationException('"%s" is not a valid recording MBID in class "%s"%s.' %
                                       (recording, cls_name, class_number_text))
 
@@ -262,4 +262,11 @@ def _check_dict_structure(dictionary, keys, error_location):
 
 class ValidationException(Exception):
     """Base class for dataset validation exceptions."""
-    pass
+    def __init__(self, error, *args, **kwargs):
+        """Create a new ValidationException
+
+        Arguments:
+            error: A description of why this error was raised
+        """
+        super(Exception, self).__init__(error, *args, **kwargs)
+        self.error = error

--- a/utils/test/test_dataset_validator.py
+++ b/utils/test/test_dataset_validator.py
@@ -1,4 +1,8 @@
+# coding=utf-8
 import unittest
+
+import six
+
 from utils import dataset_validator
 
 
@@ -10,26 +14,34 @@ class DatasetValidatorTestCase(unittest.TestCase):
         # not a dictionary
         with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_recordings_add_delete("not_dictionary")
-        self.assertEqual(str(out.exception), "Request must be a dictionary.")
+        self.assertEqual(six.ensure_text(out.exception.error), "Request must be a dictionary.")
 
         # missing a required element
         with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_recordings_add_delete({"class_name": "Test"})
-        self.assertEqual(str(out.exception), "Field `recordings` is missing from recordings dictionary.")
+        self.assertEqual(six.ensure_text(out.exception.error),
+                         "Field `recordings` is missing from recordings dictionary.")
 
         with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_recordings_add_delete({"class_name": "Test", "recordings": [], "other": None})
-        self.assertEqual(str(out.exception), "Unexpected field `other` in recordings dictionary.")
+        self.assertEqual(six.ensure_text(out.exception.error), "Unexpected field `other` in recordings dictionary.")
 
         # recordings not a list
         with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_recordings_add_delete({"class_name": "Test", "recordings": "notlist"})
-        self.assertEqual(str(out.exception), 'Field `recordings` in class "Test" is not a list.')
+        self.assertEqual(six.ensure_text(out.exception.error), 'Field `recordings` in class "Test" is not a list.')
 
         # recording item not a uuid
         with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_recordings_add_delete({"class_name": "Test", "recordings": [1]})
-        self.assertEqual(str(out.exception), '"1" is not a valid recording MBID in class "Test".')
+        self.assertEqual(six.ensure_text(out.exception.error), '"1" is not a valid recording MBID in class "Test".')
+
+        # utf-8 characters in the uuid field
+        with self.assertRaises(dataset_validator.ValidationException) as out:
+            dataset_validator.validate_recordings_add_delete({"class_name": "Test",
+                                                              "recordings": [u"bé686320-8057-4ca2-b484-e01434a3a2b1"]})
+        self.assertEqual(six.ensure_text(out.exception.error),
+                         u'"bé686320-8057-4ca2-b484-e01434a3a2b1" is not a valid recording MBID in class "Test".')
 
         # all ok
         dataset_validator.validate_recordings_add_delete({"class_name": "Test", "recordings": ["cc355a8a-1cf0-4eda-a693-fd38dc1dd4e2"]})
@@ -41,7 +53,7 @@ class DatasetValidatorTestCase(unittest.TestCase):
         # recordings required depending on flag
         with self.assertRaises(dataset_validator.ValidationException) as out:
             dataset_validator.validate_class({"name": "Test", "description": "Desc"}, recordings_required=True)
-        self.assertEqual(str(out.exception), "Field `recordings` is missing from class.")
+        self.assertEqual(six.ensure_text(out.exception.error), "Field `recordings` is missing from class.")
 
         # Required=False, no error
         dataset_validator.validate_class({"name": "Test", "description": "Desc"}, recordings_required=False)
@@ -295,7 +307,7 @@ class DatasetValidatorTestCase(unittest.TestCase):
                 "classes": [],
                 "public": False,
             })
-        self.assertEqual(str(ar.exception), "Dataset name must be between 1 and 100 characters")
+        self.assertEqual(six.ensure_text(ar.exception.error), "Dataset name must be between 1 and 100 characters")
 
         with self.assertRaises(dataset_validator.ValidationException) as ar:
             dataset_validator.validate({
@@ -304,7 +316,7 @@ class DatasetValidatorTestCase(unittest.TestCase):
                 "classes": [],
                 "public": False,
             })
-        self.assertEqual(str(ar.exception), "Dataset name must be between 1 and 100 characters")
+        self.assertEqual(six.ensure_text(ar.exception.error), "Dataset name must be between 1 and 100 characters")
 
         with self.assertRaises(dataset_validator.ValidationException) as ar:
             dataset_validator.validate({
@@ -317,7 +329,7 @@ class DatasetValidatorTestCase(unittest.TestCase):
                 ],
                 "public": False,
             })
-        self.assertEqual(str(ar.exception), "Length of the `name` field in class number 0 doesn't fit the limits. Class name must be between 1 and 100 characters")
+        self.assertEqual(six.ensure_text(ar.exception.error), "Length of the `name` field in class number 0 doesn't fit the limits. Class name must be between 1 and 100 characters")
 
         with self.assertRaises(dataset_validator.ValidationException) as ar:
             dataset_validator.validate({
@@ -331,7 +343,7 @@ class DatasetValidatorTestCase(unittest.TestCase):
                 ],
                 "public": False,
             })
-        self.assertEqual(str(ar.exception), "Length of the `name` field in class number 0 doesn't fit the limits. Class name must be between 1 and 100 characters")
+        self.assertEqual(six.ensure_text(ar.exception.error), "Length of the `name` field in class number 0 doesn't fit the limits. Class name must be between 1 and 100 characters")
 
         with self.assertRaises(dataset_validator.ValidationException):
             dataset_validator.validate({

--- a/webserver/errors.py
+++ b/webserver/errors.py
@@ -1,3 +1,4 @@
+import six
 from flask import render_template, jsonify, request, has_request_context, _request_ctx_stack, current_app
 
 import webserver
@@ -60,7 +61,11 @@ def init_error_handlers(app):
 def jsonify_error(error, code=None):
     if hasattr(error, 'description'):
         message = error.description
+    elif hasattr(error, 'error'):
+        message = error.error
+    elif len(error.args):
+        message = six.ensure_text(error.args[0])
     else:
-        message = str(error)
+        message = "unknown error"
     api_error = api_exceptions.APIError(message, getattr(error, 'code', code))
     return jsonify(api_error.to_dict()), api_error.status_code

--- a/webserver/views/api/v1/datasets.py
+++ b/webserver/views/api/v1/datasets.py
@@ -77,7 +77,7 @@ def create_dataset():
     try:
         dataset_id = db.dataset.create_from_dict(dataset_dict, current_user.id)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(str(e))
+        raise api_exceptions.APIBadRequest(e.error)
 
     return jsonify(
         success=True,
@@ -129,7 +129,7 @@ def update_dataset_details(dataset_id):
     try:
         dataset_validator.validate_dataset_update(dataset_data)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(str(e))
+        raise api_exceptions.APIBadRequest(e.error)
 
     db.dataset.update_dataset_meta(ds["id"], dataset_data)
     return jsonify(
@@ -175,7 +175,7 @@ def add_class(dataset_id):
     try:
         dataset_validator.validate_class(class_dict, recordings_required=False)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(str(e))
+        raise api_exceptions.APIBadRequest(e.error)
 
     if "recordings" in class_dict:
         unique_mbids = list(set(class_dict["recordings"]))
@@ -218,7 +218,7 @@ def update_class(dataset_id):
     try:
         dataset_validator.validate_class_update(class_data)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(str(e))
+        raise api_exceptions.APIBadRequest(e.error)
 
     try:
         db.dataset.update_class(ds["id"], class_data["name"], class_data)
@@ -259,7 +259,7 @@ def delete_class(dataset_id):
     try:
         dataset_validator.validate_class(class_dict, recordings_required=False)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(str(e))
+        raise api_exceptions.APIBadRequest(e.error)
 
     db.dataset.delete_class(ds["id"], class_dict)
     return jsonify(
@@ -294,7 +294,7 @@ def add_recordings(dataset_id):
     try:
         dataset_validator.validate_recordings_add_delete(class_dict)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(str(e))
+        raise api_exceptions.APIBadRequest(e.error)
 
     unique_mbids = list(set(class_dict["recordings"]))
     class_dict["recordings"] = unique_mbids
@@ -339,7 +339,7 @@ def delete_recordings(dataset_id):
     try:
         dataset_validator.validate_recordings_add_delete(class_dict)
     except dataset_validator.ValidationException as e:
-        raise api_exceptions.APIBadRequest(str(e))
+        raise api_exceptions.APIBadRequest(e.error)
 
     unique_mbids = list(set(class_dict["recordings"]))
     class_dict["recordings"] = unique_mbids

--- a/webserver/views/data.py
+++ b/webserver/views/data.py
@@ -6,7 +6,6 @@ from six.moves.urllib.parse import quote_plus
 import db.data
 import db.exceptions
 import json
-import time
 
 data_bp = Blueprint("data", __name__)
 

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -341,16 +341,23 @@ def _parse_dataset_csv(file):
         if len(class_row) != 2:
             raise BadRequest("Bad dataset! Each row must contain one <MBID, class name> pair.")
 
-        if class_row[0] == "description":
+        # Decode the rows as UTF-8.
+        # The utf-8-sig codec removes a UTF-8 BOM if it exists at the start of a file.
+        # In that case, col1 in the first row could start with 0xfeff, so remove it.
+        # For all other items it will decode as regular UTF-8
+        col1 = class_row[0].decode("utf-8-sig")
+        col2 = class_row[1].decode("utf-8-sig")
+
+        if col1 == "description":
             # row is the dataset description
-            dataset_description = class_row[1]
-        elif (class_row[0])[:12] == "description:":
+            dataset_description = col2
+        elif col1[:12] == "description:":
             # row is a class description
-            class_name = class_row[0][12:]
-            classes_dict[class_name]["description"] = class_row[1]
+            class_name = col1[12:]
+            classes_dict[class_name]["description"] = col2
         else:
             # row is a recording
-            classes_dict[class_row[1]]["recordings"].append(class_row[0])
+            classes_dict[col2]["recordings"].append(col1)
 
     classes = []
 

--- a/webserver/views/datasets.py
+++ b/webserver/views/datasets.py
@@ -289,7 +289,7 @@ def create_service():
         except dataset_validator.ValidationException as e:
             return jsonify(
                 success=False,
-                error=str(e),
+                error=e.error,
             ), 400
 
         return jsonify(
@@ -314,7 +314,7 @@ def import_csv():
         try:
             dataset_id = db.dataset.create_from_dict(dataset_dict, current_user.id)
         except dataset_validator.ValidationException as e:
-            raise BadRequest(str(e))
+            raise BadRequest(e.error)
         flash.info("Dataset has been imported successfully.")
         return redirect(url_for(".view", dataset_id=dataset_id))
 
@@ -407,7 +407,7 @@ def edit_service(dataset_id):
         except dataset_validator.ValidationException as e:
             return jsonify(
                 success=False,
-                error=str(e),
+                error=e.error,
             ), 400
 
         return jsonify(

--- a/webserver/views/test/test_datasets.py
+++ b/webserver/views/test/test_datasets.py
@@ -316,6 +316,28 @@ class DatasetsViewsTestCase(ServerTestCase):
         self.assertEqual(test_dataset_description, expected_dataset_description)
         self.assertEqual(test_classes, expected_classes)
 
+    def test_parse_dataset_csv_utf8(self):
+        """Parse a csv file which has some utf8-ish things:
+            - UTF-8 BOM
+            - non-ascii description
+            - non-ascii in the uuid (this is invalid, but this method just reads, it doesn't validate)
+        """
+
+        utf8_bom = b'\xef\xbb\xbf'
+        test_csv_file = os.path.join(TEST_DATA_PATH, 'test_dataset_utf8.csv')
+
+        # Before starting, check that the bom hasn't been removed from this test file by an errant text editor
+        self.assertEqual(open(test_csv_file).read(3), utf8_bom)
+
+        with open(test_csv_file) as csv_data:
+            test_dataset_description, test_classes = ws_datasets._parse_dataset_csv(csv_data)
+
+            expected_classes = [{"name": u"róck music",
+                                 "description": "",
+                                 "recordings": [u"bé686320-8057-4ca2-b484-e01434a3a2b1"]}]
+            self.assertEqual(test_dataset_description, u"a datasét")
+            self.assertEqual(test_classes, expected_classes)
+
     def test_dataset_to_csv(self):
         """Test that a dataset dictionary is converted to an expected CSV file"""
 

--- a/webserver/views/test_data/test_dataset_utf8.csv
+++ b/webserver/views/test_data/test_dataset_utf8.csv
@@ -1,0 +1,2 @@
+﻿bé686320-8057-4ca2-b484-e01434a3a2b1,róck music
+description,a datasét


### PR DESCRIPTION
https://tickets.metabrainz.org/browse/AB-420

There were 2 issues here
 * Unicode text in the mbid field of an uploaded dataset failed to parse
 * Unicode text in the message of an exception failed to render because we used `str(exp)`

I've changed some of the instances where we rendered exceptions to use six and ensure that this message is always unicode text. I didn't change all cases of str(exp) because many of these exceptions use string constants in the server codebase, and all examples that I could find use only ascii text. What's more, I think that these problems will go away when we move to python 3, so I don't think we need to spend time on changing these if they're not causing problems.