### PR TITLE
Pin package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,9 @@ RUN useradd --create-home --shell /bin/bash --uid 901 --gid 901 acousticbrainz
 
 RUN chown acousticbrainz:acousticbrainz /code
 
+# Last version of pip that supports python2
+RUN pip install pip==20.3.4
+
 # Python dependencies
 RUN mkdir /code/docs/ && chown acousticbrainz:acousticbrainz /code/docs/
 COPY --chown=acousticbrainz:acousticbrainz docs/requirements.txt /code/docs/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,17 @@ pyyaml==5.3.1
 rauth == 0.7.3
 setproctitle == 1.1.10
 six==1.14.0
+Flask==1.1.2
+Jinja2==2.11.2
+werkzeug==1.0.1
+Flask-DebugToolbar==0.11.0
+Flask-UUID==0.2
+raven[flask]==6.10.0
+certifi
+redis==3.4.1
+msgpack-python==0.5.6
+requests==2.23.0
+SQLAlchemy==1.3.16
+mbdata==25.0.4
+sqlalchemy-dst==1.0.1
 -r docs/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/metabrainz/brainzutils-python.git@v1.15.0
+git+https://github.com/metabrainz/brainzutils-python.git@v1.16.1
 Flask-Admin==1.5.6
 Flask-Login==0.5.0
 Flask-SQLAlchemy==2.4.1


### PR DESCRIPTION
Once metabrainz/brainzutils-python#45 is merged, BU will use open ended versions. To make sure we use desired versions, pin the versions in downstream projects.

The BU PR must be merged before this PR and the requirements.txt must be updated to use the new release of BU. The same is applicable for the dataset hoster.