### PR TITLE
Specify number of threads to use when building annoy index

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -58,6 +58,8 @@ RATELIMIT_WINDOW = 10
 DATASET_DIR = "/data/datasets"
 FILE_STORAGE_DIR = "/data/files"
 SIMILARITY_INDEX_DIR = "/data/annoy_indices"
+# How many threads to use when building an annoy index
+SIMILARITY_BUILD_NUM_JOBS = 1
 
 #Feature Flags
 # Choose a server to perform the evaluation on

--- a/consul_config.py.ctmpl
+++ b/consul_config.py.ctmpl
@@ -48,7 +48,9 @@ LOG_SENTRY = {
 
 DATASET_DIR = '''{{template "KEY" "dataset_dir"}}'''
 FILE_STORAGE_DIR = '''{{template "KEY" "file_storage_dir"}}'''
-SIMILARITY_INDEX_DIR = '''{{template "KEY" "similarity_index_dir"}}'''
+SIMILARITY_INDEX_DIR = '''{{template "KEY" "similarity/index_dir"}}'''
+# How many threads to use when building an annoy index
+SIMILARITY_BUILD_NUM_JOBS = {{template "KEY" "similarity/build_n_jobs"}}
 
 #Feature Flags
 # Choose a server to perform the evaluation on

--- a/similarity/index_model.py
+++ b/similarity/index_model.py
@@ -54,7 +54,8 @@ class AnnoyModel(object):
     def build(self):
         """Build and load the index using the specified number of trees. An index
         must be built before it can be queried."""
-        self.index.build(self.n_trees)
+        n_jobs = current_app.config['SIMILARITY_BUILD_NUM_JOBS']
+        self.index.build(n_trees=self.n_trees, n_jobs=n_jobs)
         self.in_loaded_state = True
 
     def save(self, location=None, name=None):


### PR DESCRIPTION
Annoy 1.17 can build indexes using multiple threads, so this should speed up build time.