### PR TITLE
Don't accept submissions if too many duplicates are received

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -53,6 +53,11 @@ RATELIMIT_WINDOW = 10
 #    'level': 'ERROR',
 # }
 
+# Data rejection settings
+# If we receive more than this number of submissions for a single MBID, don't
+# accept any more. Set to None to disable.
+MAX_NUMBER_DUPLICATE_SUBMISSIONS = 10
+
 # MISCELLANEOUS
 
 DATASET_DIR = "/data/datasets"

--- a/webserver/views/api/legacy.py
+++ b/webserver/views/api/legacy.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, current_app
 from brainzutils.ratelimit import ratelimit
 from db.data import count_lowlevel, submit_low_level_data
 from db.exceptions import NoDataFoundException, BadDataException
@@ -64,8 +64,10 @@ def submit_low_level(mbid):
     except ValueError as e:
         raise exceptions.APIBadRequest("Cannot parse JSON document: %s" % e)
 
+    max_duplicate_submissions = current_app.config.get('MAX_NUMBER_DUPLICATE_SUBMISSIONS', None)
+
     try:
-        submit_low_level_data(mbid, data, 'mbid')
+        submit_low_level_data(mbid, data, 'mbid', max_duplicate_submissions)
     except BadDataException as e:
         raise exceptions.APIBadRequest("%s" % e)
     return jsonify({"message": "ok"})

--- a/webserver/views/api/v1/core.py
+++ b/webserver/views/api/v1/core.py
@@ -3,10 +3,9 @@ from __future__ import absolute_import
 import json
 import uuid
 
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, current_app
 
 import db.data
-from webserver.utils import validate_offset
 import webserver.views.api.exceptions
 from db.data import submit_low_level_data, count_lowlevel
 from db.exceptions import NoDataFoundException, BadDataException
@@ -151,8 +150,10 @@ def submit_low_level(mbid):
     except ValueError as e:
         raise webserver.views.api.exceptions.APIBadRequest("Cannot parse JSON document: %s" % e)
 
+    max_duplicate_submissions = current_app.config.get('MAX_NUMBER_DUPLICATE_SUBMISSIONS', None)
+
     try:
-        submit_low_level_data(str(mbid), data, 'mbid')
+        submit_low_level_data(str(mbid), data, 'mbid', max_duplicate_submissions)
     except BadDataException as e:
         raise webserver.views.api.exceptions.APIBadRequest("%s" % e)
     return jsonify({"message": "ok"})


### PR DESCRIPTION
We allow duplicate submissions, but over a certain number it doesn't really make sense to keep them.
This is also causing us to quickly run out of disk space.

After 10 submissions of the same MBID, stop accepting submissions