### PR TITLE
Remove similarity feedback and don't require auth to show similarity

### DIFF
--- a/webserver/static/scripts/similarity/eval-recording.tsx
+++ b/webserver/static/scripts/similarity/eval-recording.tsx
@@ -5,8 +5,6 @@ interface EvalRecordingProps {
     rec: any;
     hideForm: any;
     handleChange: any;
-    // handleYoutubeChange: any;
-    // similarYoutubeQuery: any;
 }
 
 function EvalRecording(props: EvalRecordingProps) {

--- a/webserver/static/scripts/similarity/eval.tsx
+++ b/webserver/static/scripts/similarity/eval.tsx
@@ -1,8 +1,6 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 
-const EvalRecording = require("./eval-recording.tsx");
-
 const CONTAINER_ELEMENT_ID = "similarity-eval";
 const container = document.getElementById(CONTAINER_ELEMENT_ID);
 
@@ -11,224 +9,113 @@ interface SimilarityEvalProps {}
 interface SimilarityEvalState {
     refMbid: any;
     refOffset: any;
-    formData: any;
-    similarYoutubeQuery: string;
     metric: string;
     metricDescription?: string;
-    metricCategory?: string;
-    hideForm: boolean;
-    similarMetadata: any;
-    errorMsg: any;
+    similarMetadata?: any;
+    noSimilarityData: boolean;
 }
 
 class SimilarityEval extends Component<
     SimilarityEvalProps,
     SimilarityEvalState
 > {
-    private _isMounted: boolean;
-    private _metadataLoaded: boolean;
-    private readonly _initFormData: any;
-
     constructor(props: Readonly<SimilarityEvalProps>) {
         super(props);
-        this._isMounted = false;
-        this._metadataLoaded = false;
-        this._initFormData = {};
         this.state = {
             refMbid: container!.dataset.refMbid,
             refOffset: container!.dataset.refOffset,
             metric: container!.dataset.metric!,
             metricDescription: undefined,
-            metricCategory: undefined,
-            hideForm: false,
             similarMetadata: null,
-            errorMsg: null,
-            formData: {},
-            similarYoutubeQuery: "",
+            noSimilarityData: false,
         };
     }
 
     componentDidMount = () => {
-        this._isMounted = true;
-        $.get(
-            `/similarity/service/similar/${this.state.metric}/${this.state.refMbid}?n=${this.state.refOffset}`,
-            (result: any) => {
-                if (this._isMounted) {
-                    result.metadata.forEach((rec: any) => {
-                        this._initFormData[rec.lowlevel_id] = {
-                            feedback: "",
-                            suggestion: "",
-                        };
-                    });
-                    this.setState({
-                        similarMetadata: result.metadata,
-                        similarYoutubeQuery: result.metadata[0].youtube_query,
-                        metricDescription: result.metric.description,
-                        metricCategory: result.metric.category,
-                        formData: this._initFormData,
-                        hideForm: result.submitted,
-                    });
-                }
-            }
-        );
-        this._metadataLoaded = true;
-    };
-
-    componentWillUnmount() {
-        this._isMounted = false;
-    }
-
-    handleChange = (event: any) => {
-        this.setState((state) => {
-            const formData = { ...state.formData };
-            const item = {
-                ...formData[event.currentTarget.getAttribute("data-lowlevel")],
-            };
-            item[event.target.name] = event.target.value;
-            formData[event.currentTarget.getAttribute("data-lowlevel")] = item;
-            return { formData };
-        });
-    };
-
-    handleYoutubeChange = (query: string) => {
-        this.setState({
-            similarYoutubeQuery: query,
-        });
-    };
-
-    handleSubmit = (event: any) => {
-        event.preventDefault();
-        this.setState({
-            errorMsg: null,
-        });
-        if (
-            JSON.stringify(this.state.formData) !==
-            JSON.stringify(this._initFormData)
-        ) {
-            const so = this;
-            $.ajax({
-                method: "POST",
-                url: `/similarity/service/evaluate/${this.state.metric}/${this.state.refMbid}?n=${this.state.refOffset}`,
-                data: JSON.stringify({
-                    form: this.state.formData,
-                    metadata: this.state.similarMetadata,
-                }),
-                contentType: "application/json",
-                success() {
-                    so.setState({ hideForm: true });
-                    console.log("success");
-                },
-                error(error: any) {
-                    so.setState({
-                        errorMsg: error.responseJSON,
-                    });
-                    console.log(error);
-                    console.error("Failed to submit feedback.");
-                },
+        fetch(
+            `/similarity/service/similar/${this.state.metric}/${this.state.refMbid}?n=${this.state.refOffset}`
+        )
+            .then((response) => response.json())
+            .then((result: any) => {
+                this.setState({
+                    similarMetadata: result.metadata,
+                    metricDescription: result.metric.description,
+                });
+            })
+            .catch((error: any) => {
+                this.setState({
+                    noSimilarityData: true,
+                });
             });
-        } else {
-            this.setState({
-                errorMsg: {
-                    error: "A rating or suggestion must be given to at least one similar recording!",
-                },
-            });
-        }
     };
 
     render() {
-        if (this._metadataLoaded) {
-            const similarRecordings = this.state.similarMetadata.map(
-                (rec: any) => (
-                    <EvalRecording
-                        key={`${rec.recording_mid}-${rec.offset}`}
-                        rec={rec}
-                        form={this.state.formData}
-                        hideForm={this.state.hideForm}
-                        handleChange={this.handleChange}
-                        handleYoutubeChange={this.handleYoutubeChange}
-                        similarYoutubeQuery={this.state.similarYoutubeQuery}
-                    />
-                )
-            );
-            let error;
-            if (this.state.errorMsg) {
-                error = (
-                    <p className="text-danger">
-                        <strong>
-                            An error occurred while submitting the feedback:
-                        </strong>
-                        &nbsp;{this.state.errorMsg.error || "Unknown error"}
-                    </p>
-                );
-            } else {
-                error = "";
-            }
-            return (
-                <div className="row">
-                    <div className="col-md-8">
-                        <div>
-                            Back to{" "}
-                            <a
-                                href={`/similarity/${this.state.refMbid}?n=${this.state.refOffset}`}
-                            >
-                                metrics
-                            </a>{" "}
-                            /
-                            <a
-                                href={`/${this.state.refMbid}?n=${this.state.refOffset}`}
-                            >
-                                {" "}
-                                summary
-                            </a>
-                        </div>
-                        <h3>Most similar by {this.state.metricDescription}:</h3>
-                        <p
-                            className="feedback-request"
-                            hidden={this.state.hideForm}
+        return (
+            <div className="row">
+                <div className="col-md-8">
+                    <div>
+                        Back to{" "}
+                        <a
+                            href={`/similarity/${this.state.refMbid}?n=${this.state.refOffset}`}
                         >
-                            Please give us feedback - in terms of{" "}
-                            <strong>{this.state.metricCategory}</strong>, how
-                            similar are the result tracks to original one?
+                            metrics
+                        </a>{" "}
+                        /
+                        <a
+                            href={`/${this.state.refMbid}?n=${this.state.refOffset}`}
+                        >
+                            {" "}
+                            summary
+                        </a>
+                    </div>
+                    {this.state.noSimilarityData && (
+                        <p>
+                            We have no similarity data for this recording, sorry
                         </p>
-
-                        <form id="feedback-select" onSubmit={this.handleSubmit}>
+                    )}
+                    {this.state.similarMetadata && (
+                        <>
+                            <h3>
+                                Most similar by {this.state.metricDescription}:
+                            </h3>
                             <table className="table table-striped">
                                 <thead>
                                     <tr>
                                         <th>Recording</th>
-                                        <th
-                                            className="feedback-request"
-                                            hidden={this.state.hideForm}
-                                        >
-                                            Feedback
-                                        </th>
-                                        <th
-                                            className="feedback-request"
-                                            hidden={this.state.hideForm}
-                                        >
-                                            Suggestion
-                                        </th>
                                     </tr>
                                 </thead>
-                                <tbody>{similarRecordings}</tbody>
+                                <tbody>
+                                    {this.state.similarMetadata.map(
+                                        (rec: any) => {
+                                            return (
+                                                <tr
+                                                    key={`${rec.mbid}?n=${rec.submission_offset}`}
+                                                >
+                                                    <td>
+                                                        <a
+                                                            href={`/${rec.mbid}?n=${rec.submission_offset}`}
+                                                            target="_blank"
+                                                            rel="noreferrer"
+                                                        >
+                                                            {rec.artist} -{" "}
+                                                            {rec.title}
+                                                        </a>
+                                                    </td>
+                                                </tr>
+                                            );
+                                        }
+                                    )}
+                                </tbody>
                             </table>
-                            {error}
-                            {!this.state.hideForm ? (
-                                <button
-                                    className="btn btn-default btn-primary btn-feedback"
-                                    type="submit"
-                                >
-                                    Submit Feedback
-                                </button>
-                            ) : (
-                                <></>
-                            )}
-                        </form>
-                    </div>
+                        </>
+                    )}
+                    {!this.state.similarMetadata &&
+                        !this.state.noSimilarityData && (
+                            <strong>Loading...</strong>
+                        )}
                 </div>
-            );
-        }
-        return <strong>Loading...</strong>;
+            </div>
+        );
     }
 }
 

--- a/webserver/templates/similarity/eval.html
+++ b/webserver/templates/similarity/eval.html
@@ -11,7 +11,6 @@
     <div id="similarity-eval" 
          data-ref-mbid="{{ ref_metadata['mbid'] }}" 
          data-ref-offset="{{ ref_metadata['submission_offset'] }}"
-         data-ref-youtube-query="{{ ref_metadata['youtube_query'] }}" 
          data-metric="{{ metric }}">
     </div>
 {%- endblock -%}


### PR DESCRIPTION
Because we're not providing song playback or allowing feedback to similarity results at the moment, allow this page to be loaded even if you're not logged in.
Also fix some bugs with the display of data when similarity for a recording isn't available.