### PR TITLE
AB-407: Redirect legacy API endpoints to new endpoint with http redirect

### DIFF
--- a/webserver/views/api/legacy.py
+++ b/webserver/views/api/legacy.py
@@ -19,7 +19,7 @@ def count(mbid):
     """
     This API is redirected to the /api/v1/core view with a HTTP 301 redirect
     """
-    return(redirect(url_for('api_v1_core.count', mbid=mbid),code=301))
+    return(redirect(url_for('api_v1_core.count', mbid=mbid), code=301))
 
 
 @api_legacy_bp.route("/<string:mbid>/low-level", methods=["GET"])
@@ -29,7 +29,7 @@ def get_low_level(mbid):
     """Endpoint for fetching low-level data.
     If there is more than one document with the same mbid, you can specify
     an offset as a query parameter in the form of ?n=x, where x is an integer
-    starting from 0          
+    starting from 0
     This API is redirected to the /api/v1/core view with a HTTP 301 redirect
     """
     return(redirect(url_for('api_v1_core.get_low_level', mbid=mbid), code=301))
@@ -43,7 +43,7 @@ def get_high_level(mbid):
     """Endpoint for fetching high-level data.
     If there is more than one document with the same mbid, you can specify
     an offset as a query parameter in the form of ?n=x, where x is an integer
-    starting from 0       
+    starting from 0
     This API is redirected to the /api/v1/core view with a HTTP 301 redirect
     """
     return(redirect(url_for('api_v1_core.get_high_level', mbid=mbid), code=301))

--- a/webserver/views/api/legacy.py
+++ b/webserver/views/api/legacy.py
@@ -16,11 +16,10 @@ api_legacy_bp = Blueprint('api', __name__)
 @crossdomain()
 @ratelimit()
 def count(mbid):
-    mbid, offset = _validate_data_arguments(str(mbid), None)
-    return jsonify({
-        'mbid': mbid,
-        'count': count_lowlevel(mbid),
-    })
+    """
+    This API is redirected to the /api/v1/core view with a HTTP 301 redirect
+    """
+    return(redirect(url_for('api_v1_core.count', mbid=mbid),code=301))
 
 
 @api_legacy_bp.route("/<string:mbid>/low-level", methods=["GET"])
@@ -31,12 +30,11 @@ def get_low_level(mbid):
     If there is more than one document with the same mbid, you can specify
     an offset as a query parameter in the form of ?n=x, where x is an integer
     starting from 0
+            
+    This API is redirected to the /api/v1/core view with a HTTP 301 redirect
     """
-    mbid, offset = _validate_data_arguments(mbid, request.args.get("n"))
-    try:
-        return jsonify(db.data.load_low_level(mbid, offset))
-    except NoDataFoundException:
-        raise exceptions.APINotFound("Not found")
+    return(redirect(url_for('api_v1_core.get_low_level', mbid=mbid),code=301))
+
 
 
 @api_legacy_bp.route("/<string:mbid>/high-level", methods=["GET"])
@@ -47,12 +45,10 @@ def get_high_level(mbid):
     If there is more than one document with the same mbid, you can specify
     an offset as a query parameter in the form of ?n=x, where x is an integer
     starting from 0
+        
+    This API is redirected to the /api/v1/core view with a HTTP 301 redirect
     """
-    mbid, offset = _validate_data_arguments(mbid, request.args.get("n"))
-    try:
-        return jsonify(db.data.load_high_level(mbid, offset))
-    except NoDataFoundException:
-        raise exceptions.APINotFound("Not found")
+    return(redirect(url_for('api_v1_core.get_high_level', mbid=mbid),code=301))
 
 
 @api_legacy_bp.route("/<uuid:mbid>/low-level", methods=["POST"])

--- a/webserver/views/api/legacy.py
+++ b/webserver/views/api/legacy.py
@@ -29,11 +29,10 @@ def get_low_level(mbid):
     """Endpoint for fetching low-level data.
     If there is more than one document with the same mbid, you can specify
     an offset as a query parameter in the form of ?n=x, where x is an integer
-    starting from 0
-            
+    starting from 0          
     This API is redirected to the /api/v1/core view with a HTTP 301 redirect
     """
-    return(redirect(url_for('api_v1_core.get_low_level', mbid=mbid),code=301))
+    return(redirect(url_for('api_v1_core.get_low_level', mbid=mbid), code=301))
 
 
 
@@ -44,11 +43,10 @@ def get_high_level(mbid):
     """Endpoint for fetching high-level data.
     If there is more than one document with the same mbid, you can specify
     an offset as a query parameter in the form of ?n=x, where x is an integer
-    starting from 0
-        
+    starting from 0       
     This API is redirected to the /api/v1/core view with a HTTP 301 redirect
     """
-    return(redirect(url_for('api_v1_core.get_high_level', mbid=mbid),code=301))
+    return(redirect(url_for('api_v1_core.get_high_level', mbid=mbid), code=301))
 
 
 @api_legacy_bp.route("/<uuid:mbid>/low-level", methods=["POST"])


### PR DESCRIPTION
Redirecting legacy GET API views to the /api/v1 views with HTTP 301.