### PR TITLE
Gracefully handle errors due to invalid oauth codes

### DIFF
--- a/webserver/views/login.py
+++ b/webserver/views/login.py
@@ -25,10 +25,14 @@ def musicbrainz():
 def musicbrainz_post():
     """Callback endpoint."""
     if provider.validate_post_login():
-        login_user(provider.get_user())
-        next = session.get('next')
-        if next:
-            return redirect(next)
+        user = provider.get_user()
+        if user:
+            login_user(user)
+            next = session.get('next')
+            if next:
+                return redirect(next)
+        else:
+            flash.error("Login failed.")
     else:
         flash.error("Login failed.")
     return redirect(url_for('index.index'))


### PR DESCRIPTION
Identified in https://sentry.metabrainz.org/metabrainz/listenbrainz/issues/145812/?environment=production&referrer=alert_email

Although it doesn't happen in a normal successful oauth flow, there are some cases where a manually constructed URL could cause an uncaught exception. Handle the situation where:
 * the auth code isn't valid on the musicbrainz end, therefore returning an error message
 * the response from musicbrainz isn't valid json