### PR TITLE
AB-439: Use concurrent.futures to manage threading in hl extractor

### DIFF
--- a/db/data.py
+++ b/db/data.py
@@ -651,12 +651,20 @@ def get_unprocessed_highlevel_documents_for_model(highlevel_model, within=None):
 
 
 def get_unprocessed_highlevel_documents(limit=100):
-    """Fetch up to 100 low-level documents which have no associated high level data."""
+    """Fetch up to 100 low-level documents which have no associated high level data.
+
+    Arguments:
+        limit: Retrieve up to this many low-level documents
+
+    Returns:
+        a list of tuples (rowid, mbid, lowlevel-json as text)
+
+    """
     with db.engine.connect() as connection:
         query = text(
-            """SELECT ll.gid::text
+            """SELECT ll.id
+                , ll.gid::text
                 , llj.data::text
-                , ll.id
              FROM lowlevel AS ll
              JOIN lowlevel_json AS llj
                ON llj.id = ll.id

--- a/db/data.py
+++ b/db/data.py
@@ -650,11 +650,12 @@ def get_unprocessed_highlevel_documents_for_model(highlevel_model, within=None):
         return docs
 
 
-def get_unprocessed_highlevel_documents(limit=100):
+def get_unprocessed_highlevel_documents(limit=100, id_from=0):
     """Fetch up to 100 low-level documents which have no associated high level data.
 
     Arguments:
         limit: Retrieve up to this many low-level documents
+        id_from: Select only low-level documents whose id is greater than this value
 
     Returns:
         a list of tuples (rowid, mbid, lowlevel-json as text)
@@ -663,17 +664,22 @@ def get_unprocessed_highlevel_documents(limit=100):
     with db.engine.connect() as connection:
         query = text(
             """SELECT ll.id
-                , ll.gid::text
-                , llj.data::text
-             FROM lowlevel AS ll
-             JOIN lowlevel_json AS llj
-               ON llj.id = ll.id
-        LEFT JOIN highlevel AS hl
-               ON ll.id = hl.id
-            WHERE hl.mbid IS NULL
-         ORDER BY ll.id
-            LIMIT :limit""")
-        result = connection.execute(query, {"limit": limit})
+                    , ll.gid::text
+                    , llj.data::text
+                 FROM lowlevel AS ll
+                 JOIN lowlevel_json AS llj
+                   ON llj.id = ll.id
+                WHERE ll.id IN (
+                        SELECT ll.id
+                          FROM lowlevel AS ll
+                     LEFT JOIN highlevel AS hl
+                            ON ll.id = hl.id
+                         WHERE hl.mbid IS NULL
+                           AND ll.id > :id_from
+                      ORDER BY ll.id
+                         LIMIT :limit
+                )""")
+        result = connection.execute(query, {"id_from": id_from, "limit": limit})
         docs = result.fetchall()
         return docs
 

--- a/db/data.py
+++ b/db/data.py
@@ -650,7 +650,7 @@ def get_unprocessed_highlevel_documents_for_model(highlevel_model, within=None):
         return docs
 
 
-def get_unprocessed_highlevel_documents():
+def get_unprocessed_highlevel_documents(limit=100):
     """Fetch up to 100 low-level documents which have no associated high level data."""
     with db.engine.connect() as connection:
         query = text(
@@ -663,8 +663,9 @@ def get_unprocessed_highlevel_documents():
         LEFT JOIN highlevel AS hl
                ON ll.id = hl.id
             WHERE hl.mbid IS NULL
-            LIMIT 100""")
-        result = connection.execute(query)
+         ORDER BY ll.id
+            LIMIT :limit""")
+        result = connection.execute(query, {"limit": limit})
         docs = result.fetchall()
         return docs
 

--- a/hl_extractor/hl_calc.py
+++ b/hl_extractor/hl_calc.py
@@ -197,10 +197,11 @@ def main(num_threads=DEFAULT_NUM_THREADS):
         sys.exit(-1)
 
     num_processed = 0
+    max_ll_id = 0
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
         while True:
-            docs = db.data.get_unprocessed_highlevel_documents(DOCUMENTS_PER_QUERY)
+            docs = db.data.get_unprocessed_highlevel_documents(DOCUMENTS_PER_QUERY, max_ll_id)
             current_app.logger.info("Got {} documents".format(len(docs)))
 
             futures = []
@@ -217,6 +218,8 @@ def main(num_threads=DEFAULT_NUM_THREADS):
                     current_app.logger.error(u"Unknown error when calling extractor: {}".format(e))
                 else:
                     num_processed += len(hl_data_list)
+                    this_max_ll_id = max([rowid for rowid, _, _ in hl_data_list])
+                    max_ll_id = max(max_ll_id, this_max_ll_id)
                     save_hl_documents(hl_data_list, build_sha1)
 
             # If we got less than the number of documents we asked for then we should wait

--- a/hl_extractor/hl_calc.py
+++ b/hl_extractor/hl_calc.py
@@ -11,7 +11,6 @@ import time
 import traceback
 
 import concurrent.futures
-import six
 import yaml
 from flask import current_app
 
@@ -52,7 +51,7 @@ def process_lowlevel_data(data, logger_name=None):
     """Process a set of lowlevel submissions with the highlevel binary.
 
     Arguments:
-        data: list of up to ``MAX_ITEMS_PER_PROCeSS` (rowid, mbid, ll_data) tuples containing
+        data: list of up to ``MAX_ITEMS_PER_PROCESS`` (rowid, mbid, ll_data) tuples containing
          the lowlevel id of a submission, its MBID, and the actual data of the submission
 
     Returns:
@@ -75,9 +74,9 @@ def process_lowlevel_data(data, logger_name=None):
     if logger_name:
         logger = logging.getLogger(logger_name)
 
-    mbids = ", ".join([mbid for _, mbid, _ in data])
+    llids = ", ".join([str(llid) for llid, _, _ in data])
     if logger:
-        logger.info("Starting {}".format(mbids))
+        logger.info("Starting {}".format(llids))
 
     try:
         working_dir = tempfile.mkdtemp(prefix="hlcalc")
@@ -126,7 +125,7 @@ def process_lowlevel_data(data, logger_name=None):
         shutil.rmtree(working_dir, ignore_errors=True)
 
     if logger:
-        logger.info("Finished {}".format(mbids))
+        logger.info("Finished {}".format(llids))
     return results
 
 

--- a/hl_extractor/test/test_data/known_file
+++ b/hl_extractor/test/test_data/known_file
@@ -1,0 +1,1 @@
+We know the contents of this file, and therefore know its sha1 for testing the get_build_sha1 method

--- a/hl_extractor/test/test_hl_calc.py
+++ b/hl_extractor/test/test_hl_calc.py
@@ -1,0 +1,145 @@
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import mock
+import yaml
+
+from hl_extractor import hl_calc
+
+
+class HlCalcTest(unittest.TestCase):
+    maxDiff = None
+
+    def test_process_lowlevel_data_no_items(self):
+        # Pass in an empty list of lowlevel items
+        with self.assertRaises(ValueError):
+            hl_calc.process_lowlevel_data([], None)
+
+    def test_process_lowlevel_data_too_many(self):
+        # Pass in too many lowlevel items to be processed
+        old_max_items = hl_calc.MAX_ITEMS_PER_PROCESS
+        hl_calc.MAX_ITEMS_PER_PROCESS = 1
+        with self.assertRaises(ValueError):
+            hl_calc.process_lowlevel_data([(1, 'mbid', '{data}'), (2, 'mbid', '{data2}')], None)
+        hl_calc.MAX_ITEMS_PER_PROCESS = old_max_items
+
+    @mock.patch("__builtin__.open", new_callable=mock.mock_open, read_data='{"data": 1}')
+    @mock.patch("tempfile.mkdtemp")
+    @mock.patch("subprocess.check_call")
+    @mock.patch("shutil.rmtree")
+    def test_process_lowlevel_data_readwrite_failure(self, mock_rmtree, mock_check_call, mock_mkdtemp, mock_open):
+        # Some lowlevel files fail to write lowlevel to or read highleve from the temp directory
+        mock_mkdtemp.return_value = "/tmp/hl"
+        mock_open.side_effect = (IOError,  # write lowlevel 1
+                                 IOError)  # write lowlevel 2
+
+        with self.assertRaises(hl_calc.HighLevelExtractorError) as e:
+            hl_calc.process_lowlevel_data([(1, 'mbid1', '{data}'), (2, 'mbid2', '{data2}')], None)
+        self.assertEqual(str(e), "Unable to write any lowlevel files to temporary directory")
+
+    @mock.patch("__builtin__.open", new_callable=mock.mock_open, read_data='{"data": 1}')
+    @mock.patch("tempfile.mkdtemp")
+    @mock.patch("subprocess.check_call")
+    @mock.patch("shutil.rmtree")
+    def test_process_lowlevel_data_readwrite_failure(self, mock_rmtree, mock_check_call, mock_mkdtemp, mock_open):
+        # Some lowlevel files fail to write lowlevel to or read highleve from the temp directory
+        mock_mkdtemp.return_value = "/tmp/hl"
+        mock_open.side_effect = (mock_open.return_value,  # write lowlevel 1
+                                 IOError,  # write lowlevel 2
+                                 mock_open(os.devnull, 'w'),  # /dev/null for check_call
+                                 mock_open.return_value,  # read highlevel 1
+                                 IOError)  # read highlevel 2
+
+        results = hl_calc.process_lowlevel_data([(1, 'mbid1', '{data}'), (2, 'mbid2', '{data2}')], None)
+
+        assert len(results) == 2
+        assert results[0] == (1, 'mbid1', {"data": 1})
+        assert results[1] == (2, 'mbid2', {})
+
+        # Even though 2 items were returned, the highlevel extractor was only called with 1 file because the second
+        # file failed to be written
+        mock_check_call.assert_called_with(
+            ['/usr/local/bin/essentia_streaming_extractor_music_svm', '/tmp/hl/1-input.json', '/tmp/hl/1-output.json',
+             '/code/hl_extractor/profile.conf'], stderr=mock.ANY, stdout=mock.ANY)
+
+    @mock.patch("__builtin__.open", new_callable=mock.mock_open, read_data="{}")
+    @mock.patch("tempfile.mkdtemp")
+    @mock.patch("subprocess.check_call")
+    @mock.patch("shutil.rmtree")
+    def test_process_lowlevel_data_exec_failure(self, mock_rmtree, mock_check_call, mock_mkdtemp, mock_open):
+        # The binary fails to execute
+        mock_mkdtemp.return_value = "/tmp/hl"
+        mock_check_call.side_effect = subprocess.CalledProcessError(1, 'hl_extractor')
+
+        with self.assertRaises(hl_calc.HighLevelExtractorError):
+            hl_calc.process_lowlevel_data([(1, 'mbid', '{data}')], None)
+
+    @mock.patch("__builtin__.open", new_callable=mock.mock_open, read_data="{}")
+    @mock.patch("tempfile.mkdtemp")
+    @mock.patch("subprocess.check_call")
+    @mock.patch("shutil.rmtree")
+    def test_process_lowlevel_data_success(self, mock_rmtree, mock_check_call, mock_mkdtemp, mock_open):
+        mock_mkdtemp.return_value = "/tmp/hl"
+
+        hl_calc.process_lowlevel_data([(1, 'mbid', '{data}'), (2, 'mbid', '{data2}')], None)
+
+        mock_open.assert_has_calls([mock.call('/tmp/hl/1-input.json', 'w'),
+                                    mock.call('/tmp/hl/2-input.json', 'w'),
+                                    mock.call('/tmp/hl/1-output.json', 'r'),
+                                    mock.call('/tmp/hl/2-output.json', 'r')], any_order=True)
+
+        mock_check_call.assert_called_with(
+            ['/usr/local/bin/essentia_streaming_extractor_music_svm', '/tmp/hl/1-input.json', '/tmp/hl/1-output.json',
+             '/tmp/hl/2-input.json', '/tmp/hl/2-output.json', '/code/hl_extractor/profile.conf'], stderr=mock.ANY,
+            stdout=mock.ANY)
+        mock_rmtree.assert_called_with("/tmp/hl", ignore_errors=True)
+
+    def test_create_profile(self):
+        # TODO: Use `with tempfile.TemporaryDirectory` in Python 3
+        dirname = tempfile.mkdtemp()
+        inputname = os.path.join(dirname, "input.yaml")
+        outputname = os.path.join(dirname, "output.yaml")
+        source = """
+indent: 0
+highlevel:
+   compute: 1.
+   svm_models: [/data/svm_models/danceability.history,
+                /data/svm_models/gender.history
+               ]
+mergeValues:
+    metadata:
+        version:
+            highlevel:
+                essentia_build_sha:
+                models_essentia_git_sha: v2.1
+        """.strip()
+        with open(inputname, "w") as fp:
+            fp.write(source)
+        hl_calc.create_profile(inputname, outputname, 'this_value_to_interpolate')
+
+        expected = {'indent': 0, 'mergeValues': {
+                                     'metadata': {'version': {
+                                                  'highlevel': {'essentia_build_sha': 'this_value_to_interpolate',
+                                                                'models_essentia_git_sha': 'v2.1'}}}},
+                    'highlevel': {
+                        'svm_models': ['/data/svm_models/danceability.history', '/data/svm_models/gender.history'],
+                        'compute': 1.0}}
+
+        with open(outputname, "r") as fp:
+            conf = yaml.safe_load(fp)
+            self.assertEqual(conf, expected)
+
+        shutil.rmtree(dirname)
+
+    def test_get_build_sha1(self):
+        data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "test_data")
+        data_file = os.path.join(data_dir, "known_file")
+        result_sha1 = hl_calc.get_build_sha1(data_file)
+        self.assertEqual(result_sha1, "018507c3c54e655320feee0a87e7b56447a45258")
+
+        with self.assertRaises(hl_calc.HighLevelConfigurationError):
+            data_file = os.path.join(data_dir, "unknown_file")
+            hl_calc.get_build_sha1(data_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Login==0.5.0
 Flask-SQLAlchemy==2.4.1
 Flask-Testing==0.8.0
 Flask-WTF == 0.14.3
+futures==3.3.0
 mock==3.0.5
 musicbrainzngs==0.7.1
 ndg-httpsclient==0.5.1


### PR DESCRIPTION
https://tickets.metabrainz.org/projects/AB/issues/AB-439
https://tickets.metabrainz.org/projects/AB/issues/AB-440

This is the first part of AB-439 and AB-440. I'm going to split it up into a few different PRs to make it easier to follow the evolution of the changes.

This specific change moves from manual thread pool management to using [concurrent.futures](https://docs.python.org/3/library/concurrent.futures.html). For now we use a python2 backport. This won't be needed in python 3. This makes the queue submission code much simpler and easier to extend.

There's one difference to the way we load the thread pool in this new version. We load all document to the pool, but when it starts to run out we don't fill it up again. e.g. if we have 10 threads, and we've processed 90 and are on the last 10 documents, and some threads finish processing. In this case, we'll have some threads lying around. I didn't improve this case because it will add additional complexity to the code, and we know that each thread takes about the same time to run (and only a few seconds at that), so we assume that in most cases the threads will all finish at about the same time.

This also addresses the second point listed at AB-440. If we ask for 100 unprocessed items but only get 15, it means that there aren't many pending items. We should sleep for 30s after this to not continually query the database for items to process.

I've tested this myself, and the results seem to be correct (the hl data for the associated ll data is correctly written to the db), but @paramsingh I'd appreciate you looking over the changes and seeing if you can find anything that looks wrong.