### PR TITLE
Dump cleanups

### DIFF
--- a/db/dump.py
+++ b/db/dump.py
@@ -473,11 +473,12 @@ def import_db_dump(archive_path, tables):
     logging.info('Done!')
 
 
-def dump_lowlevel_json(location, num_files_per_archive=float("inf")):
+def dump_lowlevel_json(location, threads=None, num_files_per_archive=float("inf")):
     """Create JSON dump with low level data.
 
     Args:
         location: Directory where archive will be created.
+        threads: Number of threads to use for zstd compression
         num_files_per_archive: The maximum number of recordings to dump in one file.
                    Infinite if not specified.
 
@@ -508,7 +509,11 @@ def dump_lowlevel_json(location, num_files_per_archive=float("inf")):
             filename = filename_pattern % file_num
             file_path = os.path.join(dump_path, "%s.tar.zstd" % filename)
             with open(file_path, "w") as archive:
-                zstd_command = ["zstd", "--compress", "-10", "-T8"]
+                # Manual testing shows that -10 compression level gives a good tradeoff between
+                # compression speed and final file size with AB data
+                zstd_command = ["zstd", "--compress", "-10"]
+                if threads:
+                    zstd_command.append("-T%s" % threads)
                 zstd = subprocess.Popen(zstd_command, stdin=subprocess.PIPE, stdout=archive)
 
                 # Creating the archive
@@ -574,11 +579,12 @@ def dump_lowlevel_json(location, num_files_per_archive=float("inf")):
     return dump_path
 
 
-def dump_highlevel_json(location, num_files_per_archive=float("inf")):
+def dump_highlevel_json(location, threads=None, num_files_per_archive=float("inf")):
     """Create JSON dump with high-level data.
 
     Args:
         location: Directory where archive will be created.
+        threads: Number of threads to use for zstd compression
         num_files_per_archive: The maximum number of recordings to dump in one file.
                    Infinite if not specified.
 
@@ -608,7 +614,11 @@ def dump_highlevel_json(location, num_files_per_archive=float("inf")):
             filename = filename_pattern % file_num
             file_path = os.path.join(dump_path, "%s.tar.zstd" % filename)
             with open(file_path, "w") as archive:
-                zstd_command = ["zstd", "--compress", "-10", "-T8"]
+                # Manual testing shows that -10 compression level gives a good tradeoff between
+                # compression speed and final file size with AB data
+                zstd_command = ["zstd", "--compress", "-10"]
+                if threads:
+                    zstd_command.append("-T%s" % threads)
                 zstd = subprocess.Popen(zstd_command, stdin=subprocess.PIPE, stdout=archive)
 
                 # Creating the archive

--- a/db/dump.py
+++ b/db/dump.py
@@ -567,15 +567,17 @@ def dump_lowlevel_json(location, full=False, dump_id=None, max_count=500000):
                             dump_tempfile = os.path.join(temp_dir, json_filename)
                             with open(dump_tempfile, "w") as f:
                                 f.write(json_data)
+                            # Use archive_dirname here (i.e. acousticbrainz-lowlevel-json-20220616) without a -n part suffix
+                            # so that uncompressing multiple parts of the same dump will go into the same place
                             tar.add(dump_tempfile, arcname=os.path.join(
-                                filename, "lowlevel", mbid[0:1], mbid[0:2], json_filename))
+                                archive_dirname, "lowlevel", mbid[0:2], mbid[2:3], json_filename))
                             os.unlink(dump_tempfile)
 
                             dumped_count += 1
 
                     # Copying legal text
                     tar.add(DUMP_LICENSE_FILE_PATH,
-                            arcname=os.path.join(filename, "COPYING"))
+                            arcname=os.path.join(archive_dirname, "COPYING"))
 
                     shutil.rmtree(temp_dir)  # Cleanup
 
@@ -720,13 +722,13 @@ def dump_highlevel_json(location, full=False, dump_id=None, max_count=500000):
                             with open(dump_tempfile, "w") as f:
                                 f.write(ujson.dumps(hl_data, sort_keys=True))
                             tar.add(dump_tempfile, arcname=os.path.join(
-                                filename, "highlevel", mbid[0:1], mbid[0:2], json_filename))
+                                archive_dirname, "highlevel", mbid[0:2], mbid[2:3], json_filename))
                             os.unlink(dump_tempfile)
 
                             dumped_count += 1
                     # Copying legal text
                     tar.add(DUMP_LICENSE_FILE_PATH,
-                            arcname=os.path.join(filename, "COPYING"))
+                            arcname=os.path.join(archive_dirname, "COPYING"))
 
                     shutil.rmtree(temp_dir)  # Cleanup
 

--- a/db/dump.py
+++ b/db/dump.py
@@ -449,7 +449,7 @@ def update_sequences():
 
 
 def import_db_dump(archive_path, tables):
-    """Import data from .tar.zstd archive into the database."""
+    """Import data from .tar.zst archive into the database."""
     zstd_command = ["zstd", "--decompress", "--stdout", archive_path]
     zstd = subprocess.Popen(zstd_command, stdout=subprocess.PIPE)
 
@@ -626,7 +626,7 @@ def dump_lowlevel_json(location, threads=None, sample=False, num_files_per_archi
         while True:
             # create a new file and dump recordings there
             filename = filename_pattern % file_num
-            file_path = os.path.join(dump_path, "%s.tar.zstd" % filename)
+            file_path = os.path.join(dump_path, "%s.tar.zst" % filename)
             with open(file_path, "w") as archive:
                 # Manual testing shows that -10 compression level gives a good tradeoff between
                 # compression speed and final file size with AB data
@@ -740,7 +740,7 @@ def dump_highlevel_json(location, threads=None, sample=False, num_files_per_arch
         while True:
             # create a new file and dump recordings there
             filename = filename_pattern % file_num
-            file_path = os.path.join(dump_path, "%s.tar.zstd" % filename)
+            file_path = os.path.join(dump_path, "%s.tar.zst" % filename)
             with open(file_path, "w") as archive:
                 # Manual testing shows that -10 compression level gives a good tradeoff between
                 # compression speed and final file size with AB data
@@ -1028,7 +1028,7 @@ def dump_dataset_tables(location, threads=None):
     time_now = datetime.today()
     archive_name = "acousticbrainz-dataset-dump-%s" % time_now.strftime("%Y%m%d-%H%M%S")
 
-    archive_path = os.path.join(location, archive_name + ".tar.zstd")
+    archive_path = os.path.join(location, archive_name + ".tar.zst")
     _dump_tables(
         archive_path=archive_path,
         threads=threads,
@@ -1062,7 +1062,7 @@ def dump_public_tables(location, threads=None, full=True, dump_id=None):
 
     time_now = datetime.today()
 
-    archive_path = os.path.join(location, archive_name + ".tar.zstd")
+    archive_path = os.path.join(location, archive_name + ".tar.zst")
     _dump_tables(
         archive_path=archive_path,
         threads=threads,
@@ -1073,10 +1073,10 @@ def dump_public_tables(location, threads=None, full=True, dump_id=None):
 
 
 def import_dump(archive_path):
-    """Imports a database dump from .tar.zstd archive into the database."""
+    """Imports a database dump from .tar.zst archive into the database."""
     import_db_dump(archive_path, _TABLES)
 
 
 def import_datasets_dump(archive_path):
-    """Import datasets from .tar.zstd archive into the database."""
+    """Import datasets from .tar.zst archive into the database."""
     import_db_dump(archive_path, _DATASET_TABLES)

--- a/db/dump.py
+++ b/db/dump.py
@@ -566,7 +566,7 @@ def dump_lowlevel_json(location, full=False, dump_id=None, max_count=500000):
                             json_filename = mbid + "-%d.json" % submission_offset
                             dump_tempfile = os.path.join(temp_dir, json_filename)
                             with open(dump_tempfile, "w") as f:
-                                f.write(ujson.dumps(json_data))
+                                f.write(json_data)
                             tar.add(dump_tempfile, arcname=os.path.join(
                                 filename, "lowlevel", mbid[0:1], mbid[0:2], json_filename))
                             os.unlink(dump_tempfile)

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -59,6 +59,17 @@ def full_db(location, threads, rotate, dump_id):
 @cli.command()
 @click.option("--location", "-l", default=os.path.join(os.getcwd(), 'export'), show_default=True,
               help="Directory where dumps need to be created")
+@click.option("--feature-type", "-t", help="Feature type")
+def features(location, feature_type):
+    """Generate a CSV dump of select low-level features"""
+    current_app.logger.info("Creating low-level CSV feature dump...")
+    path = dump.dump_lowlevel_features(location, feature_type)
+    current_app.logger.info("Done! Created: %s", path)
+
+
+@cli.command()
+@click.option("--location", "-l", default=os.path.join(os.getcwd(), 'export'), show_default=True,
+              help="Directory where dumps need to be created")
 @click.option("--rotate", "-r", is_flag=True)
 @click.option("--no-lowlevel", "-nl", is_flag=True, help="Don't dump low-level data.")
 @click.option("--no-highlevel", "-nh", is_flag=True, help="Don't dump high-level data.")

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -95,7 +95,7 @@ def _json_lowlevel(location, rotate, threads, sample, files_per_archive):
 
     if rotate:
         current_app.logger.info("Removing old dumps (except two latest)...")
-        remove_old_archives(location, "acousticbrainz-lowlevel-json-[0-9]+.tar.zstd",
+        remove_old_archives(location, "acousticbrainz-lowlevel-json-[0-9]+.tar.zst",
                             is_dir=False, sort_key=lambda x: os.path.getmtime(x))
 
 
@@ -106,7 +106,7 @@ def _json_highlevel(location, rotate, threads, sample, files_per_archive):
 
     if rotate:
         current_app.logger.info("Removing old dumps (except two latest)...")
-        remove_old_archives(location, "acousticbrainz-highlevel-json-[0-9]+.tar.zstd",
+        remove_old_archives(location, "acousticbrainz-highlevel-json-[0-9]+.tar.zst",
                             is_dir=False, sort_key=lambda x: os.path.getmtime(x))
 
 

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -62,38 +62,38 @@ def full_db(location, threads, rotate, dump_id):
 @click.option("--rotate", "-r", is_flag=True)
 @click.option("--no-lowlevel", "-nl", is_flag=True, help="Don't dump low-level data.")
 @click.option("--no-highlevel", "-nh", is_flag=True, help="Don't dump high-level data.")
-@click.option("--max-files", type=int, default=1000000, help="Split dump into files with this many items each")
-def json(location, rotate, no_lowlevel, no_highlevel, max_files):
+@click.option("--files-per-archive", type=float, default=float("inf"), help="Split dump into files with this many items each")
+def json(location, rotate, no_lowlevel, no_highlevel, files_per_archive):
     if no_lowlevel and no_highlevel:
         current_app.logger.info("wut? check your options, mate!")
         return
 
     if not no_lowlevel:
-        _json_lowlevel(location, rotate, max_files)
+        _json_lowlevel(location, rotate, files_per_archive)
 
     if not no_highlevel:
-        _json_highlevel(location, rotate, max_files)
+        _json_highlevel(location, rotate, files_per_archive)
 
 
-def _json_lowlevel(location, rotate, max_files):
+def _json_lowlevel(location, rotate, files_per_archive):
     current_app.logger.info("Creating low-level JSON data dump...")
-    path = dump.dump_lowlevel_json(location, full=True, dump_id=None, max_count=max_files)
+    path = dump.dump_lowlevel_json(location, num_files_per_archive=files_per_archive)
     current_app.logger.info("Done! Created: %s", path)
 
     if rotate:
         current_app.logger.info("Removing old dumps (except two latest)...")
-        remove_old_archives(location, "acousticbrainz-lowlevel-json-[0-9]+.tar.bz2",
+        remove_old_archives(location, "acousticbrainz-lowlevel-json-[0-9]+.tar.zstd",
                             is_dir=False, sort_key=lambda x: os.path.getmtime(x))
 
 
-def _json_highlevel(location, rotate, max_files):
+def _json_highlevel(location, rotate, files_per_archive):
     current_app.logger.info("Creating high-level JSON data dump...")
-    path = dump.dump_highlevel_json(location, full=True, dump_id=None, max_count=max_files)
+    path = dump.dump_highlevel_json(location, num_files_per_archive=files_per_archive)
     current_app.logger.info("Done! Created: %s", path)
 
     if rotate:
         current_app.logger.info("Removing old dumps (except two latest)...")
-        remove_old_archives(location, "acousticbrainz-highlevel-json-[0-9]+.tar.bz2",
+        remove_old_archives(location, "acousticbrainz-highlevel-json-[0-9]+.tar.zstd",
                             is_dir=False, sort_key=lambda x: os.path.getmtime(x))
 
 

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -62,22 +62,23 @@ def full_db(location, threads, rotate, dump_id):
 @click.option("--rotate", "-r", is_flag=True)
 @click.option("--no-lowlevel", "-nl", is_flag=True, help="Don't dump low-level data.")
 @click.option("--no-highlevel", "-nh", is_flag=True, help="Don't dump high-level data.")
+@click.option("--threads", "-t", type=int, default=1, help="Number of threads to use for compression (default=1)")
 @click.option("--files-per-archive", type=float, default=float("inf"), help="Split dump into files with this many items each")
-def json(location, rotate, no_lowlevel, no_highlevel, files_per_archive):
+def json(location, rotate, no_lowlevel, no_highlevel, threads, files_per_archive):
     if no_lowlevel and no_highlevel:
         current_app.logger.info("wut? check your options, mate!")
         return
 
     if not no_lowlevel:
-        _json_lowlevel(location, rotate, files_per_archive)
+        _json_lowlevel(location, rotate, threads, files_per_archive)
 
     if not no_highlevel:
-        _json_highlevel(location, rotate, files_per_archive)
+        _json_highlevel(location, rotate, threads, files_per_archive)
 
 
-def _json_lowlevel(location, rotate, files_per_archive):
+def _json_lowlevel(location, rotate, threads, files_per_archive):
     current_app.logger.info("Creating low-level JSON data dump...")
-    path = dump.dump_lowlevel_json(location, num_files_per_archive=files_per_archive)
+    path = dump.dump_lowlevel_json(location, threads, num_files_per_archive=files_per_archive)
     current_app.logger.info("Done! Created: %s", path)
 
     if rotate:
@@ -86,9 +87,9 @@ def _json_lowlevel(location, rotate, files_per_archive):
                             is_dir=False, sort_key=lambda x: os.path.getmtime(x))
 
 
-def _json_highlevel(location, rotate, files_per_archive):
+def _json_highlevel(location, rotate, threads, files_per_archive):
     current_app.logger.info("Creating high-level JSON data dump...")
-    path = dump.dump_highlevel_json(location, num_files_per_archive=files_per_archive)
+    path = dump.dump_highlevel_json(location, threads, num_files_per_archive=files_per_archive)
     current_app.logger.info("Done! Created: %s", path)
 
     if rotate:

--- a/db/dump_manage.py
+++ b/db/dump_manage.py
@@ -63,22 +63,23 @@ def full_db(location, threads, rotate, dump_id):
 @click.option("--no-lowlevel", "-nl", is_flag=True, help="Don't dump low-level data.")
 @click.option("--no-highlevel", "-nh", is_flag=True, help="Don't dump high-level data.")
 @click.option("--threads", "-t", type=int, default=1, help="Number of threads to use for compression (default=1)")
+@click.option("--sample", "-s", is_flag=True, default=False, help="Generate a very small sample dataset")
 @click.option("--files-per-archive", type=float, default=float("inf"), help="Split dump into files with this many items each")
-def json(location, rotate, no_lowlevel, no_highlevel, threads, files_per_archive):
+def json(location, rotate, no_lowlevel, no_highlevel, threads, sample, files_per_archive):
     if no_lowlevel and no_highlevel:
         current_app.logger.info("wut? check your options, mate!")
         return
 
     if not no_lowlevel:
-        _json_lowlevel(location, rotate, threads, files_per_archive)
+        _json_lowlevel(location, rotate, threads, sample, files_per_archive)
 
     if not no_highlevel:
-        _json_highlevel(location, rotate, threads, files_per_archive)
+        _json_highlevel(location, rotate, threads, sample, files_per_archive)
 
 
-def _json_lowlevel(location, rotate, threads, files_per_archive):
+def _json_lowlevel(location, rotate, threads, sample, files_per_archive):
     current_app.logger.info("Creating low-level JSON data dump...")
-    path = dump.dump_lowlevel_json(location, threads, num_files_per_archive=files_per_archive)
+    path = dump.dump_lowlevel_json(location, threads, sample, num_files_per_archive=files_per_archive)
     current_app.logger.info("Done! Created: %s", path)
 
     if rotate:
@@ -87,9 +88,9 @@ def _json_lowlevel(location, rotate, threads, files_per_archive):
                             is_dir=False, sort_key=lambda x: os.path.getmtime(x))
 
 
-def _json_highlevel(location, rotate, threads, files_per_archive):
+def _json_highlevel(location, rotate, threads, sample, files_per_archive):
     current_app.logger.info("Creating high-level JSON data dump...")
-    path = dump.dump_highlevel_json(location, threads, num_files_per_archive=files_per_archive)
+    path = dump.dump_highlevel_json(location, threads, sample, num_files_per_archive=files_per_archive)
     current_app.logger.info("Done! Created: %s", path)
 
     if rotate:


### PR DESCRIPTION
* Don't double-encode lowlevel json

* Don't include part number in tar location

With a part file acousticbrainz-lowlevel-json-20220616-0.tar.zstd, we want the files inside to be in a subdirectory

    acousticbrainz-lowlevel-json-20220616/

so that when many part files are uncompressed in the same directory they all fill in the same directory structure.

* Update subdir location

With 30m data files and a subdirectory structure of `m/mb/mbid-offset.json` we end up with 30m/256 = 117000 files per directory, which could cause some problems in some filesystems or with incorrect use of `ls`.
Instead, save as `mb/i/mbid-offset.json`, resulting in ~7000 items per directory

* Generate a sample data dump (lowlevel, highlevel json) with only 100,000 items

* Add a lowlevel individual feature dump for lowlevel, rhythm, and tonal features.
This generates 3 separate tar.zst files, each with a csv and a COPYING file. The csv includes mbid, offset, and some features for that specific feature class.
I'm not sure if we should do this with 3 separate tar files, one per data class, or one tar file containing 3 CSV files. By having separate tar files, someone doesn't have to download all of the other data, although a tar.zst file with all 3 csvs is only going to be ~3gb anyway...