### PR TITLE
AB-448: Only validate filter_type if FEATURE_EVAL_FILTERING is True

### DIFF
--- a/webserver/forms.py
+++ b/webserver/forms.py
@@ -1,3 +1,4 @@
+from flask import current_app
 from wtforms import BooleanField, SelectField, StringField, TextAreaField, \
     SelectMultipleField, widgets, ValidationError
 from wtforms.validators import DataRequired
@@ -47,13 +48,13 @@ class DatasetEvaluationForm(FlaskForm):
     filter_type = SelectField("Filtering", choices=[
         (DATASET_EVAL_NO_FILTER, "Don't filter"),
         (dataset_eval.FILTER_ARTIST, "By Artist"),
-    ])
+    ], validate_choice=False)
     normalize = BooleanField("Normalize classes")
     evaluation_location = SelectField("Evaluation location", choices=[
         (DATASET_EVAL_LOCAL, "Evaluate on acousticbrainz.org"),
         (DATASET_EVAL_REMOTE, "Evaluate on your own machine")],
-                                      default=DATASET_EVAL_LOCAL
-                                      )
+                                      default=DATASET_EVAL_LOCAL,
+                                      validate_choice=False)
 
     svm_filtering = BooleanField("Use advanced SVM options",
                                  render_kw={"data-toggle": "collapse",
@@ -70,6 +71,11 @@ class DatasetEvaluationForm(FlaskForm):
     preprocessing_values = MultiCheckboxField('Preprocessing Values', choices=PREPROCESSING_VALUES,
                                               default=[p for p, _ in PREPROCESSING_VALUES],
                                               render_kw={"class": "list-unstyled"})
+
+    def validate_filter_type(self, field):
+        if current_app.config['FEATURE_EVAL_FILTERING']:
+            field.validate_choice = True
+            field.pre_validate(self)
 
     def validate_preprocessing_values(self, field):
         # If we don't have SVM options enabled, don't validate the field


### PR DESCRIPTION
AB-448

If the feature flag is disabled, the HTML form doesn't include this field, so we have to ignore the pre_validate() method, which checks if the value is one of the valid choices (as there is no value submitted with the form, it's invalid).
Explicitly perform this check if the feature flag is enabled.