### PR TITLE
Skip a recording_ids bulk param if there is an empty mbid

### DIFF
--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -221,9 +221,11 @@ def _parse_bulk_params(params):
     Where offset is a number >=0. Offsets are optional.
     mbid must be a UUID.
 
-    If an offset is not specified non-numeric, or negative it is replaced with 0.
+    If an offset is not specified, is non-numeric, or negative it is replaced with 0.
     If an mbid is not valid, an APIBadRequest Exception is
     raised listing the bad MBID and no further processing is done.
+    If an mbid is missing (e.g. a parameter string of ';;') then the empty mbid is silently skipped,
+    even if an offset is provided.
 
     The mbid is normalised to all lower-case, with hyphens between sections.
 
@@ -237,6 +239,8 @@ def _parse_bulk_params(params):
     for recording in params.split(";"):
         parts = str(recording).split(":")
         mbid = parts[0]
+        if not mbid:
+            continue
         if len(parts) == 1:
             offset = None
         elif len(parts) == 2:

--- a/webserver/views/api/v1/test/test_core.py
+++ b/webserver/views/api/v1/test/test_core.py
@@ -607,3 +607,11 @@ class GetBulkValidationTest(unittest.TestCase):
         expected = [("C5F4909E-1D7B-4F15-A6F6-1AF376BC01C9", "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0),
                     ("7F27D7A927F046639D202C9C40200E6D", "7f27d7a9-27f0-4663-9d20-2c9c40200e6d", 0)]
         self.assertEqual(expected, validated)
+
+    def test_validate_bulk_params_emptyvalue(self):
+        # If there is an extra ; in the string, causing an empty mbid, skip it
+        params = "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9;;:x"
+        validated = core._parse_bulk_params(params)
+
+        expected = [("c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", "c5f4909e-1d7b-4f15-a6f6-1af376bc01c9", 0)]
+        self.assertEqual(expected, validated)


### PR DESCRIPTION
An extra ; in the query parameter would cause us to try and validate `''` as a valid UUID, which would fail. Silently skip these cases